### PR TITLE
Wire UI to data/services (part 1)

### DIFF
--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		4F5732951EA69CF00082035C /* godtools.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 4F5732931EA69CF00082035C /* godtools.xcdatamodeld */; };
 		4F5732971EA69CF00082035C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4F5732961EA69CF00082035C /* Assets.xcassets */; };
 		4F57329A1EA69CF00082035C /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4F5732981EA69CF00082035C /* LaunchScreen.storyboard */; };
+		4F8048011EB38B4F00943DFF /* TranslationsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8048001EB38B4F00943DFF /* TranslationsManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -126,6 +127,7 @@
 		4F5732961EA69CF00082035C /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		4F5732991EA69CF00082035C /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		4F57329B1EA69CF00082035C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		4F8048001EB38B4F00943DFF /* TranslationsManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TranslationsManager.swift; path = Managers/Translations/TranslationsManager.swift; sourceTree = "<group>"; };
 		B03BA6AC6918BE450406F1E6 /* Pods-godtools.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-godtools.debug.xcconfig"; path = "Pods/Target Support Files/Pods-godtools/Pods-godtools.debug.xcconfig"; sourceTree = "<group>"; };
 		D61FF360D11F854476B6E206 /* Pods_godtools.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_godtools.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -353,6 +355,7 @@
 			isa = PBXGroup;
 			children = (
 				4F1C959E1EA7EB65007B47DB /* TranslationResource.swift */,
+				4F8048001EB38B4F00943DFF /* TranslationsManager.swift */,
 			);
 			name = Translations;
 			sourceTree = "<group>";
@@ -582,6 +585,7 @@
 				4F1C959A1EA7E859007B47DB /* DownloadedResourceJson.swift in Sources */,
 				4F1C95A11EA7ED43007B47DB /* DownloadedResourceManager.swift in Sources */,
 				4F1C95831EA7B05D007B47DB /* LanguageResource.swift in Sources */,
+				4F8048011EB38B4F00943DFF /* TranslationsManager.swift in Sources */,
 				4F1C956B1EA6C204007B47DB /* Translation+CoreDataProperties.swift in Sources */,
 				0FB73E561EA9063E000BA60D /* BlueButton.swift in Sources */,
 				4F5732951EA69CF00082035C /* godtools.xcdatamodeld in Sources */,

--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		4F5732971EA69CF00082035C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4F5732961EA69CF00082035C /* Assets.xcassets */; };
 		4F57329A1EA69CF00082035C /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4F5732981EA69CF00082035C /* LaunchScreen.storyboard */; };
 		4F8048011EB38B4F00943DFF /* TranslationsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8048001EB38B4F00943DFF /* TranslationsManager.swift */; };
+		4F8048051EB3A2FB00943DFF /* GTSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8048041EB3A2FB00943DFF /* GTSettings.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -128,6 +129,7 @@
 		4F5732991EA69CF00082035C /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		4F57329B1EA69CF00082035C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		4F8048001EB38B4F00943DFF /* TranslationsManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TranslationsManager.swift; path = Managers/Translations/TranslationsManager.swift; sourceTree = "<group>"; };
+		4F8048041EB3A2FB00943DFF /* GTSettings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GTSettings.swift; sourceTree = "<group>"; };
 		B03BA6AC6918BE450406F1E6 /* Pods-godtools.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-godtools.debug.xcconfig"; path = "Pods/Target Support Files/Pods-godtools/Pods-godtools.debug.xcconfig"; sourceTree = "<group>"; };
 		D61FF360D11F854476B6E206 /* Pods_godtools.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_godtools.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -282,6 +284,7 @@
 				0FB73E731EA906A7000BA60D /* GTUIExtensions.swift */,
 				0FB73E741EA906A7000BA60D /* GTConstants.swift */,
 				0F350DA01EAEB54A0025C4BB /* GTNotifications.swift */,
+				4F8048041EB3A2FB00943DFF /* GTSettings.swift */,
 			);
 			path = Constants;
 			sourceTree = "<group>";
@@ -567,6 +570,7 @@
 				0FB73E571EA9063E000BA60D /* GTButton.swift in Sources */,
 				0FB73E6A1EA90669000BA60D /* BaseFlowController.swift in Sources */,
 				4F1C95671EA6C204007B47DB /* PageFile+CoreDataProperties.swift in Sources */,
+				4F8048051EB3A2FB00943DFF /* GTSettings.swift in Sources */,
 				0F93A9341EAA56EC0049C110 /* ToolsManager.swift in Sources */,
 				4F1C95651EA6C204007B47DB /* Language+CoreDataProperties.swift in Sources */,
 				0FB0E7C11EAFFC4000583BF3 /* MenuTableViewCell.swift in Sources */,

--- a/godtools/Constants/GTSettings.swift
+++ b/godtools/Constants/GTSettings.swift
@@ -27,8 +27,8 @@ class GTSettings {
         }
         
         set {
-            primaryLanguageIdInternal = primaryLanguageId
-            UserDefaults.standard.set(primaryLanguageId, forKey: "kPrimaryLanguageId")
+            primaryLanguageIdInternal = newValue
+            UserDefaults.standard.set(newValue, forKey: "kPrimaryLanguageId")
         }
     }
     
@@ -43,8 +43,8 @@ class GTSettings {
         }
         
         set {
-            primaryLanguageIdInternal = primaryLanguageId
-            UserDefaults.standard.set(primaryLanguageId, forKey: "kParallelLanguageId")
+            parallelLanguageIdInternal = newValue
+            UserDefaults.standard.set(newValue, forKey: "kParallelLanguageId")
         }
     }
 }

--- a/godtools/Constants/GTSettings.swift
+++ b/godtools/Constants/GTSettings.swift
@@ -1,0 +1,50 @@
+//
+//  GTSettings.swift
+//  godtools
+//
+//  Created by Ryan Carlson on 4/28/17.
+//  Copyright © 2017 Cru. All rights reserved.
+//
+
+import Foundation
+
+import Foundation
+
+class GTSettings {
+    static let shared = GTSettings()
+    
+    private var primaryLanguageIdInternal: String?
+    private var parallelLanguageIdInternal: String?
+    
+    var primaryLanguageId: String? {
+        get {
+            if primaryLanguageIdInternal != nil {
+                return primaryLanguageIdInternal
+            }
+            
+            primaryLanguageIdInternal = UserDefaults.standard.string(forKey: "kPrimaryLanguageId")
+            return primaryLanguageIdInternal
+        }
+        
+        set {
+            primaryLanguageIdInternal = primaryLanguageId
+            UserDefaults.standard.set(primaryLanguageId, forKey: "kPrimaryLanguageId")
+        }
+    }
+    
+    var parallelLanguageId: String? {
+        get {
+            if parallelLanguageIdInternal != nil {
+                return parallelLanguageIdInternal
+            }
+            
+            parallelLanguageIdInternal = UserDefaults.standard.string(forKey: "kParallelLanguageId")
+            return parallelLanguageIdInternal
+        }
+        
+        set {
+            primaryLanguageIdInternal = primaryLanguageId
+            UserDefaults.standard.set(primaryLanguageId, forKey: "kParallelLanguageId")
+        }
+    }
+}

