### PR TITLE
Track views

### DIFF
--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -134,6 +134,8 @@
 		4FC74ED41ED5E14500D6BFFF /* Attachment+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FC74ED21ED5E14500D6BFFF /* Attachment+CoreDataClass.swift */; };
 		4FC74ED51ED5E14500D6BFFF /* Attachment+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FC74ED31ED5E14500D6BFFF /* Attachment+CoreDataProperties.swift */; };
 		4FC74ED81ED5E2BD00D6BFFF /* AttachmentResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FC74ED71ED5E2BD00D6BFFF /* AttachmentResource.swift */; };
+		4FE4AF2A1EE0F19C000E3125 /* ToolsManager+ResourceViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE4AF291EE0F19C000E3125 /* ToolsManager+ResourceViews.swift */; };
+		4FE4AF2C1EE0F386000E3125 /* ResourceViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE4AF2B1EE0F386000E3125 /* ResourceViews.swift */; };
 		4FEE566F1EC4EAD20085249E /* GTProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FEE566E1EC4EAD20085249E /* GTProgressView.swift */; };
 		4FF646291ECF35DF00953090 /* FirstLaunchInitializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FF646281ECF35DF00953090 /* FirstLaunchInitializer.swift */; };
 		4FF6462D1ECF69D400953090 /* TranslationFileRemover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FF6462C1ECF69D400953090 /* TranslationFileRemover.swift */; };
@@ -285,6 +287,8 @@
 		4FC74ED21ED5E14500D6BFFF /* Attachment+CoreDataClass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Attachment+CoreDataClass.swift"; path = "Models/Attachment+CoreDataClass.swift"; sourceTree = "<group>"; };
 		4FC74ED31ED5E14500D6BFFF /* Attachment+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Attachment+CoreDataProperties.swift"; path = "Models/Attachment+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		4FC74ED71ED5E2BD00D6BFFF /* AttachmentResource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AttachmentResource.swift; path = Managers/Attachments/AttachmentResource.swift; sourceTree = "<group>"; };
+		4FE4AF291EE0F19C000E3125 /* ToolsManager+ResourceViews.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "ToolsManager+ResourceViews.swift"; path = "Managers/ToolsManager+ResourceViews.swift"; sourceTree = "<group>"; };
+		4FE4AF2B1EE0F386000E3125 /* ResourceViews.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ResourceViews.swift; path = Managers/ResourceViews.swift; sourceTree = "<group>"; };
 		4FEE566E1EC4EAD20085249E /* GTProgressView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = GTProgressView.swift; path = Views/GTProgressView.swift; sourceTree = "<group>"; };
 		4FF646281ECF35DF00953090 /* FirstLaunchInitializer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FirstLaunchInitializer.swift; path = Managers/FirstLaunchInitializer.swift; sourceTree = "<group>"; };
 		4FF6462C1ECF69D400953090 /* TranslationFileRemover.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TranslationFileRemover.swift; path = Managers/TranslationFileRemover.swift; sourceTree = "<group>"; };
@@ -695,6 +699,8 @@
 				4F5707D61EAA985500A540C2 /* PageResource.swift */,
 				4F5707D81EAE760D00A540C2 /* GTDataManager.swift */,
 				0F93A9331EAA56EC0049C110 /* ToolsManager.swift */,
+				4FE4AF291EE0F19C000E3125 /* ToolsManager+ResourceViews.swift */,
+				4FE4AF2B1EE0F386000E3125 /* ResourceViews.swift */,
 				0F0352BD1EC0CE97006CD4E5 /* TractManager.swift */,
 				4F855F091EC3907300B42146 /* TranslationZipImporter.swift */,
 				4FF6462C1ECF69D400953090 /* TranslationFileRemover.swift */,
@@ -1107,6 +1113,8 @@
 				0FB73E701EA90669000BA60D /* LanguagesTableViewController.swift in Sources */,
 				68C0A3861ED4C6B100CC97A3 /* Config.swift in Sources */,
 				0F806C6D1EB3E6D700F3ED2B /* TractCard.swift in Sources */,
