### PR TITLE
GT-294: Change style of navigation bar of tract

### DIFF
--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -148,6 +148,7 @@
 		EC55A6251EE0AD03000235CA /* TractPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC55A6241EE0AD03000235CA /* TractPage.swift */; };
 		EC8A6B991EE1CD7A003B4C02 /* kgp-7.xml in Resources */ = {isa = PBXBuildFile; fileRef = EC8A6B981EE1CD7A003B4C02 /* kgp-7.xml */; };
 		EC8A6B9B1EE200CF003B4C02 /* TractPagination.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC8A6B9A1EE200CF003B4C02 /* TractPagination.swift */; };
+		ECA4B3441EE7119A00BAE23C /* UIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECA4B3431EE7119A00BAE23C /* UIColor.swift */; };
 		ECB5A8BE1EE5CA1F008E4AB7 /* AboutViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECB5A8BC1EE5CA1F008E4AB7 /* AboutViewController.swift */; };
 		ECB5A8BF1EE5CA1F008E4AB7 /* AboutViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = ECB5A8BD1EE5CA1F008E4AB7 /* AboutViewController.xib */; };
 		ECB5A8C21EE5E326008E4AB7 /* WebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECB5A8C01EE5E326008E4AB7 /* WebViewController.swift */; };
@@ -317,6 +318,7 @@
 		EC55A6241EE0AD03000235CA /* TractPage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TractPage.swift; path = TractClasses/TractPage.swift; sourceTree = "<group>"; };
 		EC8A6B981EE1CD7A003B4C02 /* kgp-7.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "kgp-7.xml"; sourceTree = "<group>"; };
 		EC8A6B9A1EE200CF003B4C02 /* TractPagination.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TractPagination.swift; path = TractClasses/TractPagination.swift; sourceTree = "<group>"; };
+		ECA4B3431EE7119A00BAE23C /* UIColor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UIColor.swift; path = GeneralExtensions/UIColor.swift; sourceTree = "<group>"; };
 		ECB5A8BC1EE5CA1F008E4AB7 /* AboutViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AboutViewController.swift; sourceTree = "<group>"; };
 		ECB5A8BD1EE5CA1F008E4AB7 /* AboutViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = AboutViewController.xib; sourceTree = "<group>"; };
 		ECB5A8C01EE5E326008E4AB7 /* WebViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebViewController.swift; sourceTree = "<group>"; };
@@ -391,6 +393,7 @@
 			children = (
 				0F350D9A1EAE786A0025C4BB /* String.swift */,
 				0F9E32531EDE8D0D0081DBB9 /* UIImage.swift */,
+				ECA4B3431EE7119A00BAE23C /* UIColor.swift */,
 			);
 			name = GeneralExtensions;
 			sourceTree = "<group>";
@@ -1107,6 +1110,7 @@
 				0F2837981EC62D3F0049CCE5 /* TractLink.swift in Sources */,
 				0F806C711EB3E72C00F3ED2B /* TractCallToAction.swift in Sources */,
 				0F806C691EB3E6B100F3ED2B /* TractNumber.swift in Sources */,
+				ECA4B3441EE7119A00BAE23C /* UIColor.swift in Sources */,
 				0F9E323F1EDCEDEE0081DBB9 /* TractModalActions.swift in Sources */,
 				4F462A3D1EB0F43400C03447 /* BaseTractElement.swift in Sources */,
 				0FB73E571EA9063E000BA60D /* GTButton.swift in Sources */,