--- a/godtools/Constants/GTUIExtensions.swift
+++ b/godtools/Constants/GTUIExtensions.swift
@@ -11,7 +11,7 @@ import UIKit
 extension UIColor {
     
     static let gtWhite = UIColor(red: 255.0/255.0, green: 255.0/255.0, blue: 255.0/255.0, alpha: 1.0)
-    static let gtBlue = UIColor(red: 50.0/255.0, green: 164.0/255.0, blue: 219.0/255.0, alpha: 1.0)
+    static let gtBlue = UIColor(red: 59.0/255.0, green: 164.0/255.0, blue: 219.0/255.0, alpha: 1.0)
     static let gtBlack = UIColor(red: 90.0/255.0, green: 90.0/255.0, blue: 90.0/255.0, alpha: 1.0)
     static let gtGrey = UIColor(red: 190.0/255.0, green: 190.0/255.0, blue: 190.0/255.0, alpha: 1.0)
     static let gtGreyLight = UIColor(red: 230.0/255.0, green: 230.0/255.0, blue: 230.0/255.0, alpha: 1.0)

--- a/godtools/Localizable.strings
+++ b/godtools/Localizable.strings
@@ -34,6 +34,7 @@
 "primary_language" = "Primary Language";
 "select_primary_language" = "Select a Primary Language";
 "parallel_language" = "Parallel Language";
+"select_parallel_language" = "Select a Parallel Language";
 "share_god_tools_native_language" = "Share God Tools with someone in their native language";
 "not_every_tool_is_available" = "Not every tool is available in every language";
 

--- a/godtools/Managers/DownloadResources/DownloadedResourceJson.swift
+++ b/godtools/Managers/DownloadResources/DownloadedResourceJson.swift
@@ -14,6 +14,7 @@ class DownloadedResourceJson: Resource {
     var name: String?
     var abbreviation: String?
     
+    var latestTranslations: LinkedResourceCollection?
     var translations: LinkedResourceCollection?
     var pages: LinkedResourceCollection?
     
@@ -26,6 +27,7 @@ class DownloadedResourceJson: Resource {
             "name" : Attribute(),
             "abbreviation" : Attribute(),
             "translations" : ToManyRelationship(TranslationResource.self),
+            "latestTranslations" : ToManyRelationship(TranslationResource.self).serializeAs("latest-translations"),
             "pages" : ToManyRelationship(PageResource.self)])
     }
 }