+				4FE4AF2C1EE0F386000E3125 /* ResourceViews.swift in Sources */,
+				4FE4AF2A1EE0F19C000E3125 /* ToolsManager+ResourceViews.swift in Sources */,
 				0FF3D8CF1ED5E27200A19BCC /* GTAppDefaultColors.swift in Sources */,
 				0F9E32521EDE794F0081DBB9 /* TractViewControllerDataManagement.swift in Sources */,
 				0F350D9B1EAE786A0025C4BB /* String.swift in Sources */,

--- a/godtools/Managers/ResourceViews.swift
+++ b/godtools/Managers/ResourceViews.swift
@@ -1,0 +1,32 @@
+//
+//  ResourceViews.swift
+//  godtools
+//
+//  Created by Ryan Carlson on 6/1/17.
+//  Copyright © 2017 Cru. All rights reserved.
+//
+
+import Foundation
+import Spine
+
+class ResourceViews: Resource {
+    
+    var resourceId: NSNumber?
+    var quantity: NSNumber?
+    
+    convenience init(resourceId: NSNumber, quantity: NSNumber) {
+        self.init()
+        self.resourceId = resourceId
+        self.quantity = quantity
+    }
+    
+    override class var resourceType: ResourceType {
+        return "view"
+    }
+    
+    override class var fields: [Field] {
+        return fieldsFromDictionary([
+            "resourceId" : Attribute().serializeAs("resource_id"),
+            "quantity" : Attribute()])
+    }
+}

--- a/godtools/Managers/ToolsManager+ResourceViews.swift
+++ b/godtools/Managers/ToolsManager+ResourceViews.swift
@@ -1,0 +1,42 @@
+//
+//  ToolsManager+ResourceViews.swift
+//  godtools
+//
+//  Created by Ryan Carlson on 6/1/17.
+//  Copyright © 2017 Cru. All rights reserved.
+//
+
+import Foundation
+import Alamofire
+import PromiseKit
+import Spine
+
+extension ToolsManager {
+    
+    func recordViewed(_ resource: DownloadedResource) {
+        recordViewOnRemote(resource).catch { (error) in
+            resource.myViews += 1
+            self.saveToDisk()
+        }
+    }
+    
+    private func recordViewOnRemote(_ resource: DownloadedResource) -> Promise<String> {
+        return Alamofire.request((Config.shared().baseUrl?.appendingPathComponent(viewsPath))!,
+                          method: .post,
+                          parameters: buildParameters(resource: resource),
+                          encoding: URLEncoding.default,
+                          headers: nil)
+            .validate()
+            .responseString()
+        
+    }
+    
+    private func buildParameters(resource: DownloadedResource) -> [String: Any] {
+        let resourceViews = ResourceViews(resourceId: NSNumber(value: Int(resource.remoteId!)!),
+                                          quantity: 1)
+        
+        
+        let paramsData = try! self.serializer.serializeResources([resourceViews])
+        return try! JSONSerialization.jsonObject(with: paramsData, options: []) as! [String: Any]
+    }
+}

--- a/godtools/Managers/ToolsManager+ResourceViews.swift
+++ b/godtools/Managers/ToolsManager+ResourceViews.swift
@@ -10,33 +10,55 @@ import Foundation
 import Alamofire
 import PromiseKit
 import Spine
