### PR TITLE
Download two banners, one for home page, one for about page

### DIFF
--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -107,6 +107,7 @@
 		4F462A3A1EB0E28900C03447 /* TractParagraph.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F462A361EB0E28900C03447 /* TractParagraph.swift */; };
 		4F462A3B1EB0E28900C03447 /* TractTextContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F462A371EB0E28900C03447 /* TractTextContent.swift */; };
 		4F462A3D1EB0F43400C03447 /* BaseTractElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F462A3C1EB0F43400C03447 /* BaseTractElement.swift */; };
+		4F4FE0821EF86EFC008AE579 /* GTDataManager+Migrations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F4FE0811EF86EFC008AE579 /* GTDataManager+Migrations.swift */; };
 		4F5707D91EAE760D00A540C2 /* GTDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F5707D81EAE760D00A540C2 /* GTDataManager.swift */; };
 		4F5707E11EAE8CA300A540C2 /* TractViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4F5707E01EAE8CA300A540C2 /* TractViewController.xib */; };
 		4F5707E31EAE8CB600A540C2 /* TractViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F5707E21EAE8CB600A540C2 /* TractViewController.swift */; };
@@ -297,6 +298,7 @@
 		4F462A361EB0E28900C03447 /* TractParagraph.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TractParagraph.swift; path = Views/TractElements/TractParagraph.swift; sourceTree = "<group>"; };
 		4F462A371EB0E28900C03447 /* TractTextContent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TractTextContent.swift; path = Views/TractElements/TractTextContent.swift; sourceTree = "<group>"; };
 		4F462A3C1EB0F43400C03447 /* BaseTractElement.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BaseTractElement.swift; path = Views/TractElements/BaseTractElement.swift; sourceTree = "<group>"; };
+		4F4FE0811EF86EFC008AE579 /* GTDataManager+Migrations.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "GTDataManager+Migrations.swift"; path = "Managers/GTDataManager+Migrations.swift"; sourceTree = "<group>"; };
 		4F5707D81EAE760D00A540C2 /* GTDataManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = GTDataManager.swift; path = Managers/GTDataManager.swift; sourceTree = "<group>"; };
 		4F5707E01EAE8CA300A540C2 /* TractViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = TractViewController.xib; path = Tract/TractViewController.xib; sourceTree = "<group>"; };
 		4F5707E21EAE8CB600A540C2 /* TractViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TractViewController.swift; path = Tract/TractViewController.swift; sourceTree = "<group>"; };
@@ -756,6 +758,7 @@
 				4F1C95981EA7E742007B47DB /* DownloadedResources */,
 				4F1C95811EA7B03B007B47DB /* Languages */,
 				4F5707D81EAE760D00A540C2 /* GTDataManager.swift */,
+				4F4FE0811EF86EFC008AE579 /* GTDataManager+Migrations.swift */,
 				0F93A9331EAA56EC0049C110 /* ToolsManager.swift */,
 				4FE4AF291EE0F19C000E3125 /* ToolsManager+ResourceViews.swift */,
 				4FE4AF2B1EE0F386000E3125 /* ResourceViews.swift */,
@@ -1415,6 +1418,7 @@
 				ECBE2E551EF048F600A13849 /* TractCard+UI.swift in Sources */,
 				0F28379C1EC65A330049CCE5 /* TractTab.swift in Sources */,
 				0FB0E7C51EB00C6F00583BF3 /* GTSwitch.swift in Sources */,
+				4F4FE0821EF86EFC008AE579 /* GTDataManager+Migrations.swift in Sources */,
 				0F9E32411EDD170C0081DBB9 /* TractCallToAction+Actions.swift in Sources */,
 				ECBE2E6B1EF1053000A13849 /* TractProperties.swift in Sources */,
 			);

--- a/godtools/Managers/BannerManager.swift
+++ b/godtools/Managers/BannerManager.swift
@@ -9,6 +9,7 @@
 import Foundation
 import PromiseKit
 import Crashlytics
