### PR TITLE
GT-337: Fix crash when moving through pages

### DIFF
--- a/godtools/Managers/TractManager.swift
+++ b/godtools/Managers/TractManager.swift
@@ -13,7 +13,7 @@ import Crashlytics
 
 class TractManager: GTDataManager {
     
-    let testMode = true
+    let testMode = false
 
 }
 

--- a/godtools/ViewControllers/Tract/TractViewController.swift
+++ b/godtools/ViewControllers/Tract/TractViewController.swift
@@ -26,7 +26,7 @@ class TractViewController: BaseViewController {
         return CGFloat(currentPage) *  -self.view.frame.width
     }
     var containerView = UIView()
-    var pagesViews = [BaseTractView]()
+    var pagesViews = [BaseTractView?]()
     var progressView = UIView()
     var progressViewHelper = UIView()
     var currentProgressView = UIView()

--- a/godtools/ViewControllers/Tract/TractViewControllerContent.swift
+++ b/godtools/ViewControllers/Tract/TractViewControllerContent.swift
@@ -50,16 +50,16 @@ extension TractViewController {
         let width = self.containerView.frame.size.width
         let height = self.containerView.frame.size.height
         let lastPosition = self.totalPages() - 1
-        var tmpPagesViews = [BaseTractView?](repeating: nil, count: 10)
+        var tmpPagesViews = [BaseTractView?](repeating: nil, count: totalPages())
         
         for position in range.start...range.end {
-            let pageView = self.pagesViews[position]
-            if pageView != nil {
-                tmpPagesViews[position] = pageView!
+            if let pageView = self.pagesViews[position] {
+                tmpPagesViews[position] = pageView
             } else {
                 let view = buildPage(position, width: width, height: height)
                 tmpPagesViews[position] = view
                 self.containerView.addSubview(view)
+                
             }
         }
         
@@ -101,7 +101,7 @@ extension TractViewController {
     }
     
     func resetPagesView() {
-        self.pagesViews = [BaseTractView?](repeating: nil, count: 10)
+        self.pagesViews = [BaseTractView?](repeating: nil, count: totalPages())
     }
     
     private func addSnapshotView() {

--- a/godtools/ViewControllers/Tract/TractViewControllerContent.swift
+++ b/godtools/ViewControllers/Tract/TractViewControllerContent.swift
@@ -19,7 +19,7 @@ extension TractViewController {
         let range = getRangeOfViews()
         for pageNumber in range.start...range.end {
             let view = buildPage(pageNumber, width: width, height: height)
-            self.pagesViews.append(view)
+            self.pagesViews[pageNumber] = view
             self.containerView.addSubview(view)
         }
         
@@ -47,39 +47,30 @@ extension TractViewController {
     
     func reloadPagesViews() {
         let range = getRangeOfViews()
-        let firstTag = (self.pagesViews.first?.tag)! - self.viewTagOrigin
-        let lastTag = (self.pagesViews.last?.tag)! - self.viewTagOrigin
         let width = self.containerView.frame.size.width
         let height = self.containerView.frame.size.height
+        let lastPosition = self.totalPages() - 1
+        var tmpPagesViews = [BaseTractView?](repeating: nil, count: 10)
         
-        if firstTag < range.start {
-            for _ in 0...firstTag {
-                self.pagesViews.first?.removeFromSuperview()
-                self.pagesViews.removeFirst()
-            }
-            
-        } else if firstTag > range.start {
-            var position = 0
-            for _ in range.start...firstTag {
-                let view = buildPage(range.start + position, width: width, height: height)
-                self.pagesViews.insert(view, at: position)
-                self.containerView.addSubview(view)
-                position += 1
-            }
-        }
-        
-        if lastTag < range.end {
-            for position in lastTag...range.end {
+        for position in range.start...range.end {
+            let pageView = self.pagesViews[position]
+            if pageView != nil {
+                tmpPagesViews[position] = pageView!
+            } else {
                 let view = buildPage(position, width: width, height: height)
-                self.pagesViews.append(view)
+                tmpPagesViews[position] = view
                 self.containerView.addSubview(view)
             }
-        } else if lastTag > range.end {
-            for _ in range.end...lastTag {
-                self.pagesViews.last?.removeFromSuperview()
-                self.pagesViews.removeLast()
+        }
+        
+        for position in 0...lastPosition {
+            let pageView = self.pagesViews[position]
+            if pageView != nil && (position < range.start || position > range.end) {
+                pageView?.removeFromSuperview()
             }
         }
+        
+        self.pagesViews = tmpPagesViews
     }
     
     func getRangeOfViews() -> (start: Int, end: Int) {
@@ -89,7 +80,7 @@ extension TractViewController {
         }
         
         var end = self.currentPage + 2
-        if end > self.totalPages() - 1 {
+        if end >= self.totalPages() {
             end = totalPages() - 1
         }
         
@@ -106,6 +97,11 @@ extension TractViewController {
         }
         
         self.pagesViews.removeAll()
+        resetPagesView()
+    }
+    
+    func resetPagesView() {
+        self.pagesViews = [BaseTractView?](repeating: nil, count: 10)
     }
     
     private func addSnapshotView() {

--- a/godtools/ViewControllers/Tract/TractViewControllerPageMovements.swift
+++ b/godtools/ViewControllers/Tract/TractViewControllerPageMovements.swift
@@ -56,7 +56,7 @@ extension TractViewController {
             if pageView == currentPageView {
                 break
             }
-            pageView.removeFromSuperview()
+            pageView?.removeFromSuperview()
         }
     }
     
@@ -72,7 +72,7 @@ extension TractViewController {
                        animations: {
                         self.currentProgressView.frame = newCurrentProgressViewFrame
                         for view in self.pagesViews {
-                            view.transform = CGAffineTransform(translationX: self.currentMovement, y: 0.0)
+                            view?.transform = CGAffineTransform(translationX: self.currentMovement, y: 0.0)
                         } },
                        completion: nil )
     }


### PR DESCRIPTION
This PR changes the way of how the views are managed. It will always have a max of 5 items, but will have a specific space for storing each view (that, when not used will be nil). This fix the crash and helps by making the code easy to understand and handle, and allows to move from long distance views.