+import Crashlytics
 
 extension ToolsManager {
     
     func recordViewed(_ resource: DownloadedResource) {
-        recordViewOnRemote(resource).catch { (error) in
+        recordViewOnRemote(resource, quantity: 1).catch { (error) in
             resource.myViews += 1
             self.saveToDisk()
+            self.record(error)
         }
     }
     
-    private func recordViewOnRemote(_ resource: DownloadedResource) -> Promise<String> {
+    func syncCachedRecordViews() {
+        for resource in findAllEntities(DownloadedResource.self) {
+            if resource.myViews == 0 {
+                continue
+            }
+            recordViewOnRemote(resource, quantity: NSNumber(value: resource.myViews))
+                .then(execute: { (_) -> Promise<Void> in
+                    resource.myViews = 0
+                    self.saveToDisk()
+                    return Promise(value: ())
+                })
+                .catch(execute: { (error) in
+                    self.record(error)
+                })
+        }
+    }
+    
+    private func recordViewOnRemote(_ resource: DownloadedResource, quantity: NSNumber) -> Promise<String> {
         return Alamofire.request((Config.shared().baseUrl?.appendingPathComponent(viewsPath))!,
                           method: .post,
-                          parameters: buildParameters(resource: resource),
+                          parameters: buildParameters(resource: resource, quantity: quantity),
                           encoding: URLEncoding.default,
                           headers: nil)
             .validate()
             .responseString()
-        
     }
     
-    private func buildParameters(resource: DownloadedResource) -> [String: Any] {
+    private func buildParameters(resource: DownloadedResource, quantity: NSNumber) -> [String: Any] {
         let resourceViews = ResourceViews(resourceId: NSNumber(value: Int(resource.remoteId!)!),
-                                          quantity: 1)
+                                          quantity: quantity)
         
         
         let paramsData = try! self.serializer.serializeResources([resourceViews])
         return try! JSONSerialization.jsonObject(with: paramsData, options: []) as! [String: Any]
+    }
+    
+    private func record(_ error: Error) {
+        Crashlytics().recordError(error, withAdditionalUserInfo: ["customMessage": "Unable to sync views to remote for resource \(resource.remoteId!)"])
     }
 }

--- a/godtools/Managers/ToolsManager+ResourceViews.swift
+++ b/godtools/Managers/ToolsManager+ResourceViews.swift
@@ -18,7 +18,7 @@ extension ToolsManager {
         recordViewOnRemote(resource, quantity: 1).catch { (error) in
             resource.myViews += 1
             self.saveToDisk()
-            self.record(error)
+            self.record(error, resource: resource)
         }
     }
     
@@ -34,7 +34,7 @@ extension ToolsManager {
                     return Promise(value: ())
                 })
                 .catch(execute: { (error) in
-                    self.record(error)
+                    self.record(error, resource: resource)
                 })
         }
     }
@@ -58,7 +58,7 @@ extension ToolsManager {
         return try! JSONSerialization.jsonObject(with: paramsData, options: []) as! [String: Any]
     }
     
-    private func record(_ error: Error) {
+    private func record(_ error: Error, resource: DownloadedResource) {
         Crashlytics().recordError(error, withAdditionalUserInfo: ["customMessage": "Unable to sync views to remote for resource \(resource.remoteId!)"])
     }
 }

