### PR TITLE
Layout tweaks

### DIFF
--- a/godtools/Views/TractElements/TractHeading.swift
+++ b/godtools/Views/TractElements/TractHeading.swift
@@ -19,7 +19,7 @@ class TractHeading: BaseTractElement {
     
     override func textStyle() -> TractTextContentProperties {
         let properties = super.textStyle()
-        properties.font = .gtThin(size: 54.0)
+        properties.font = .gtRegular(size: 30.0)
         return properties
     }
     

--- a/godtools/Views/TractElements/TractParagraph.swift
+++ b/godtools/Views/TractElements/TractParagraph.swift
@@ -13,7 +13,7 @@ class TractParagraph: BaseTractElement {
     
     // MARK: Positions constants
     
-    static let marginConstant: CGFloat = 8.0
+    static let marginConstant: CGFloat = 0.0
     
     
     // MARK: - Setup

--- a/godtools/Views/TractElements/TractTextContentProperties.swift
+++ b/godtools/Views/TractElements/TractTextContentProperties.swift
@@ -93,7 +93,7 @@ class TractTextContentProperties: TractProperties {
     var font: UIFont {
         get {
             if _font == nil {
-                return UIFont.gtRegular(size: 15.0)
+                return UIFont.gtRegular(size: 16.0)
             } else {
                 return _font!
             }


### PR DESCRIPTION
- Change default text size to 16 to match designs
- Change hero heading text from 54 light to 30 regular to match designs
- Eliminate extra margin constant on paragraph 