### PR TITLE
Localized name description

### DIFF
--- a/godtools/Managers/DownloadResources/DownloadedResourceManager.swift
+++ b/godtools/Managers/DownloadResources/DownloadedResourceManager.swift
@@ -97,7 +97,9 @@ class DownloadedResourceManager: GTDataManager {
                 cachedTranslation.version = remoteTranslation.version!.int16Value
                 cachedTranslation.isPublished = remoteTranslation.isPublished!.boolValue
                 cachedTranslation.manifestFilename = remoteTranslation.manifestName
-                
+                cachedTranslation.localizedName = remoteTranslation.translatedName
+                cachedTranslation.localizedDescription = remoteTranslation.translatedDescription
+                                
                 cachedResource.addToTranslations(cachedTranslation)
                 
                 TranslationsManager.shared.purgeTranslationsOlderThan(cachedTranslation, saving: false)

--- a/godtools/Managers/Translations/TranslationResource.swift
+++ b/godtools/Managers/Translations/TranslationResource.swift
@@ -14,6 +14,8 @@ class TranslationResource: Resource {
     var version: NSNumber?
     var isPublished: NSNumber?
     var manifestName: String?
+    var translatedName: String?
+    var translatedDescription: String?
     
     var language: LanguageResource?
     
@@ -26,6 +28,8 @@ class TranslationResource: Resource {
             "version" : Attribute(),
             "isPublished" : BooleanAttribute().serializeAs("is-published"),
             "manifestName" : Attribute().serializeAs("manifest-name"),
+            "translatedName": Attribute().serializeAs("translated-name"),
+            "translatedDescription": Attribute().serializeAs("translated-description"),
             "language" : ToOneRelationship(LanguageResource.self)
         ])
     }

--- a/godtools/Models/DownloadedResource+CoreDataClass.swift
+++ b/godtools/Models/DownloadedResource+CoreDataClass.swift
@@ -46,4 +46,20 @@ public class DownloadedResource: NSManagedObject {
     func translationsAsArray() -> [Translation] {
         return Array(translations!) as! [Translation]
     }
+    
+    func localizedName(language: Language?) -> String {
+        guard let language = language else {
+            return name!
+        }
+        
+        if isAvailableInLanguage(language) {
+            guard let translation = getTranslationForLanguage(language) else {
+                return name!
+            }
+            
+            return translation.localizedName ?? name!
+        }
+        
+        return name!
+    }
 }