--- a/godtools/Managers/ToolsManager.swift
+++ b/godtools/Managers/ToolsManager.swift
@@ -21,6 +21,8 @@ class ToolsManager: GTDataManager {
     
     static let shared = ToolsManager()
     
+    let viewsPath = "views"
+    
     var resources: [DownloadedResource]?
     
     weak var delegate: ToolsManagerDelegate? {
@@ -112,7 +114,7 @@ extension ToolsManager: UITableViewDelegate {
         }
         
         if cell.isAvailable {
-            cell.resource!.myViews += 1
+            self.recordViewed(cell.resource!)
             self.delegate?.didSelectTableViewRow!(cell: cell)
         }
     }

--- a/godtools/Managers/ToolsManager.swift
+++ b/godtools/Managers/ToolsManager.swift
@@ -21,6 +21,11 @@ class ToolsManager: GTDataManager {
     
     static let shared = ToolsManager()
     
+    private override init() {
+        super.init()
+        self.syncCachedRecordViews()
+    }
+    
     let viewsPath = "views"
     
     var resources: [DownloadedResource]?

--- a/godtools/Managers/ToolsManager.swift
+++ b/godtools/Managers/ToolsManager.swift
@@ -106,7 +106,13 @@ extension ToolsManager: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let cell = tableView.cellForRow(at: indexPath) as! HomeToolTableViewCell
         
-        if cell.isAvailable || self.delegate is AddToolsViewController {
+        if self.delegate is AddToolsViewController {
+            self.delegate?.didSelectTableViewRow!(cell: cell)
+            return
+        }
+        
+        if cell.isAvailable {
+            cell.resource!.myViews += 1
             self.delegate?.didSelectTableViewRow!(cell: cell)
         }
     }

--- a/godtools/Models/DownloadedResource+CoreDataProperties.swift
+++ b/godtools/Models/DownloadedResource+CoreDataProperties.swift
@@ -2,7 +2,7 @@
 //  DownloadedResource+CoreDataProperties.swift
 //  godtools
 //
-//  Created by Ryan Carlson on 5/24/17.
+//  Created by Ryan Carlson on 6/1/17.
 //  Copyright © 2017 Cru. All rights reserved.
 //
 
@@ -16,16 +16,34 @@ extension DownloadedResource {
         return NSFetchRequest<DownloadedResource>(entityName: "DownloadedResource");
     }
 
+    @NSManaged public var bannerRemoteId: String?
     @NSManaged public var code: String?
     @NSManaged public var copyrightDescription: String?
     @NSManaged public var name: String?
     @NSManaged public var remoteId: String?
     @NSManaged public var shouldDownload: Bool
     @NSManaged public var totalViews: Int32
-    @NSManaged public var bannerRemoteId: String?
+    @NSManaged public var myViews: Int32
+    @NSManaged public var attachments: NSSet?
     @NSManaged public var pages: NSSet?
     @NSManaged public var translations: NSSet?
-    @NSManaged public var attachments: NSSet?
+
+}
+
+// MARK: Generated accessors for attachments
+extension DownloadedResource {
+
+    @objc(addAttachmentsObject:)
+    @NSManaged public func addToAttachments(_ value: Attachment)
+
+    @objc(removeAttachmentsObject:)
+    @NSManaged public func removeFromAttachments(_ value: Attachment)
+
+    @objc(addAttachments:)
+    @NSManaged public func addToAttachments(_ values: NSSet)
+
+    @objc(removeAttachments:)
+    @NSManaged public func removeFromAttachments(_ values: NSSet)
 
 }
 
@@ -60,22 +78,5 @@ extension DownloadedResource {
 
     @objc(removeTranslations:)
     @NSManaged public func removeFromTranslations(_ values: NSSet)
-
-}
-
-// MARK: Generated accessors for attachments
-extension DownloadedResource {
-
-    @objc(addAttachmentsObject:)
-    @NSManaged public func addToAttachments(_ value: Attachment)
-
-    @objc(removeAttachmentsObject:)
-    @NSManaged public func removeFromAttachments(_ value: Attachment)
-
-    @objc(addAttachments:)
-    @NSManaged public func addToAttachments(_ values: NSSet)
-
-    @objc(removeAttachments:)
-    @NSManaged public func removeFromAttachments(_ values: NSSet)
 
 }

--- a/godtools/godtools.xcdatamodeld/godtools.xcdatamodel/contents
+++ b/godtools/godtools.xcdatamodeld/godtools.xcdatamodel/contents
@@ -11,6 +11,7 @@
         <attribute name="bannerRemoteId" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="code" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="copyrightDescription" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="myViews" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="remoteId" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="shouldDownload" optional="YES" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
@@ -49,7 +50,7 @@
     </entity>
     <elements>
         <element name="Attachment" positionX="-45" positionY="72" width="128" height="120"/>
-        <element name="DownloadedResource" positionX="-36" positionY="9" width="128" height="195"/>
+        <element name="DownloadedResource" positionX="-36" positionY="9" width="128" height="210"/>
         <element name="Language" positionX="-63" positionY="-18" width="128" height="105"/>
         <element name="PageFile" positionX="-18" positionY="27" width="128" height="90"/>
         <element name="ReferencedFile" positionX="-45" positionY="63" width="128" height="75"/>


### PR DESCRIPTION
This PR adds the ability to record with the API that a resource has been viewed. If the request fails, then a counter is incremented on DownloadedResource object. These stored values are then synced on app re-launch. If successful the counter resets to 0