### PR TITLE
Platform updates

### DIFF
--- a/godtools/FlowControllers/BaseFlowController.swift
+++ b/godtools/FlowControllers/BaseFlowController.swift
@@ -164,7 +164,7 @@ extension BaseFlowController: LanguageSettingsViewControllerDelegate {
     func moveToLanguagesList(primaryLanguage: Bool) {
         let viewController = LanguagesTableViewController(nibName: String(describing:LanguagesTableViewController.self), bundle: nil)
         viewController.delegate = self
-        viewController.selectingPrimaryLanguage(primaryLanguage)
+        viewController.selectingForPrimary = primaryLanguage
         self.pushViewController(viewController: viewController)
     }
 }

--- a/godtools/Localizable.strings
+++ b/godtools/Localizable.strings
@@ -57,6 +57,7 @@
 "dismiss" = "Dismiss";
 "done" = "Done";
 "remove" = "Remove";
+"clear" = "Clear";
 
 // Alerts
 "ok" = "Ok";

--- a/godtools/ViewControllers/BaseViewController.swift
+++ b/godtools/ViewControllers/BaseViewController.swift
@@ -124,6 +124,11 @@ class BaseViewController: UIViewController {
         self.navigationRightButtons.append(button)
     }
     
+    func addClearButton() {
+        let button = UIBarButtonItem(title: "clear".localized, style: UIBarButtonItemStyle.done, target: self, action: #selector(clearButtonAction))
+        self.navigationRightButtons.append(button)
+    }
+    
     func buildNavigationButton(imageName: String, action: Selector) -> UIBarButtonItem {
         let buttonFrame = CGRect(x: 0.0, y: 0.0, width: 22.0, height: 22.0)
         let button: UIButton = UIButton(frame: buttonFrame)
@@ -153,6 +158,10 @@ class BaseViewController: UIViewController {
     
     func doneButtonAction() {
         NotificationCenter.default.post(name: .dismissMenuNotification, object: nil)
+    }
+    
+    func clearButtonAction() {
+        
     }
     
     // MARK: - Helpers

--- a/godtools/ViewControllers/Platform/HomeViewController.swift
+++ b/godtools/ViewControllers/Platform/HomeViewController.swift
@@ -60,6 +60,11 @@ class HomeViewController: BaseViewController {
                                                selector: #selector(reloadView),
                                                name: .initialAppStateCleanupCompleted,
                                                object: nil)
+        
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(reloadView),
+                                               name: .downloadPrimaryTranslationCompleteNotification,
+                                               object: nil)
     }
     
     @objc private func presentLanguageSettings() {

--- a/godtools/ViewControllers/Platform/LanguagesTableViewController.swift
+++ b/godtools/ViewControllers/Platform/LanguagesTableViewController.swift
@@ -40,6 +40,10 @@ class LanguagesTableViewController: BaseViewController {
     }
     
     override func viewDidLoad() {
+        if !selectingForPrimary {
+            addClearButton()
+        }
+
         super.viewDidLoad()
         
         registerCells()
@@ -62,7 +66,6 @@ class LanguagesTableViewController: BaseViewController {
     func selectingPrimaryLanguage(_ primary:Bool) {
         if primary {
             screenTitleAux = "primary_language"
-
         } else {
             screenTitleAux = "parallel_language"
         }
@@ -70,6 +73,11 @@ class LanguagesTableViewController: BaseViewController {
         languagesManager.selectingPrimaryLanguage = primary
     }
     
+    override func clearButtonAction() {
+        GTSettings.shared.parallelLanguageId = nil
+        tableView.reloadData()
+    }
+
     private func configureListForParallelChoice() {
         // remove primary language from list of options for parallel
         if let primaryLanguage = languagesManager.loadPrimaryLanguageFromDisk() {

--- a/godtools/ViewControllers/Platform/LanguagesTableViewController.swift
+++ b/godtools/ViewControllers/Platform/LanguagesTableViewController.swift
@@ -22,6 +22,8 @@ class LanguagesTableViewController: BaseViewController {
     let languagesManager = LanguagesManager()
     let zipImporter = TranslationZipImporter()
     
+    var selectingForPrimary = true
+    
     var screenTitleAux: String = "primary_language"
     
     override var screenTitle: String {
@@ -49,6 +51,9 @@ class LanguagesTableViewController: BaseViewController {
     func loadLanguages() {
         languages = languagesManager.loadFromDisk()
 
+        if !selectingForPrimary {
+            configureListForParallelChoice()
+        }
         tableView.reloadData()
     }
     
@@ -57,13 +62,23 @@ class LanguagesTableViewController: BaseViewController {
     func selectingPrimaryLanguage(_ primary:Bool) {
         if primary {
             screenTitleAux = "primary_language"
+
         } else {
             screenTitleAux = "parallel_language"
         }
         
         languagesManager.selectingPrimaryLanguage = primary
     }
-
+    
+    private func configureListForParallelChoice() {
+        // remove primary language from list of options for parallel
+        if let primaryLanguage = languagesManager.loadPrimaryLanguageFromDisk() {
+            if let index = languages.index(of: primaryLanguage) {
+                languages.remove(objectAtIndex: index)
+            }
+        }
+    }
+    
     fileprivate func registerCells() {
         tableView.register(UINib(nibName: "LanguageTableViewCell", bundle: nil),
                            forCellReuseIdentifier: LanguagesTableViewController.languageCellIdentifier)

--- a/godtools/ViewControllers/Platform/LanguagesTableViewController.swift
+++ b/godtools/ViewControllers/Platform/LanguagesTableViewController.swift
@@ -40,7 +40,7 @@ class LanguagesTableViewController: BaseViewController {
     }
     
     override func viewDidLoad() {
-        if !selectingForPrimary {
+        if !selectingForPrimary, languagesManager.loadParallelLanguageFromDisk() != nil {
             addClearButton()
         }
 

--- a/godtools/ViewControllers/Platform/ToolDetailViewController.swift
+++ b/godtools/ViewControllers/Platform/ToolDetailViewController.swift
@@ -87,12 +87,11 @@ class ToolDetailViewController: BaseViewController {
         if resource!.shouldDownload {
             DownloadedResourceManager().delete(self.resource!)
             downloadProgressView.setProgress(0.0, animated: false)
-            displayButton()
-            returnToHome()
         } else {
             DownloadedResourceManager().download(self.resource!)
-            displayButton()
         }
+        displayButton()
+        returnToHome()
     }
     
     private func returnToHome() {


### PR DESCRIPTION
- return to home view after delete or download from tract info view
- demo a "Clear" button as one way to deselect a parallel language
   - this button is an imcomplete feature as it should show hide appropriate based on state updates within the view. However b/c other changes are coming to the LanguagesManager and we don't know if we will use this, i want to put off those changes until later.