--- a/godtools/Constants/GTAppDefaultColors.swift
+++ b/godtools/Constants/GTAppDefaultColors.swift
@@ -10,6 +10,8 @@ import Foundation
 
 struct GTAppDefaultColors {
     
+    static let navBarColor = "rgba(59, 164, 219, 1)"
+    static let navBarControlColor = "rgba(255, 255, 255, 1)"
     static let primaryColor = "rgba(59, 164, 219, 1)"
     static let primaryTextColorString = "rgba(59, 164, 219, 1)"
     static let textColorString = "rgba(90, 90, 90, 1)"

--- a/godtools/FlowControllers/BaseFlowController.swift
+++ b/godtools/FlowControllers/BaseFlowController.swift
@@ -128,7 +128,13 @@ extension BaseFlowController: BaseViewControllerDelegate {
     
     func changeNavigationColors(backgroundColor: UIColor, controlColor: UIColor) {
         let navigationController: UINavigationController = (self.currentViewController?.navigationController)!
-        configureNavigationColor(navigationController: navigationController, color: backgroundColor)
+        
+        if backgroundColor.colorWithoutTransparency() != nil {
+            configureNavigationColor(navigationController: navigationController, color: backgroundColor.colorWithoutTransparency()!)
+        } else {
+            configureNavigationColor(navigationController: navigationController, color: backgroundColor)
+        }
+        
         navigationController.navigationBar.tintColor = controlColor
     }
     

--- a/godtools/FlowControllers/BaseFlowController.swift
+++ b/godtools/FlowControllers/BaseFlowController.swift
@@ -126,6 +126,12 @@ extension BaseFlowController: BaseViewControllerDelegate {
         configureNavigationColor(navigationController: navigationController, color: color)
     }
     
+    func changeNavigationColors(backgroundColor: UIColor, controlColor: UIColor) {
+        let navigationController: UINavigationController = (self.currentViewController?.navigationController)!
+        configureNavigationColor(navigationController: navigationController, color: backgroundColor)
+        navigationController.navigationBar.tintColor = controlColor
+    }
+    
 }
 
 extension BaseFlowController: MenuViewControllerDelegate {

--- a/godtools/GeneralExtensions/String.swift
+++ b/godtools/GeneralExtensions/String.swift
@@ -26,7 +26,7 @@ extension String {
         
         for component in components {
             let result = String(component.characters.filter {
-                String($0).rangeOfCharacter(from: CharacterSet(charactersIn: "0123456789")) != nil
+                String($0).rangeOfCharacter(from: CharacterSet(charactersIn: ".0123456789")) != nil
             })
             let value = NumberFormatter().number(from: result)
             values.append(CGFloat(value!))

--- a/godtools/GeneralExtensions/UIColor.swift
+++ b/godtools/GeneralExtensions/UIColor.swift
@@ -1,0 +1,34 @@
+//
+//  UIColor.swift
+//  godtools
+//
+//  Created by Pablo Marti on 6/6/17.
+//  Copyright © 2017 Cru. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+extension UIColor {
+    
+    func colorWithoutTransparency() -> UIColor? {
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+        if self.getRed(&red, green: &green, blue: &blue, alpha: &alpha) {
+            if alpha == 1.0 {
+                return self
+            } else {
+                let background: CGFloat = 255.0
+                let red2: CGFloat = alpha * red + (1 - alpha) * background
+                let green2: CGFloat = alpha * green + (1 - green) * background
+                let blue2: CGFloat = alpha * blue + (1 - blue) * background
+                return UIColor(red: red2/255.0, green: green2/255.0, blue: blue2/255.0, alpha: 1.0)
+            }
+        } else {
+            return nil
+        }
+    }
+    
+}

--- a/godtools/Managers/TractManager.swift
+++ b/godtools/Managers/TractManager.swift
@@ -13,7 +13,7 @@ import Crashlytics
 
 class TractManager: GTDataManager {
     
-    let testMode = false
+    let testMode = true
 
 }
 
@@ -45,6 +45,8 @@ extension TractManager {
             return (pages, tractColors)
         }
         
+        let navBarColorString: String = (manifest.element?.attribute(by: "navbar-color")?.text) ?? GTAppDefaultColors.navBarColor
+        let navBarControlColorString: String = (manifest.element?.attribute(by: "navbar-control-color")?.text) ?? GTAppDefaultColors.navBarControlColor
         let primaryColorString: String = (manifest.element?.attribute(by: "primary-color")?.text) ?? GTAppDefaultColors.primaryColor
         let primaryTextColorString: String = (manifest.element?.attribute(by: "primary-text-color")?.text) ?? GTAppDefaultColors.primaryTextColorString
         let textColorString: String = (manifest.element?.attribute(by: "text-color")?.text) ?? GTAppDefaultColors.textColorString
@@ -60,6 +62,8 @@ extension TractManager {
             }
         }
         
+        tractColors.navBarColor = navBarColorString.getRGBAColor()
+        tractColors.navBarControlColor = navBarControlColorString.getRGBAColor()
         tractColors.primaryColor = primaryColorString.getRGBAColor()
         tractColors.primaryTextColor = primaryTextColorString.getRGBAColor()
         tractColors.textColor = textColorString.getRGBAColor()

--- a/godtools/Managers/TractManager.swift
+++ b/godtools/Managers/TractManager.swift
@@ -13,7 +13,7 @@ import Crashlytics
 
 class TractManager: GTDataManager {
     
-    let testMode = true
+    let testMode = false
 
 }
 

--- a/godtools/TractClasses/TractColors.swift
+++ b/godtools/TractClasses/TractColors.swift
@@ -10,6 +10,8 @@ import UIKit
 
 class TractColors: NSObject {
     
+    var navBarColor: UIColor?
+    var navBarControlColor: UIColor?
     var primaryColor: UIColor?
     var primaryTextColor: UIColor?
     var textColor: UIColor?
@@ -18,14 +20,18 @@ class TractColors: NSObject {
         super.init()
     }
     
-    init(primaryColor: UIColor, primaryTextColor: UIColor, textColor: UIColor) {
+    init(navBarColor: UIColor, navBarControlColor: UIColor, primaryColor: UIColor, primaryTextColor: UIColor, textColor: UIColor) {
+        self.navBarColor = navBarColor
+        self.navBarControlColor = navBarControlColor
         self.primaryColor = primaryColor
         self.primaryTextColor = primaryTextColor
         self.textColor = textColor
     }
     
     func copyObject() -> TractColors {
-        return TractColors(primaryColor: self.primaryColor!,
+        return TractColors(navBarColor: self.navBarColor!,
+                           navBarControlColor: self.navBarControlColor!,
+                           primaryColor: self.primaryColor!,
                            primaryTextColor: self.primaryTextColor!,
                            textColor: self.textColor!)
     }

--- a/godtools/ViewControllers/BaseViewController.swift
+++ b/godtools/ViewControllers/BaseViewController.swift
@@ -11,7 +11,7 @@ import UIKit
 protocol BaseViewControllerDelegate {
     mutating func goBack()
     mutating func goHome()
-    mutating func changeNavigationBarColor(_ color: UIColor)
+    mutating func changeNavigationColors(backgroundColor: UIColor, controlColor: UIColor)
 }
 
 class BaseViewController: UIViewController {

--- a/godtools/ViewControllers/Tract/TractViewController.swift
+++ b/godtools/ViewControllers/Tract/TractViewController.swift
@@ -106,7 +106,7 @@ class TractViewController: BaseViewController {
     }
     
     fileprivate func setupNavigationBarStyles() {
-        self.baseDelegate?.changeNavigationColors(backgroundColor: (self.colors?.primaryColor)!, controlColor: (self.colors?.primaryTextColor)!)
+        self.baseDelegate?.changeNavigationColors(backgroundColor: (self.colors?.navBarColor)!, controlColor: (self.colors?.navBarControlColor)!)
         
         let navigationBar = navigationController!.navigationBar
         

--- a/godtools/ViewControllers/Tract/TractViewController.swift
+++ b/godtools/ViewControllers/Tract/TractViewController.swift
@@ -106,7 +106,7 @@ class TractViewController: BaseViewController {
     }
     
     fileprivate func setupNavigationBarStyles() {
-        self.baseDelegate?.changeNavigationBarColor((self.colors?.primaryColor)!)
+        self.baseDelegate?.changeNavigationColors(backgroundColor: (self.colors?.primaryColor)!, controlColor: (self.colors?.primaryTextColor)!)
         
         let navigationBar = navigationController!.navigationBar
         

--- a/godtools/XMLContent/KGP/kgp-0.xml
+++ b/godtools/XMLContent/KGP/kgp-0.xml
@@ -4,7 +4,7 @@
     xmlns:content="https://mobile-content-api.cru.org/xmlns/content">
     <hero>
         <heading>
-            <content:text i18n-id="{{uuid}}">Knowing God Personally :)</content:text>
+            <content:text i18n-id="{{uuid}}">Knowing God Personally</content:text>
         </heading>
         
         <paragraph>

--- a/godtools/XMLContent/KGP/kgp-0.xml
+++ b/godtools/XMLContent/KGP/kgp-0.xml
@@ -4,7 +4,7 @@
     xmlns:content="https://mobile-content-api.cru.org/xmlns/content">
     <hero>
         <heading>
-            <content:text i18n-id="{{uuid}}">Knowing God Personally</content:text>
+            <content:text i18n-id="{{uuid}}">Knowing God Personally :)</content:text>
         </heading>
         
         <paragraph>

--- a/godtools/XMLContent/KGP/kgp-manifest.xml
+++ b/godtools/XMLContent/KGP/kgp-manifest.xml
@@ -3,6 +3,8 @@
           xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
           background-image="resource/bg-texture.png"
           background-image-align="repeat"
+          navbar-color="rgba(0, 0, 0, 0)"
+          navbar-control-color="rgba(255, 255, 255, 1)"
           primary-color="rgba(59, 164, 219, 1)"
           primary-text-color="rgba(59, 164, 219, 1)"
           text-color="rgba(90, 90, 90, 1)">

--- a/godtools/XMLContent/KGP/kgp-manifest.xml
+++ b/godtools/XMLContent/KGP/kgp-manifest.xml
@@ -4,7 +4,7 @@
           background-image="resource/bg-texture.png"
           background-image-align="repeat"
           navbar-color="rgba(0, 0, 0, 0)"
-          navbar-control-color="rgba(255, 255, 255, 1)"
+          navbar-control-color="rgba(59, 164, 219, 1)"
           primary-color="rgba(59, 164, 219, 1)"
           primary-text-color="rgba(59, 164, 219, 1)"
           text-color="rgba(90, 90, 90, 1)">


### PR DESCRIPTION
This PR sets the navigation bar items to have the color defined in the primary text color of the manifest. The background color also changes, but first it transforms the color with an alpha to a similar color without alpha, removing the transparency.