--- a/godtools/Managers/DownloadResources/DownloadedResourceManager.swift
+++ b/godtools/Managers/DownloadResources/DownloadedResourceManager.swift
@@ -25,6 +25,7 @@ class DownloadedResourceManager: GTDataManager {
         serializer.registerResource(DownloadedResourceJson.self)
         serializer.registerResource(TranslationResource.self)
         serializer.registerResource(PageResource.self)
+        serializer.registerResource(LanguageResource.self)
     }
     
     func loadFromDisk() -> Promise<[DownloadedResource]> {
@@ -57,12 +58,13 @@ class DownloadedResourceManager: GTDataManager {
                 cachedResource.code = remoteResource.abbreviation
                 cachedResource.name = remoteResource.name
                 
-                let remoteTranslations = remoteResource.translations!
+                let remoteTranslations = remoteResource.latestTranslations!
                 for remoteTranslationGeneric in remoteTranslations {
                     let remoteTranslation = remoteTranslationGeneric as! TranslationResource
                     
                     let cachedTranslation = Translation.mr_findFirstOrCreate(byAttribute: "remoteId", withValue: remoteTranslation.id!, in: context)
                     
+                    cachedTranslation.language = Language.mr_findFirst(byAttribute: "remoteId", withValue: remoteTranslation.language?.id ?? "-1", in: context)
                     cachedTranslation.version = remoteTranslation.version!.int16Value
                     cachedTranslation.isPublished = remoteTranslation.isPublished!.boolValue
                     cachedResource.addToTranslations(cachedTranslation)

--- a/godtools/Managers/DownloadResources/DownloadedResourceManager.swift
+++ b/godtools/Managers/DownloadResources/DownloadedResourceManager.swift
@@ -28,9 +28,9 @@ class DownloadedResourceManager: GTDataManager {
         serializer.registerResource(LanguageResource.self)
     }
     
-    func loadFromDisk() -> Promise<[DownloadedResource]> {
+    func loadFromDisk() -> [DownloadedResource] {
         resources = DownloadedResource.mr_findAll() as! [DownloadedResource]
-        return Promise(value: resources)
+        return resources
     }
     
     func loadFromRemote() -> Promise<[DownloadedResource]> {
@@ -46,7 +46,7 @@ class DownloadedResourceManager: GTDataManager {
                 } catch {
                     return Promise(error: error)
                 }
-                return self.loadFromDisk()
+                return Promise(value:self.loadFromDisk())
             }
     }
     

--- a/godtools/Managers/DownloadResources/DownloadedResourceManager.swift
+++ b/godtools/Managers/DownloadResources/DownloadedResourceManager.swift
@@ -63,8 +63,9 @@ class DownloadedResourceManager: GTDataManager {
                     let remoteTranslation = remoteTranslationGeneric as! TranslationResource
                     
                     let cachedTranslation = Translation.mr_findFirstOrCreate(byAttribute: "remoteId", withValue: remoteTranslation.id!, in: context)
-                    
-                    cachedTranslation.language = Language.mr_findFirst(byAttribute: "remoteId", withValue: remoteTranslation.language?.id ?? "-1", in: context)
+                    let languageId = remoteTranslation.language?.id ?? "-1"
+                        
+                    cachedTranslation.language = LanguagesManager.shared.loadFromDisk(id: languageId)
                     cachedTranslation.version = remoteTranslation.version!.int16Value
                     cachedTranslation.isPublished = remoteTranslation.isPublished!.boolValue
                     cachedResource.addToTranslations(cachedTranslation)

--- a/godtools/Managers/GTDataManager.swift
+++ b/godtools/Managers/GTDataManager.swift
@@ -10,6 +10,7 @@ import Foundation
 import Alamofire
 import PromiseKit
 import Spine
+import CoreData
 
 class GTDataManager: NSObject {
     
@@ -28,6 +29,10 @@ class GTDataManager: NSObject {
                                  encoding: URLEncoding.default,
                                  headers: nil)
             .responseData()
+    }
+    
+    func saveToDisk() {
+        NSManagedObjectContext.mr_default().mr_saveToPersistentStore(completion: nil)
     }
     
     func buildURLString() -> String {

--- a/godtools/Managers/LanguageResource.swift
+++ b/godtools/Managers/LanguageResource.swift
@@ -13,8 +13,6 @@ class LanguageResource: Resource {
 
     var code: String?
     
-    var translations: LinkedResourceCollection?
-    
     override class var resourceType: ResourceType {
         return "language"
     }
@@ -22,7 +20,6 @@ class LanguageResource: Resource {
     override class var fields: [Field] {
         return fieldsFromDictionary([
             "code" : Attribute(),
-            "translations" : ToManyRelationship(TranslationResource.self)
             ])
     }
 }

--- a/godtools/Managers/LanguagesManager.swift
+++ b/godtools/Managers/LanguagesManager.swift
@@ -27,7 +27,10 @@ class LanguagesManager: GTDataManager {
     }
     
     func loadFromDisk(id: String) -> Language {
-        return Language.mr_findFirst(byAttribute: "remoteId", withValue: id)!
+        let language = Language.mr_findFirst(byAttribute: "remoteId", withValue: id)!
+        language.localizedName = NSLocale.current.localizedString(forLanguageCode: language.code!)
+        
+        return language
     }
     
     func loadFromDisk() -> Promise<[Language]> {

--- a/godtools/Managers/LanguagesManager.swift
+++ b/godtools/Managers/LanguagesManager.swift
@@ -70,7 +70,12 @@ class LanguagesManager: GTDataManager {
 }
 
 extension LanguagesManager: UITableViewDelegate {
-    
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let selectedLanguage = languages[indexPath.row]
+        GTSettings.shared.primaryLanguageId = selectedLanguage.remoteId
+        selectedLanguage.shouldDownload = true
+        saveToDisk()
+    }
 }
 
 extension LanguagesManager: UITableViewDataSource {

--- a/godtools/Managers/LanguagesManager.swift
+++ b/godtools/Managers/LanguagesManager.swift
@@ -19,10 +19,15 @@ class LanguagesManager: GTDataManager {
     let path = "/languages"
     
     var languages = [Language]()
+    var selectingPrimaryLanguage = true
     
     override init() {
         super.init()
         serializer.registerResource(LanguageResource.self)
+    }
+    
+    func loadFromDisk(id: String) -> Language {
+        return Language.mr_findFirst(byAttribute: "remoteId", withValue: id)!
     }
     
     func loadFromDisk() -> Promise<[Language]> {

--- a/godtools/Managers/LanguagesManager.swift
+++ b/godtools/Managers/LanguagesManager.swift
@@ -33,6 +33,10 @@ class LanguagesManager: GTDataManager {
         return language
     }
     
+    func loadPrimaryLanguageFromDisk() -> Language {
+        return loadFromDisk(id: GTSettings.shared.primaryLanguageId ?? "-1")
+    }
+    
     func loadFromDisk() -> Promise<[Language]> {
         languages = Language.mr_findAll() as! [Language]
         

--- a/godtools/Managers/LanguagesManager.swift
+++ b/godtools/Managers/LanguagesManager.swift
@@ -102,6 +102,10 @@ class LanguagesManager: GTDataManager {
     fileprivate func setSelectedLanguageId(_ id: String) {
         if selectingPrimaryLanguage {
             GTSettings.shared.primaryLanguageId = id
+            if id == GTSettings.shared.parallelLanguageId {
+                GTSettings.shared.parallelLanguageId = nil
+            }
+
         } else {
             GTSettings.shared.parallelLanguageId = id
         }

--- a/godtools/Managers/LanguagesManager.swift
+++ b/godtools/Managers/LanguagesManager.swift
@@ -60,16 +60,6 @@ class LanguagesManager: GTDataManager {
             for remoteLanguage in languages {
                 let cachedlanguage = Language.mr_findFirstOrCreate(byAttribute: "remoteId", withValue: remoteLanguage.id!, in: context)
                 cachedlanguage.code = remoteLanguage.code
-                
-                for relatedTranslation in remoteLanguage.translations!.linkage! {
-                    print(relatedTranslation.toDictionary())
-
-                    let cachedTranslation = Translation.mr_findFirstOrCreate(byAttribute: "remoteId",
-                                                                             withValue: relatedTranslation.id,
-                                                                             in: context)
-                    
-                    cachedlanguage.addToTranslations(cachedTranslation)
-                }
             }
         })
     }

--- a/godtools/Managers/LanguagesManager.swift
+++ b/godtools/Managers/LanguagesManager.swift
@@ -69,6 +69,22 @@ class LanguagesManager: GTDataManager {
         })
     }
 
+    fileprivate func selectedLanguageId() -> String? {
+        if selectingPrimaryLanguage {
+            return GTSettings.shared.primaryLanguageId
+        } else {
+            return GTSettings.shared.parallelLanguageId
+        }
+    }
+    
+    fileprivate func setSelectedLanguageId(_ id: String) {
+        if selectingPrimaryLanguage {
+            GTSettings.shared.primaryLanguageId = id
+        } else {
+            GTSettings.shared.parallelLanguageId = id
+        }
+    }
+    
     override func buildURLString() -> String {
         return "\(GTConstants.kApiBase)\(path)"
     }
@@ -77,7 +93,7 @@ class LanguagesManager: GTDataManager {
 extension LanguagesManager: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let selectedLanguage = languages[indexPath.row]
-        GTSettings.shared.primaryLanguageId = selectedLanguage.remoteId
+        self.setSelectedLanguageId(selectedLanguage.remoteId!)
         selectedLanguage.shouldDownload = true
         saveToDisk()
     }
@@ -99,7 +115,7 @@ extension LanguagesManager: UITableViewDataSource {
     
     func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
         let language = languages[indexPath.row]
-        let selected = language.remoteId == GTSettings.shared.primaryLanguageId
+        let selected = language.remoteId == self.selectedLanguageId()
         
         if selected {
             cell.setSelected(selected, animated: true)

--- a/godtools/Managers/LanguagesManager.swift
+++ b/godtools/Managers/LanguagesManager.swift
@@ -33,8 +33,12 @@ class LanguagesManager: GTDataManager {
         return language
     }
     
-    func loadPrimaryLanguageFromDisk() -> Language {
-        return loadFromDisk(id: GTSettings.shared.primaryLanguageId ?? "-1")
+    func loadPrimaryLanguageFromDisk() -> Language? {
+        if GTSettings.shared.primaryLanguageId == nil {
+            return nil
+        }
+        
+        return loadFromDisk(id: GTSettings.shared.primaryLanguageId!)
     }
     
     func loadFromDisk() -> Promise<[Language]> {

--- a/godtools/Managers/LanguagesManager.swift
+++ b/godtools/Managers/LanguagesManager.swift
@@ -83,10 +83,24 @@ extension LanguagesManager: UITableViewDataSource {
     static let languageCellIdentifier = "languageCell"
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let language = languages[indexPath.row]
         let cell = tableView.dequeueReusableCell(withIdentifier: LanguagesManager.languageCellIdentifier) as! LanguageTableViewCell
-        cell.languageLabel.text = languages[indexPath.row].localizedName
-        cell.languageExists(false)
+        
+        cell.languageLabel.text = language.localizedName
+        cell.languageExists(language.shouldDownload)
+        
         return cell
+    }
+    
+    func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        let language = languages[indexPath.row]
+        let selected = language.remoteId == GTSettings.shared.primaryLanguageId
+        
+        if selected {
+            cell.setSelected(selected, animated: true)
+            tableView.selectRow(at: indexPath, animated: true, scrollPosition: .none)
+        }
+        
     }
     
     func numberOfSections(in tableView: UITableView) -> Int {

--- a/godtools/Managers/LanguagesManager.swift
+++ b/godtools/Managers/LanguagesManager.swift
@@ -41,7 +41,7 @@ class LanguagesManager: GTDataManager {
         return loadFromDisk(id: GTSettings.shared.primaryLanguageId!)
     }
     
-    func loadFromDisk() -> Promise<[Language]> {
+    func loadFromDisk() -> [Language] {
         languages = Language.mr_findAll() as! [Language]
         
         for language in languages {
@@ -52,7 +52,7 @@ class LanguagesManager: GTDataManager {
             return language1.localizedName!.compare(language2.localizedName!).rawValue < 0
         }
         
-        return Promise(value:languages)
+        return languages
     }
     
     func loadFromRemote() -> Promise<[Language]> {
@@ -67,7 +67,7 @@ class LanguagesManager: GTDataManager {
                 } catch {
                     return Promise(error: error)
                 }
-                return self.loadFromDisk()
+                return Promise(value:self.loadFromDisk())
         }
     }
     

--- a/godtools/Managers/LanguagesManager.swift
+++ b/godtools/Managers/LanguagesManager.swift
@@ -83,12 +83,12 @@ class LanguagesManager: GTDataManager {
     }
     
     private func saveToDisk(_ languages: [LanguageResource]) {
-        MagicalRecord.save(blockAndWait: { (context) in
-            for remoteLanguage in languages {
-                let cachedlanguage = Language.mr_findFirstOrCreate(byAttribute: "remoteId", withValue: remoteLanguage.id!, in: context)
-                cachedlanguage.code = remoteLanguage.code
-            }
-        })
+        let context = NSManagedObjectContext.mr_default()
+        for remoteLanguage in languages {
+            let cachedlanguage = Language.mr_findFirstOrCreate(byAttribute: "remoteId", withValue: remoteLanguage.id!, in: context)
+            cachedlanguage.code = remoteLanguage.code
+        }
+        saveToDisk()
     }
 
     fileprivate func selectedLanguageId() -> String? {

--- a/godtools/Managers/LanguagesManager.swift
+++ b/godtools/Managers/LanguagesManager.swift
@@ -71,6 +71,17 @@ class LanguagesManager: GTDataManager {
         }
     }
     
+    
+    func recordLanguageShouldDownload(language: Language) {
+        language.shouldDownload = true
+        saveToDisk()
+    }
+    
+    func recordLanguageShouldDelete(language: Language) {
+        language.shouldDownload = false
+        saveToDisk()
+    }
+    
     private func saveToDisk(_ languages: [LanguageResource]) {
         MagicalRecord.save(blockAndWait: { (context) in
             for remoteLanguage in languages {
@@ -101,12 +112,21 @@ class LanguagesManager: GTDataManager {
     }
 }
 
+extension LanguagesManager: LanguageTableViewCellDelegate {
+    func deleteButtonWasPressed(_ cell: LanguageTableViewCell) {
+        self.recordLanguageShouldDelete(language: cell.language!)
+    }
+    
+    func downloadButtonWasPressed(_ cell: LanguageTableViewCell) {
+        self.recordLanguageShouldDownload(language: cell.language!)
+    }
+}
+
 extension LanguagesManager: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        let selectedLanguage = languages[indexPath.row]
-        self.setSelectedLanguageId(selectedLanguage.remoteId!)
-        selectedLanguage.shouldDownload = true
-        saveToDisk()
+        let language = languages[indexPath.row]
+        self.setSelectedLanguageId(language.remoteId!)
+        self.recordLanguageShouldDownload(language: language)
     }
 }
 
@@ -118,8 +138,8 @@ extension LanguagesManager: UITableViewDataSource {
         let language = languages[indexPath.row]
         let cell = tableView.dequeueReusableCell(withIdentifier: LanguagesManager.languageCellIdentifier) as! LanguageTableViewCell
         
-        cell.languageLabel.text = language.localizedName
-        cell.languageExists(language.shouldDownload)
+        cell.cellDelegate = self
+        cell.language = language
         
         return cell
     }
@@ -132,7 +152,6 @@ extension LanguagesManager: UITableViewDataSource {
             cell.setSelected(selected, animated: true)
             tableView.selectRow(at: indexPath, animated: true, scrollPosition: .none)
         }
-        
     }
     
     func numberOfSections(in tableView: UITableView) -> Int {
@@ -142,5 +161,4 @@ extension LanguagesManager: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return languages.count
     }
-    
 }

--- a/godtools/Managers/ToolsManager.swift
+++ b/godtools/Managers/ToolsManager.swift
@@ -63,8 +63,8 @@ extension ToolsManager: UITableViewDataSource {
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: ToolsManager.toolCellIdentifier) as! HomeToolTableViewCell
-        cell.titleLabel.text = self.resources![indexPath.section].name
-        cell.languageLabel.text = LanguagesManager.shared.loadPrimaryLanguageFromDisk()?.localizedName
+        cell.setTitle(self.resources![indexPath.section].name)
+        cell.setLanguage(LanguagesManager.shared.loadPrimaryLanguageFromDisk()?.localizedName)
         return cell
     }
     

--- a/godtools/Managers/ToolsManager.swift
+++ b/godtools/Managers/ToolsManager.swift
@@ -78,7 +78,7 @@ extension ToolsManager: UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: ToolsManager.toolCellIdentifier) as! HomeToolTableViewCell
         cell.titleLabel.text = getShownTranslations()[indexPath.section].downloadedResource!.name
-        cell.languageLabel.text = LanguagesManager.shared.loadPrimaryLanguageFromDisk().localizedName
+        cell.languageLabel.text = LanguagesManager.shared.loadPrimaryLanguageFromDisk()!.localizedName
         return cell
     }
     

--- a/godtools/Managers/ToolsManager.swift
+++ b/godtools/Managers/ToolsManager.swift
@@ -77,6 +77,8 @@ extension ToolsManager: UITableViewDataSource {
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: ToolsManager.toolCellIdentifier) as! HomeToolTableViewCell
+        cell.titleLabel.text = getShownTranslations()[indexPath.section].downloadedResource!.name
+        cell.languageLabel.text = LanguagesManager.shared.loadPrimaryLanguageFromDisk().localizedName
         return cell
     }
     

--- a/godtools/Managers/ToolsManager.swift
+++ b/godtools/Managers/ToolsManager.swift
@@ -18,6 +18,8 @@ class ToolsManager: NSObject {
     static let shared = ToolsManager()
     var delegate: ToolsManagerDelegate?
     
+    var showDownloaded = true
+    
     override init() {
         super.init()
     }
@@ -58,7 +60,11 @@ extension ToolsManager: UITableViewDataSource {
     }
     
     func numberOfSections(in tableView: UITableView) -> Int {
-        return 5
+        if showDownloaded {
+            return TranslationsManager.shared.loadDownloadedTranslationsFromDisk(languageId: "4").count
+        } else {
+            return TranslationsManager.shared.loadLatestTranslationsFromDisk(languageId: "4").count
+        }
     }
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {

--- a/godtools/Managers/ToolsManager.swift
+++ b/godtools/Managers/ToolsManager.swift
@@ -16,14 +16,35 @@ import UIKit
 class ToolsManager: NSObject {
     
     static let shared = ToolsManager()
-    var delegate: ToolsManagerDelegate?
+    var delegate: ToolsManagerDelegate? {
+        didSet {
+            let languageId = GTSettings.shared.primaryLanguageId
+            if languageId == nil {
+                return
+            }
+            
+            if self.delegate is HomeViewController {
+                downloadedTranslations = TranslationsManager.shared.loadDownloadedTranslationsFromDisk(languageId: languageId!)
+            } else {
+                latestTranslations = TranslationsManager.shared.loadLatestTranslationsFromDisk(languageId: languageId!)
+            }
+        }
+    }
     
-    var showDownloaded = true
+    var latestTranslations: [Translation]?
+    var downloadedTranslations: [Translation]?
     
     override init() {
         super.init()
     }
-
+    
+    fileprivate func getShownTranslations() -> [Translation] {
+        if self.delegate is HomeViewController {
+            return downloadedTranslations!
+        } else {
+            return latestTranslations!
+        }
+    }
 }
 
 extension ToolsManager: UITableViewDelegate {
@@ -66,11 +87,7 @@ extension ToolsManager: UITableViewDataSource {
             return 0
         }
         
-        if self.delegate is HomeViewController {
-            return TranslationsManager.shared.loadDownloadedTranslationsFromDisk(languageId: languageId!).count
-        } else {
-            return TranslationsManager.shared.loadLatestTranslationsFromDisk(languageId: languageId!).count
-        }
+        return getShownTranslations().count
     }
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {

--- a/godtools/Managers/ToolsManager.swift
+++ b/godtools/Managers/ToolsManager.swift
@@ -60,10 +60,16 @@ extension ToolsManager: UITableViewDataSource {
     }
     
     func numberOfSections(in tableView: UITableView) -> Int {
-        if showDownloaded {
-            return TranslationsManager.shared.loadDownloadedTranslationsFromDisk(languageId: "4").count
+        let languageId = GTSettings.shared.primaryLanguageId
+        
+        if languageId == nil {
+            return 0
+        }
+        
+        if self.delegate is HomeViewController {
+            return TranslationsManager.shared.loadDownloadedTranslationsFromDisk(languageId: languageId!).count
         } else {
-            return TranslationsManager.shared.loadLatestTranslationsFromDisk(languageId: "4").count
+            return TranslationsManager.shared.loadLatestTranslationsFromDisk(languageId: languageId!).count
         }
     }
     

--- a/godtools/Managers/Translations/TranslationResource.swift
+++ b/godtools/Managers/Translations/TranslationResource.swift
@@ -14,6 +14,8 @@ class TranslationResource: Resource {
     var version: NSNumber?
     var isPublished: NSNumber?
     
+    var language: LanguageResource?
+    
     override class var resourceType: ResourceType {
         return "translation"
     }
@@ -21,7 +23,8 @@ class TranslationResource: Resource {
     override class var fields: [Field] {
         return fieldsFromDictionary([
             "version" : Attribute(),
-            "isPublished" : BooleanAttribute().serializeAs("is-published")
+            "isPublished" : BooleanAttribute().serializeAs("is-published"),
+            "language" : ToOneRelationship(LanguageResource.self)
         ])
     }
 }

--- a/godtools/Managers/Translations/TranslationsManager.swift
+++ b/godtools/Managers/Translations/TranslationsManager.swift
@@ -1,0 +1,43 @@
+//
+//  TranslationsManager.swift
+//  godtools
+//
+//  Created by Ryan Carlson on 4/28/17.
+//  Copyright © 2017 Cru. All rights reserved.
+//
+
+import Foundation
+import PromiseKit
+import Alamofire
+
+class TranslationsManager {
+    static let shared = TranslationsManager()
+    
+    var latestTranslations: [Translation]?
+    var downloadedTranslations: [Translation]?
+    
+    func loadLatestTranslationsFromDisk(languageId: String) -> [Translation] {
+        if latestTranslations != nil {
+            return latestTranslations!
+        }
+        
+        let predicate = NSPredicate(format: "language.remoteId = %@ AND isPublished = true", languageId)
+        latestTranslations = Translation.mr_findAll(with: predicate) as! [Translation]?
+        
+        return latestTranslations!
+    }
+    
+    func loadDownloadedTranslationsFromDisk(languageId: String) -> [Translation] {
+        if downloadedTranslations != nil {
+            return downloadedTranslations!
+        }
+        
+        let predicate = NSPredicate(format: "language.remoteId = %@ AND isDownloaded = true", languageId)
+        downloadedTranslations = Translation.mr_findAll(with: predicate) as! [Translation]?
+        return downloadedTranslations!
+    }
+    
+    func loadTranslationFromRemote(id: String) -> Promise<Translation> {
+        return Promise(value: Translation.mr_createEntity()!)
+    }
+}

--- a/godtools/Managers/Translations/TranslationsManager.swift
+++ b/godtools/Managers/Translations/TranslationsManager.swift
@@ -13,28 +13,14 @@ import Alamofire
 class TranslationsManager {
     static let shared = TranslationsManager()
     
-    var latestTranslations: [Translation]?
-    var downloadedTranslations: [Translation]?
-    
     func loadLatestTranslationsFromDisk(languageId: String) -> [Translation] {
-        if latestTranslations != nil {
-            return latestTranslations!
-        }
-        
         let predicate = NSPredicate(format: "language.remoteId = %@ AND isPublished = true", languageId)
-        latestTranslations = Translation.mr_findAll(with: predicate) as! [Translation]?
-        
-        return latestTranslations!
+        return Translation.mr_findAll(with: predicate) as! [Translation]
     }
     
     func loadDownloadedTranslationsFromDisk(languageId: String) -> [Translation] {
-        if downloadedTranslations != nil {
-            return downloadedTranslations!
-        }
-        
         let predicate = NSPredicate(format: "language.remoteId = %@ AND isDownloaded = true", languageId)
-        downloadedTranslations = Translation.mr_findAll(with: predicate) as! [Translation]?
-        return downloadedTranslations!
+        return Translation.mr_findAll(with: predicate) as! [Translation]
     }
     
     func loadTranslationFromRemote(id: String) -> Promise<Translation> {

--- a/godtools/Managers/Translations/TranslationsManager.swift
+++ b/godtools/Managers/Translations/TranslationsManager.swift
@@ -13,13 +13,13 @@ import Alamofire
 class TranslationsManager {
     static let shared = TranslationsManager()
     
-    func loadLatestTranslationsFromDisk(languageId: String) -> [Translation] {
-        let predicate = NSPredicate(format: "language.remoteId = %@ AND isPublished = true", languageId)
+    func loadLatestTranslationsFromDisk() -> [Translation] {
+        let predicate = NSPredicate(format: "isPublished = true")
         return Translation.mr_findAll(with: predicate) as! [Translation]
     }
     
-    func loadDownloadedTranslationsFromDisk(languageId: String) -> [Translation] {
-        let predicate = NSPredicate(format: "language.remoteId = %@ AND isDownloaded = true", languageId)
+    func loadDownloadedTranslationsFromDisk() -> [Translation] {
+        let predicate = NSPredicate(format: "isDownloaded = true")
         return Translation.mr_findAll(with: predicate) as! [Translation]
     }
     

--- a/godtools/Models/DownloadedResource+CoreDataProperties.swift
+++ b/godtools/Models/DownloadedResource+CoreDataProperties.swift
@@ -2,7 +2,7 @@
 //  DownloadedResource+CoreDataProperties.swift
 //  godtools
 //
-//  Created by Ryan Carlson on 4/21/17.
+//  Created by Ryan Carlson on 4/28/17.
 //  Copyright © 2017 Cru. All rights reserved.
 //
 
@@ -19,25 +19,9 @@ extension DownloadedResource {
     @NSManaged public var code: String?
     @NSManaged public var name: String?
     @NSManaged public var remoteId: String?
-    @NSManaged public var translations: NSSet?
+    @NSManaged public var shouldDownload: Bool
     @NSManaged public var pages: NSSet?
-
-}
-
-// MARK: Generated accessors for translations
-extension DownloadedResource {
-
-    @objc(addTranslationsObject:)
-    @NSManaged public func addToTranslations(_ value: Translation)
-
-    @objc(removeTranslationsObject:)
-    @NSManaged public func removeFromTranslations(_ value: Translation)
-
-    @objc(addTranslations:)
-    @NSManaged public func addToTranslations(_ values: NSSet)
-
-    @objc(removeTranslations:)
-    @NSManaged public func removeFromTranslations(_ values: NSSet)
+    @NSManaged public var translations: NSSet?
 
 }
 
@@ -55,5 +39,22 @@ extension DownloadedResource {
 
     @objc(removePages:)
     @NSManaged public func removeFromPages(_ values: NSSet)
+
+}
+
+// MARK: Generated accessors for translations
+extension DownloadedResource {
+
+    @objc(addTranslationsObject:)
+    @NSManaged public func addToTranslations(_ value: Translation)
+
+    @objc(removeTranslationsObject:)
+    @NSManaged public func removeFromTranslations(_ value: Translation)
+
+    @objc(addTranslations:)
+    @NSManaged public func addToTranslations(_ values: NSSet)
+
+    @objc(removeTranslations:)
+    @NSManaged public func removeFromTranslations(_ values: NSSet)
 
 }

--- a/godtools/Models/Language+CoreDataProperties.swift
+++ b/godtools/Models/Language+CoreDataProperties.swift
@@ -2,7 +2,7 @@
 //  Language+CoreDataProperties.swift
 //  godtools
 //
-//  Created by Ryan Carlson on 4/19/17.
+//  Created by Ryan Carlson on 4/28/17.
 //  Copyright © 2017 Cru. All rights reserved.
 //
 
@@ -17,8 +17,9 @@ extension Language {
     }
 
     @NSManaged public var code: String?
-    @NSManaged public var remoteId: String?
     @NSManaged public var localizedName: String?
+    @NSManaged public var remoteId: String?
+    @NSManaged public var shouldDownload: Bool
     @NSManaged public var translations: NSSet?
 
 }

--- a/godtools/ViewControllers/Platform/AddToolsViewController.swift
+++ b/godtools/ViewControllers/Platform/AddToolsViewController.swift
@@ -52,6 +52,7 @@ class AddToolsViewController: BaseViewController, ToolsManagerDelegate {
     // MARK: - ToolsManagerDelegate
     
     func didSelectTableViewRow(cell: HomeToolTableViewCell) {
+        _ = self.navigationController?.popViewController(animated: true)
     }
 
 }

--- a/godtools/ViewControllers/Platform/AddToolsViewController.swift
+++ b/godtools/ViewControllers/Platform/AddToolsViewController.swift
@@ -32,6 +32,7 @@ class AddToolsViewController: BaseViewController, ToolsManagerDelegate {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        self.toolsManager.showDownloaded = false
         self.toolsManager.delegate = self
     }
 

--- a/godtools/ViewControllers/Platform/AddToolsViewController.swift
+++ b/godtools/ViewControllers/Platform/AddToolsViewController.swift
@@ -32,7 +32,6 @@ class AddToolsViewController: BaseViewController, ToolsManagerDelegate {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        self.toolsManager.showDownloaded = false
         self.toolsManager.delegate = self
     }
 

--- a/godtools/ViewControllers/Platform/HomeViewController.swift
+++ b/godtools/ViewControllers/Platform/HomeViewController.swift
@@ -36,6 +36,10 @@ class HomeViewController: BaseViewController {
         self.registerCells()
         self.setupStyle()
         self.defineObservers()
+        
+        if LanguagesManager.shared.loadPrimaryLanguageFromDisk() == nil {
+            self.displayOnboarding()
+        }
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -45,7 +49,6 @@ class HomeViewController: BaseViewController {
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-//        self.displayOnboarding()
     }
 
     override func didReceiveMemoryWarning() {

--- a/godtools/ViewControllers/Platform/HomeViewController.swift
+++ b/godtools/ViewControllers/Platform/HomeViewController.swift
@@ -46,7 +46,7 @@ class HomeViewController: BaseViewController {
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        self.displayOnboarding()
+//        self.displayOnboarding()
     }
 
     override func didReceiveMemoryWarning() {

--- a/godtools/ViewControllers/Platform/HomeViewController.swift
+++ b/godtools/ViewControllers/Platform/HomeViewController.swift
@@ -40,7 +40,6 @@ class HomeViewController: BaseViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        self.toolsManager.showDownloaded = true
         self.toolsManager.delegate = self
     }
     

--- a/godtools/ViewControllers/Platform/HomeViewController.swift
+++ b/godtools/ViewControllers/Platform/HomeViewController.swift
@@ -40,6 +40,7 @@ class HomeViewController: BaseViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        self.toolsManager.showDownloaded = true
         self.toolsManager.delegate = self
     }
     

--- a/godtools/ViewControllers/Platform/HomeViewController.swift
+++ b/godtools/ViewControllers/Platform/HomeViewController.swift
@@ -45,6 +45,7 @@ class HomeViewController: BaseViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         self.toolsManager.delegate = self
+        self.tableView.reloadData()
     }
     
     override func viewDidAppear(_ animated: Bool) {

--- a/godtools/ViewControllers/Platform/LanguageSettingsViewController.swift
+++ b/godtools/ViewControllers/Platform/LanguageSettingsViewController.swift
@@ -22,12 +22,6 @@ class LanguageSettingsViewController: BaseViewController {
         }
     }
     
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        
-        _ = DownloadedResourceManager.shared.loadFromRemote()
-    }
-
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
     }

--- a/godtools/ViewControllers/Platform/LanguageSettingsViewController.swift
+++ b/godtools/ViewControllers/Platform/LanguageSettingsViewController.swift
@@ -35,20 +35,17 @@ class LanguageSettingsViewController: BaseViewController {
     
     private func setupPrimaryLanguageButton() {
         let primaryLanguage = self.languagesManager.loadPrimaryLanguageFromDisk()
-        if primaryLanguage != nil {
-            primaryLanguageButton.setTitle(primaryLanguage!.localizedName, for: .normal)
-        } else {
-            primaryLanguageButton.setTitle("select_primary_language".localized, for: .normal)
-        }
+        let title = primaryLanguage != nil ? primaryLanguage!.localizedName : "select_primary_language".localized
+        
+        primaryLanguageButton.setTitle(title, for: .normal)
     }
-
+    
     private func setupParallelLanguageButton() {
-        if GTSettings.shared.parallelLanguageId != nil {
-            let parallelLanguage = self.languagesManager.loadFromDisk(id: GTSettings.shared.parallelLanguageId!)
-            parallelLanguageButton.setTitle(parallelLanguage.localizedName, for: .normal)
-        } else {
-            parallelLanguageButton.setTitle("select_parallel_language".localized, for: .normal)
-        }
+        let parallelLanguageId = GTSettings.shared.parallelLanguageId
+        let title = parallelLanguageId != nil ?
+            self.languagesManager.loadFromDisk(id: parallelLanguageId!).localizedName : "select_parallel_language".localized
+        
+        parallelLanguageButton.setTitle(title, for: .normal)
     }
 
     // MARK: - Actions

--- a/godtools/ViewControllers/Platform/LanguageSettingsViewController.swift
+++ b/godtools/ViewControllers/Platform/LanguageSettingsViewController.swift
@@ -15,6 +15,10 @@ protocol LanguageSettingsViewControllerDelegate {
 class LanguageSettingsViewController: BaseViewController {
     
     var delegate: LanguageSettingsViewControllerDelegate?
+    let languagesManager = LanguagesManager.shared
+    
+    @IBOutlet weak var primaryLanguageButton: BlueButton!
+    @IBOutlet weak var parallelLanguageButton: BlueButton!
     
     override var screenTitle: String {
         get {
@@ -22,13 +26,40 @@ class LanguageSettingsViewController: BaseViewController {
         }
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        setupPrimaryLanguageButton()
+        setupParallelLanguageButton()
+    }
+    
+    private func setupPrimaryLanguageButton() {
+        if GTSettings.shared.primaryLanguageId != nil {
+            let primaryLanguage = self.languagesManager.loadFromDisk(id: GTSettings.shared.primaryLanguageId!)
+            primaryLanguageButton.setTitle(primaryLanguage.code, for: .normal)
+        } else {
+            primaryLanguageButton.setTitle("select_primary_language".localized, for: .normal)
+        }
+    }
+
+    private func setupParallelLanguageButton() {
+        if GTSettings.shared.parallelLanguageId != nil {
+            let parallelLanguage = self.languagesManager.loadFromDisk(id: GTSettings.shared.parallelLanguageId!)
+            parallelLanguageButton.setTitle(parallelLanguage.code, for: .normal)
+        } else {
+            parallelLanguageButton.setTitle("select_parallel_language".localized, for: .normal)
+        }
+    }
+
     // MARK: - Actions
     
     @IBAction func pressSelectPrimaryLanguage(_ sender: Any) {
+        self.languagesManager.selectingPrimaryLanguage = true
         self.delegate?.moveToLanguagesList(primaryLanguage: true)
     }
     
     @IBAction func pressSelectParallelLanguage(_ sender: Any) {
+        self.languagesManager.selectingPrimaryLanguage = false
         self.delegate?.moveToLanguagesList(primaryLanguage: false)
     }
     

--- a/godtools/ViewControllers/Platform/LanguageSettingsViewController.swift
+++ b/godtools/ViewControllers/Platform/LanguageSettingsViewController.swift
@@ -34,9 +34,9 @@ class LanguageSettingsViewController: BaseViewController {
     }
     
     private func setupPrimaryLanguageButton() {
-        if GTSettings.shared.primaryLanguageId != nil {
-            let primaryLanguage = self.languagesManager.loadFromDisk(id: GTSettings.shared.primaryLanguageId!)
-            primaryLanguageButton.setTitle(primaryLanguage.localizedName, for: .normal)
+        let primaryLanguage = self.languagesManager.loadPrimaryLanguageFromDisk()
+        if primaryLanguage != nil {
+            primaryLanguageButton.setTitle(primaryLanguage!.localizedName, for: .normal)
         } else {
             primaryLanguageButton.setTitle("select_primary_language".localized, for: .normal)
         }

--- a/godtools/ViewControllers/Platform/LanguageSettingsViewController.swift
+++ b/godtools/ViewControllers/Platform/LanguageSettingsViewController.swift
@@ -22,10 +22,6 @@ class LanguageSettingsViewController: BaseViewController {
         }
     }
     
-    override func didReceiveMemoryWarning() {
-        super.didReceiveMemoryWarning()
-    }
-    
     // MARK: - Actions
     
     @IBAction func pressSelectPrimaryLanguage(_ sender: Any) {

--- a/godtools/ViewControllers/Platform/LanguageSettingsViewController.swift
+++ b/godtools/ViewControllers/Platform/LanguageSettingsViewController.swift
@@ -36,7 +36,7 @@ class LanguageSettingsViewController: BaseViewController {
     private func setupPrimaryLanguageButton() {
         if GTSettings.shared.primaryLanguageId != nil {
             let primaryLanguage = self.languagesManager.loadFromDisk(id: GTSettings.shared.primaryLanguageId!)
-            primaryLanguageButton.setTitle(primaryLanguage.code, for: .normal)
+            primaryLanguageButton.setTitle(primaryLanguage.localizedName, for: .normal)
         } else {
             primaryLanguageButton.setTitle("select_primary_language".localized, for: .normal)
         }
@@ -45,7 +45,7 @@ class LanguageSettingsViewController: BaseViewController {
     private func setupParallelLanguageButton() {
         if GTSettings.shared.parallelLanguageId != nil {
             let parallelLanguage = self.languagesManager.loadFromDisk(id: GTSettings.shared.parallelLanguageId!)
-            parallelLanguageButton.setTitle(parallelLanguage.code, for: .normal)
+            parallelLanguageButton.setTitle(parallelLanguage.localizedName, for: .normal)
         } else {
             parallelLanguageButton.setTitle("select_parallel_language".localized, for: .normal)
         }

--- a/godtools/ViewControllers/Platform/LanguageSettingsViewController.xib
+++ b/godtools/ViewControllers/Platform/LanguageSettingsViewController.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="15G1421" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="15G1108" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
@@ -10,6 +10,8 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="LanguageSettingsViewController" customModule="godtools" customModuleProvider="target">
             <connections>
+                <outlet property="parallelLanguageButton" destination="iQc-Pj-d7G" id="YfO-kP-oRl"/>
+                <outlet property="primaryLanguageButton" destination="wUa-h5-W1Y" id="Uke-8U-JRb"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>
         </placeholder>
@@ -53,7 +55,6 @@
                         <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
                             <real key="value" value="0.0"/>
                         </userDefinedRuntimeAttribute>
-                        <userDefinedRuntimeAttribute type="string" keyPath="translationKey" value="select_primary_language"/>
                     </userDefinedRuntimeAttributes>
                     <connections>
                         <action selector="pressSelectPrimaryLanguage:" destination="-1" eventType="touchUpInside" id="0CS-JV-4ip"/>

--- a/godtools/ViewControllers/Platform/LanguagesTableViewController.swift
+++ b/godtools/ViewControllers/Platform/LanguagesTableViewController.swift
@@ -38,16 +38,12 @@ class LanguagesTableViewController: BaseViewController {
         self.loadFromDisk()
     }
     
-    override func didReceiveMemoryWarning() {
-        super.didReceiveMemoryWarning()
-    }
-    
     // MARK: - Load data
     
     func loadFromDisk() {
-        languagesManager.loadFromDisk().always {
-            self.reloadTableView()
-        }
+        _ = languagesManager.loadFromDisk()
+
+        self.tableView.reloadData()
     }
     
     // MARK: - Helpers
@@ -63,9 +59,4 @@ class LanguagesTableViewController: BaseViewController {
     fileprivate func registerCells() {
         self.tableView.register(UINib(nibName: "LanguageTableViewCell", bundle: nil), forCellReuseIdentifier: LanguagesManager.languageCellIdentifier)
     }
-    
-    fileprivate func reloadTableView() {
-        self.tableView.reloadData()
-    }
-    
 }

--- a/godtools/ViewControllers/Platform/LanguagesTableViewController.swift
+++ b/godtools/ViewControllers/Platform/LanguagesTableViewController.swift
@@ -36,7 +36,6 @@ class LanguagesTableViewController: BaseViewController {
         self.registerCells()
         
         self.loadFromDisk()
-        self.loadFromRemote()
     }
     
     override func didReceiveMemoryWarning() {
@@ -48,17 +47,6 @@ class LanguagesTableViewController: BaseViewController {
     func loadFromDisk() {
         languagesManager.loadFromDisk().always {
             self.reloadTableView()
-        }
-    }
-    
-    func loadFromRemote() {
-        languagesManager.loadFromRemote().catch(execute: { error in
-            if self.languagesManager.languages.count == 0 {
-                self.showAlertControllerWith(message: "language_download_error".localized)
-            }
-        }).always {
-            self.reloadTableView()
-            self.hideNetworkActivityIndicator()
         }
     }
     

--- a/godtools/ViewControllers/Platform/ToolDetailViewController.swift
+++ b/godtools/ViewControllers/Platform/ToolDetailViewController.swift
@@ -26,10 +26,6 @@ class ToolDetailViewController: BaseViewController {
         self.displayData()
     }
 
-    override func didReceiveMemoryWarning() {
-        super.didReceiveMemoryWarning()
-    }
-    
     // MARK: Present data
     
     fileprivate func displayData() {

--- a/godtools/Views/Cells/HomeToolTableViewCell.swift
+++ b/godtools/Views/Cells/HomeToolTableViewCell.swift
@@ -78,6 +78,14 @@ class HomeToolTableViewCell: UITableViewCell {
         layer.shouldRasterize = true
     }
     
+    func setTitle(_ title: String?) {
+        self.titleLabel.text = title
+    }
+    
+    func setLanguage(_ language: String?) {
+        self.languageLabel.text = language
+    }
+    
     // MARK: Present data
     
     fileprivate func displayData() {

--- a/godtools/Views/Cells/LanguageTableViewCell.swift
+++ b/godtools/Views/Cells/LanguageTableViewCell.swift
@@ -23,6 +23,7 @@ class LanguageTableViewCell: UITableViewCell {
     var language: Language? {
         didSet {
             languageExists(language!.shouldDownload)
+            languageCanBeDeleted(language: language!)
             languageLabel.text = language!.localizedName
         }
     }
@@ -57,4 +58,12 @@ class LanguageTableViewCell: UITableViewCell {
         self.downloadButton.isHidden = exists
     }
     
+    fileprivate func languageCanBeDeleted(language: Language) {
+        if language.remoteId! == GTSettings.shared.primaryLanguageId ||
+            language.remoteId! == GTSettings.shared.parallelLanguageId ||
+            language.code! == Locale.current.languageCode! {
+                self.deleteButton.isEnabled = false
+                self.downloadButton.isEnabled = false
+        }
+    }
 }

--- a/godtools/Views/Cells/LanguageTableViewCell.swift
+++ b/godtools/Views/Cells/LanguageTableViewCell.swift
@@ -18,10 +18,6 @@ class LanguageTableViewCell: UITableViewCell {
         super.awakeFromNib()
         setupStyle()
     }
-
-    override func setSelected(_ selected: Bool, animated: Bool) {
-        super.setSelected(selected, animated: animated)
-    }
     
     // MARK: - Actions
     

--- a/godtools/Views/Cells/LanguageTableViewCell.swift
+++ b/godtools/Views/Cells/LanguageTableViewCell.swift
@@ -8,11 +8,24 @@
 
 import UIKit
 
+protocol LanguageTableViewCellDelegate {
+    func downloadButtonWasPressed(_ cell: LanguageTableViewCell)
+    func deleteButtonWasPressed(_ cell: LanguageTableViewCell)
+}
+
 class LanguageTableViewCell: UITableViewCell {
     
     @IBOutlet weak var downloadButton: UIButton!
     @IBOutlet weak var deleteButton: UIButton!
     @IBOutlet weak var languageLabel: GTLabel!
+    
+    var cellDelegate: LanguageTableViewCellDelegate?
+    var language: Language? {
+        didSet {
+            languageExists(language!.shouldDownload)
+            languageLabel.text = language!.localizedName
+        }
+    }
     
     override func awakeFromNib() {
         super.awakeFromNib()
@@ -22,9 +35,13 @@ class LanguageTableViewCell: UITableViewCell {
     // MARK: - Actions
     
     @IBAction func pressDownloadButton(_ sender: Any) {
+        self.cellDelegate?.downloadButtonWasPressed(self)
+        self.languageExists(true)
     }
     
     @IBAction func pressDeleteButton(_ sender: Any) {
+        self.cellDelegate?.deleteButtonWasPressed(self)
+        self.languageExists(false)
     }
     
     // MARK: - Helpers
@@ -35,7 +52,7 @@ class LanguageTableViewCell: UITableViewCell {
         self.selectedBackgroundView = selectedView
     }
     
-    func languageExists(_ exists:Bool) {
+    fileprivate func languageExists(_ exists:Bool) {
         self.deleteButton.isHidden = !exists
         self.downloadButton.isHidden = exists
     }

--- a/godtools/godtools.xcdatamodeld/godtools.xcdatamodel/contents
+++ b/godtools/godtools.xcdatamodeld/godtools.xcdatamodel/contents
@@ -4,6 +4,7 @@
         <attribute name="code" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="remoteId" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shouldDownload" optional="YES" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
         <relationship name="pages" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="PageFile" inverseName="resource" inverseEntity="PageFile" syncable="YES"/>
         <relationship name="translations" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Translation" inverseName="downloadedResource" inverseEntity="Translation" syncable="YES"/>
     </entity>
@@ -29,7 +30,7 @@
         <relationship name="language" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Language" inverseName="translations" inverseEntity="Language" syncable="YES"/>
     </entity>
     <elements>
-        <element name="DownloadedResource" positionX="-36" positionY="9" width="128" height="120"/>
+        <element name="DownloadedResource" positionX="-36" positionY="9" width="128" height="135"/>
         <element name="Language" positionX="-63" positionY="-18" width="128" height="105"/>
         <element name="PageFile" positionX="-18" positionY="27" width="128" height="90"/>
         <element name="Translation" positionX="-54" positionY="-9" width="128" height="165"/>

--- a/godtools/godtools.xcdatamodeld/godtools.xcdatamodel/contents
+++ b/godtools/godtools.xcdatamodeld/godtools.xcdatamodel/contents
@@ -12,6 +12,7 @@
         <attribute name="code" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="localizedName" optional="YES" transient="YES" attributeType="String" syncable="YES"/>
         <attribute name="remoteId" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shouldDownload" optional="YES" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
         <relationship name="translations" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Translation" inverseName="language" inverseEntity="Translation" syncable="YES"/>
     </entity>
     <entity name="PageFile" representedClassName="PageFile" syncable="YES">
@@ -31,7 +32,7 @@
     </entity>
     <elements>
         <element name="DownloadedResource" positionX="-36" positionY="9" width="128" height="135"/>
-        <element name="Language" positionX="-63" positionY="-18" width="128" height="105"/>
+        <element name="Language" positionX="-63" positionY="-18" width="128" height="120"/>
         <element name="PageFile" positionX="-18" positionY="27" width="128" height="90"/>
         <element name="Translation" positionX="-54" positionY="-9" width="128" height="165"/>
     </elements>


### PR DESCRIPTION
Begins to wire some of the front end UIs into the background data model.

- Home and Add Tools show available resources, based off of DownloadedResource.shouldDownload
- Selecting an item from Add Tools "downloads" (simulated for now) and makes it appear on the Home view
   - this should be the button driving the "download", I think, but it's done there yet
- Selecting a language from the languages screen sets it as the primary/parallel language in the user settings
  - download/delete buttons are not yet wired up.
- Onboarding view is shown in viewDidLoad so it only shows once per app open, and once a user selects a primary language it is not shown again.