### PR TITLE
switching to space separated events instead of comma separated

### DIFF
--- a/godtools/Views/TractElements/TractButtonActions.swift
+++ b/godtools/Views/TractElements/TractButtonActions.swift
@@ -13,7 +13,7 @@ extension TractButton {
     
     func buttonTarget() {
         if self.properties.type == .event {
-            let values = self.properties.value!.components(separatedBy: ",")
+            let values = self.properties.value!.components(separatedBy: " ")
             for value in values {
                 sendMessageToElement(listener: value)
             }

--- a/godtools/Views/TractElements/TractLinkActions.swift
+++ b/godtools/Views/TractElements/TractLinkActions.swift
@@ -11,7 +11,7 @@ import Foundation
 extension TractLink {
     
     override func buttonTarget() {
-        guard let events = self.properties.events?.components(separatedBy: ",") else {
+        guard let events = self.properties.events?.components(separatedBy: " ") else {
             return
         }
         

--- a/godtools/XMLContent/KGP/kgp-5.xml
+++ b/godtools/XMLContent/KGP/kgp-5.xml
@@ -76,7 +76,7 @@
                         <content:text i18n-id="{{uuid}}">Email</content:text>
                     </content:placeholder>
                 </content:input>
-                <content:button type="event" value="followup:send,send-information-modal">
+                <content:button type="event" value="followup:send send-information-modal">
                     <content:text i18n-id="{{uuid}}">
                         Send
                     </content:text>


### PR DESCRIPTION
@pablomarti I believe I adjusted the changed separator for multi-events.

This is dependent on the changes made in this PR: https://github.com/CruGlobal/mobile-content-api/pull/68