### PR TITLE
When banner is nil, then set the placeholder image.

### DIFF
--- a/godtools/Views/Cells/HomeToolTableViewCell.swift
+++ b/godtools/Views/Cells/HomeToolTableViewCell.swift
@@ -65,9 +65,7 @@ class HomeToolTableViewCell: UITableViewCell {
             setCellAsDisplayOnly()
         }
         
-        if banner != nil {
-            bannerImageView.image = banner
-        }
+        bannerImageView.image = banner ?? #imageLiteral(resourceName: "cell_banner_placeholder")
     }
     
     private func configureLabels(resource: DownloadedResource,


### PR DESCRIPTION
This ensures that when a resource is removed, the cell below it doesn't accidentally display the banner for the resource just removed.

The use case is, cell n has a banner and n+1 does not. Cell n's resource is removed, and when coming back to the home view cell n+1 (now cell n) renders the banner for the resource just removed because the banner passed into the config method was nil, and there was nothing to handle that.