+import Alamofire
 
 class BannerManager: GTDataManager {
     let path = "attachments"
@@ -20,32 +21,32 @@ class BannerManager: GTDataManager {
     }
     
     let defaultExtension = "png"
-    var bannerId: String?
     
-    func downloadFor(_ resource: DownloadedResource) -> Promise<UIImage?> {
-        guard let remoteId = resource.bannerRemoteId else {
-            return Promise<UIImage?>(value: nil)
+    func downloadFor(_ resource: DownloadedResource) {
+        
+        let homeBannerAttachment = loadAttachment(remoteId: resource.bannerRemoteId)
+        
+        if homeBannerAttachment != nil && bannerHasChanged(attachment: homeBannerAttachment!) {
+            _ = issueDownloadRequest(attachment: homeBannerAttachment!).then(execute: { (image) -> Void in
+                self.postCompletedNotification(resource: resource)
+            })
         }
-        
-        guard let attachment = loadAttachment(remoteId: remoteId) else {
-            return Promise<UIImage?>(value: nil)
+
+        let aboutBannerAttachment = loadAttachment(remoteId: resource.bannerRemoteId)
+
+        if aboutBannerAttachment != nil && bannerHasChanged(attachment: aboutBannerAttachment!) {
+            _ = issueDownloadRequest(attachment: aboutBannerAttachment!)
         }
-        
-        if !bannerHasChanged(attachment: attachment) {
-            return Promise(value: loadFor(resource))
-        }
-        
-        bannerId = remoteId
-        
-        return issueGETRequest().then { image -> Promise<UIImage?> in
+    }
+    
+    private func issueDownloadRequest(attachment: Attachment) -> Promise<UIImage?> {
+        return issueGETRequest(bannerId: attachment.remoteId).then { image -> Promise<UIImage?> in
             self.saveImageToDisk(image, attachment: attachment)
             
-            self.postCompletedNotification(resource: resource)
-            
-            return Promise(value: UIImage(data: image))
-        }.catch(execute: { error in
-            Crashlytics().recordError(error, withAdditionalUserInfo: ["customMessage": "Error downloading banner w/ id \(self.bannerId)."])
-        })
+            return Promise<UIImage?>(value: UIImage(data: image))
+            }.catch(execute: { error in
+                Crashlytics().recordError(error, withAdditionalUserInfo: ["customMessage": "Error downloading banner."])
+            })
     }
     
     func loadFor(_ resource: DownloadedResource) -> UIImage? {
@@ -67,17 +68,16 @@ class BannerManager: GTDataManager {
         
         return UIImage(contentsOfFile: path)
     }
-
-    override func buildURL() -> URL? {
-        guard let bannerID = self.bannerId else {
-            return nil
-        }
-        return Config.shared().baseUrl?
+    
+    func issueGETRequest(bannerId: String) -> Promise<Data> {
+        let url = Config.shared().baseUrl?
             .appendingPathComponent(self.path)
-            .appendingPathComponent(bannerID)
+            .appendingPathComponent(bannerId)
             .appendingPathComponent("download")
+        
+        return Alamofire.request(url!).responseData()
     }
-
+    
     private func postCompletedNotification(resource: DownloadedResource) {
         NotificationCenter.default.post(name: .downloadBannerCompleteNotifciation,
                                         object: nil,
@@ -107,13 +107,17 @@ class BannerManager: GTDataManager {
                 attachment.isBanner = true
                 
             } catch {
-                Crashlytics().recordError(error, withAdditionalUserInfo: ["customMessage": "Error writing banner w/ id \(bannerId) to disk."])
+                Crashlytics().recordError(error, withAdditionalUserInfo: ["customMessage": "Error writing banner."])
             }
         }
     }
     
-    private func loadAttachment(remoteId: String) -> Attachment? {
-        return findEntityByRemoteId(Attachment.self, remoteId: remoteId)
+    private func loadAttachment(remoteId: String?) -> Attachment? {
+        if remoteId == nil {
+            return nil
+        }
+        
+        return findEntityByRemoteId(Attachment.self, remoteId: remoteId!)
     }
     
     private func createBannersDirectoryIfNecessary() {

--- a/godtools/Managers/BannerManager.swift
+++ b/godtools/Managers/BannerManager.swift
@@ -32,7 +32,7 @@ class BannerManager: GTDataManager {
             })
         }
 
-        let aboutBannerAttachment = loadAttachment(remoteId: resource.bannerRemoteId)
+        let aboutBannerAttachment = loadAttachment(remoteId: resource.aboutBannerRemoteId)
 
         if aboutBannerAttachment != nil && bannerHasChanged(attachment: aboutBannerAttachment!) {
             _ = issueDownloadRequest(attachment: aboutBannerAttachment!)
@@ -49,8 +49,8 @@ class BannerManager: GTDataManager {
             })
     }
     
-    func loadFor(_ resource: DownloadedResource) -> UIImage? {
-        guard let remoteId = resource.bannerRemoteId else {
+    func loadFor(remoteId: String?) -> UIImage? {
+        guard let remoteId = remoteId  else {
             return nil
         }
         

--- a/godtools/Managers/DownloadResources/DownloadedResourceJson.swift
+++ b/godtools/Managers/DownloadResources/DownloadedResourceJson.swift
@@ -15,6 +15,7 @@ class DownloadedResourceJson: Resource {
     var abbreviation: String?
     var copyrightDescription: String?
     var bannerId: String?
+    var aboutBannerId: String?
     var totalViews: NSNumber?
     
     var latestTranslations: LinkedResourceCollection?
@@ -33,6 +34,7 @@ class DownloadedResourceJson: Resource {
             "translations" : ToManyRelationship(TranslationResource.self),
             "copyrightDescription": Attribute().serializeAs("attr-copyright"),
             "bannerId": Attribute().serializeAs("attr-banner"),
+            "aboutBannerId": Attribute().serializeAs("attr-banner-about"),
             "totalViews": Attribute().serializeAs("total-views"),
             "latestTranslations" : ToManyRelationship(TranslationResource.self).serializeAs("latest-translations"),
             "attachments": ToManyRelationship(AttachmentResource.self)])

--- a/godtools/Managers/DownloadResources/DownloadedResourceManager.swift
+++ b/godtools/Managers/DownloadResources/DownloadedResourceManager.swift
@@ -76,7 +76,7 @@ class DownloadedResourceManager: GTDataManager {
                     cachedAttachment.resource = cachedResource
                 }
                 
-                if cachedResource.bannerRemoteId != nil {
+                if cachedResource.bannerRemoteId != nil || cachedResource.aboutBannerRemoteId != nil {
                     _ = BannerManager().downloadFor(cachedResource)
                 }
                 
@@ -122,6 +122,7 @@ class DownloadedResourceManager: GTDataManager {
         cachedResource.name = remoteResource.name!
         cachedResource.copyrightDescription = remoteResource.copyrightDescription
         cachedResource.bannerRemoteId = remoteResource.bannerId
+        cachedResource.aboutBannerRemoteId = remoteResource.aboutBannerId
         cachedResource.totalViews = remoteResource.totalViews!.int32Value
         
         return cachedResource

--- a/godtools/Managers/GTDataManager+Migrations.swift
+++ b/godtools/Managers/GTDataManager+Migrations.swift
@@ -1,0 +1,24 @@
+//
+//  GTDataManager+Migrations.swift
+//  godtools
+//
+//  Created by Ryan Carlson on 6/19/17.
+//  Copyright © 2017 Cru. All rights reserved.
+//
+
+import Foundation
+import RealmSwift
+
+extension GTDataManager {
+    static func config() -> Realm.Configuration  {
+        return Realm.Configuration(
+            schemaVersion: 1,
+            migrationBlock: { migration, oldSchemaVersion in
+                if oldSchemaVersion < 1 {
+                    migration.enumerateObjects(ofType: DownloadedResource.className(), { (old, new) in
+                        new!["aboutBannerRemoteId"] = ""
+                    })
+                }
+        })
+    }
+}

--- a/godtools/Managers/GTDataManager.swift
+++ b/godtools/Managers/GTDataManager.swift
@@ -19,12 +19,15 @@ class GTDataManager: NSObject {
     let bannersPath: URL
     
     let serializer = Serializer()
-    let realm = try! Realm()
+    let realm: Realm
     
     override init() {
         documentsPath = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)[0]
         resourcesPath = documentsPath.appending("/").appending("Resources")
         bannersPath = URL(fileURLWithPath: documentsPath, isDirectory: true).appendingPathComponent("Banners")
+    
+        Realm.Configuration.defaultConfiguration = GTDataManager.config()
+        realm = try! Realm()
         
         super.init()
     }

--- a/godtools/Managers/ToolsManager.swift
+++ b/godtools/Managers/ToolsManager.swift
@@ -120,7 +120,7 @@ extension ToolsManager: UITableViewDataSource {
         cell.configure(resource: resource,
                        primaryLanguage: languagesManager.loadPrimaryLanguageFromDisk(),
                        parallelLanguage: languagesManager.loadParallelLanguageFromDisk(),
-                       banner: BannerManager().loadFor(resource),
+                       banner: BannerManager().loadFor(remoteId: resource.bannerRemoteId),
                        delegate: self)
                 
         return cell

--- a/godtools/Models/DownloadedResource.swift
+++ b/godtools/Models/DownloadedResource.swift
@@ -13,6 +13,7 @@ typealias DownloadedResources = List<DownloadedResource>
 
 class DownloadedResource: Object {
     dynamic var bannerRemoteId: String?
+    dynamic var aboutBannerRemoteId: String?
     dynamic var code = ""
     dynamic var copyrightDescription: String?
     dynamic var name = ""

--- a/godtools/ViewControllers/Platform/ToolDetailViewController.swift
+++ b/godtools/ViewControllers/Platform/ToolDetailViewController.swift
@@ -43,7 +43,7 @@ class ToolDetailViewController: BaseViewController {
             .joined(separator: ", ")
         
         self.displayButton()
-        self.bannerImageView.image = BannerManager().loadFor(resource!)
+        self.bannerImageView.image = BannerManager().loadFor(remoteId: resource!.aboutBannerRemoteId)
     }
     
     private func displayButton() {

--- a/godtools/Views/Cells/HomeToolTableViewCell.swift
+++ b/godtools/Views/Cells/HomeToolTableViewCell.swift
@@ -178,7 +178,7 @@ class HomeToolTableViewCell: UITableViewCell {
             return
         }
         
-        guard let bannerImage = BannerManager().loadFor(resource!) else {
+        guard let bannerImage = BannerManager().loadFor(remoteId: resourceId) else {
             return
         }
         


### PR DESCRIPTION
Restructure Banner Manager to download both. This class no longer returns a promise b/c no one listens for it. It still posts a notification when the home page banner finishes.

BannerManager also defines its own GET method b/c storing bannerId in internal state got messy with the downloading of multiple banners in one instance.