--- a/godtools/ViewControllers/Platform/ToolDetailViewController.swift
+++ b/godtools/ViewControllers/Platform/ToolDetailViewController.swift
@@ -35,7 +35,7 @@ class ToolDetailViewController: BaseViewController {
     fileprivate func displayData() {
         self.totalViewsLabel.text = String.localizedStringWithFormat("total_views".localized, resource!.totalViews)
         self.totalLanguagesLabel.text = String.localizedStringWithFormat("total_languages".localized, resource!.numberOfAvailableLanguages())
-        self.titleLabel.text = resource?.name
+        self.titleLabel.text = resource!.localizedName(language: LanguagesManager.shared.loadPrimaryLanguageFromDisk())
 
         self.languagesLabel.text = Array(resource!.translations!)
             .map({ "\(($0 as! Translation).language!.localizedName())"})

--- a/godtools/ViewControllers/Tract/TractViewController.swift
+++ b/godtools/ViewControllers/Tract/TractViewController.swift
@@ -315,10 +315,8 @@ extension TractViewController {
     
     fileprivate func currentTractTitle() -> String {
         let primaryLanguage = LanguagesManager.shared.loadPrimaryLanguageFromDisk()
-        if primaryLanguage != nil && resource!.isAvailableInLanguage(primaryLanguage) {
-            return resource?.getTranslationForLanguage(primaryLanguage!)?.localizedName ?? resource!.name!
-        }
-        return resource!.name!
+        
+        return resource!.localizedName(language: primaryLanguage)
     }
     
     fileprivate func parallelLanguageIsAvailable() -> Bool {

--- a/godtools/ViewControllers/Tract/TractViewController.swift
+++ b/godtools/ViewControllers/Tract/TractViewController.swift
@@ -314,7 +314,11 @@ class TractViewController: BaseViewController {
 extension TractViewController {
     
     fileprivate func currentTractTitle() -> String {
-        return resource != nil ? resource!.name! : "GodTools"
+        let primaryLanguage = LanguagesManager.shared.loadPrimaryLanguageFromDisk()
+        if primaryLanguage != nil && resource!.isAvailableInLanguage(primaryLanguage) {
+            return resource?.getTranslationForLanguage(primaryLanguage!)?.localizedName ?? resource!.name!
+        }
+        return resource!.name!
     }
     
     fileprivate func parallelLanguageIsAvailable() -> Bool {

--- a/godtools/ViewControllers/Tract/TractViewController.swift
+++ b/godtools/ViewControllers/Tract/TractViewController.swift
@@ -322,13 +322,11 @@ extension TractViewController {
     }
     
     fileprivate func parallelLanguageIsAvailable() -> Bool {
-        let parallelLanguage = LanguagesManager.shared.loadParallelLanguageFromDisk()
-        
-        if parallelLanguage == nil {
+        guard let parallelLanguage = LanguagesManager.shared.loadParallelLanguageFromDisk() else {
             return false
         }
         
-        return resource!.isAvailableInLanguage(parallelLanguage!)
+        return resource!.isAvailableInLanguage(parallelLanguage)
     }
     
     fileprivate func languageSegmentedControl() -> UISegmentedControl {

--- a/godtools/Views/Cells/HomeToolTableViewCell.swift
+++ b/godtools/Views/Cells/HomeToolTableViewCell.swift
@@ -75,14 +75,8 @@ class HomeToolTableViewCell: UITableViewCell {
                                  isAvailableInPrimaryLanguage: Bool,
                                  primaryLanguage: Language?,
                                  parallelLanguage: Language?) {
-        if isAvailableInPrimaryLanguage && primaryLanguage != nil {
-            titleLabel.isEnabled = true
-            titleLabel.text = resource.getTranslationForLanguage(primaryLanguage!)?.localizedName ?? resource.name
-        } else {
-            titleLabel.isEnabled = false
-            titleLabel.text = resource.name
-        }
-        
+        titleLabel.isEnabled = isAvailableInPrimaryLanguage
+        titleLabel.text = resource.localizedName(language: primaryLanguage)
         
         languageLabel.text = resource.isAvailableInLanguage(parallelLanguage) ? parallelLanguage!.localizedName() : nil
         

--- a/godtools/Views/Cells/HomeToolTableViewCell.swift
+++ b/godtools/Views/Cells/HomeToolTableViewCell.swift
@@ -54,6 +54,7 @@ class HomeToolTableViewCell: UITableViewCell {
         
         configureLabels(resource: resource,
                         isAvailableInPrimaryLanguage: isAvailableInPrimaryLanguage,
+                        primaryLanguage: primaryLanguage,
                         parallelLanguage: parallelLanguage)
         
         downloadProgressView.setProgress(0.0, animated: false)
@@ -72,9 +73,16 @@ class HomeToolTableViewCell: UITableViewCell {
     
     private func configureLabels(resource: DownloadedResource,
                                  isAvailableInPrimaryLanguage: Bool,
+                                 primaryLanguage: Language?,
                                  parallelLanguage: Language?) {
-        titleLabel.text = resource.name
-        titleLabel.isEnabled = isAvailableInPrimaryLanguage
+        if isAvailableInPrimaryLanguage && primaryLanguage != nil {
+            titleLabel.isEnabled = true
+            titleLabel.text = resource.getTranslationForLanguage(primaryLanguage!)?.localizedName ?? resource.name
+        } else {
+            titleLabel.isEnabled = false
+            titleLabel.text = resource.name
+        }
+        
         
         languageLabel.text = resource.isAvailableInLanguage(parallelLanguage) ? parallelLanguage!.localizedName() : nil
         


### PR DESCRIPTION
Retrieve localized name and description when updating translations from the database

Use these values to show throughout the app where resource.name was used.