### PR TITLE
GT-332: Hide all cards when touching the label of an open card

### DIFF
--- a/godtools/Views/TractElements/TractCardActions.swift
+++ b/godtools/Views/TractElements/TractCardActions.swift
@@ -36,7 +36,7 @@ extension TractCard {
         case .preview:
             showCardAndPreviousCards()
         case .open:
-            hideCardAndPreviousCards()
+            hideAllCards()
         case .close:
             showCardAndPreviousCards()
         case .enable:
@@ -85,7 +85,7 @@ extension TractCard {
         disableScrollview()
     }
     
-    func hideCardAndPreviousCards() {
+    func hideAllCards() {
         if self.cardState == .close || self.cardState == .hidden {
             return
         }

--- a/godtools/Views/TractElements/TractCardActions.swift
+++ b/godtools/Views/TractElements/TractCardActions.swift
@@ -36,7 +36,7 @@ extension TractCard {
         case .preview:
             showCardAndPreviousCards()
         case .open:
-            hideCard()
+            hideCardAndPreviousCards()
         case .close:
             showCardAndPreviousCards()
         case .enable:
@@ -83,6 +83,15 @@ extension TractCard {
         self.cardsParentView.hideCallToAction()
         hideCardAnimation()
         disableScrollview()
+    }
+    
+    func hideCardAndPreviousCards() {
+        if self.cardState == .close || self.cardState == .hidden {
+            return
+        }
+        
+        self.cardsParentView.resetEnvironment()
+        self.cardsParentView.hideCallToAction()
     }
     
     func resetCard() {


### PR DESCRIPTION
This will change the current behaviour, from hiding only the open card to hide all cards (moving them back to its original position) when the user press on the label of the card