### PR TITLE
Font size & color tweaks

### DIFF
--- a/godtools/TractClasses/TractProperties.swift
+++ b/godtools/TractClasses/TractProperties.swift
@@ -14,6 +14,7 @@ class TractProperties: XMLNode {
     var primaryTextColor = GTAppDefaultStyle.primaryTextColorString.getRGBAColor()
     var textColor = GTAppDefaultStyle.textColorString.getRGBAColor()
     var textScale: Int = 1
+    var textSize: Int = 18
     
     required override init() {
         super.init()
@@ -21,7 +22,7 @@ class TractProperties: XMLNode {
     
     override func getProperties() -> [String] {
         defineProperties()
-        return ["primaryColor", "primaryTextColor", "textColor", "textScale"] + self.properties
+        return ["primaryColor", "primaryTextColor", "textColor", "textScale", "textSize"] + self.properties
     }
     
     func setupDefaultProperties() { }

--- a/godtools/TractClasses/TractProperties.swift
+++ b/godtools/TractClasses/TractProperties.swift
@@ -13,7 +13,7 @@ class TractProperties: XMLNode {
     var primaryColor = GTAppDefaultStyle.primaryColor.getRGBAColor()
     var primaryTextColor = GTAppDefaultStyle.primaryTextColorString.getRGBAColor()
     var textColor = GTAppDefaultStyle.textColorString.getRGBAColor()
-    var textScale: Int = 1
+    var textScale: CGFloat = 1.0
     var textSize: Int = 18
     
     required override init() {
@@ -22,7 +22,7 @@ class TractProperties: XMLNode {
     
     override func getProperties() -> [String] {
         defineProperties()
-        return ["primaryColor", "primaryTextColor", "textColor", "textScale", "textSize"] + self.properties
+        return ["primaryColor", "primaryTextColor", "textColor", "textScale"] + self.properties
     }
     
     func setupDefaultProperties() { }

--- a/godtools/TractClasses/TractProperties.swift
+++ b/godtools/TractClasses/TractProperties.swift
@@ -13,6 +13,7 @@ class TractProperties: XMLNode {
     var primaryColor = GTAppDefaultStyle.primaryColor.getRGBAColor()
     var primaryTextColor = GTAppDefaultStyle.primaryTextColorString.getRGBAColor()
     var textColor = GTAppDefaultStyle.textColorString.getRGBAColor()
+    var textScale: Int = 1
     
     required override init() {
         super.init()
@@ -20,10 +21,12 @@ class TractProperties: XMLNode {
     
     override func getProperties() -> [String] {
         defineProperties()
-        return ["primaryColor", "primaryTextColor", "textColor"] + self.properties
+        return ["primaryColor", "primaryTextColor", "textColor", "textScale"] + self.properties
     }
     
-    func setupDefaultProperties(properties: TractProperties) {
+    func setupDefaultProperties() { }
+    
+    func setupParentProperties(properties: TractProperties) {
         let set1 = Set(self.getProperties().map { $0 })
         let set2 = Set(properties.getProperties().map { $0 })
         let commonProperties = set1.intersection(set2)

--- a/godtools/TractClasses/TractProperties.swift
+++ b/godtools/TractClasses/TractProperties.swift
@@ -13,12 +13,6 @@ class TractProperties: XMLNode {
     var primaryColor = GTAppDefaultStyle.primaryColor.getRGBAColor()
     var primaryTextColor = GTAppDefaultStyle.primaryTextColorString.getRGBAColor()
     var textColor = GTAppDefaultStyle.textColorString.getRGBAColor()
-    var textScale: CGFloat = 1.0
-    var textSize: Int = 18
-    
-    var finalTextSize: CGFloat {
-        return CGFloat(self.textSize) * self.textScale
-    }
     
     required override init() {
         super.init()
@@ -26,7 +20,7 @@ class TractProperties: XMLNode {
     
     override func getProperties() -> [String] {
         defineProperties()
-        return ["primaryColor", "primaryTextColor", "textColor", "textScale"] + self.properties
+        return ["primaryColor", "primaryTextColor", "textColor"] + self.properties
     }
     
     func setupDefaultProperties() { }

--- a/godtools/TractClasses/TractProperties.swift
+++ b/godtools/TractClasses/TractProperties.swift
@@ -16,6 +16,10 @@ class TractProperties: XMLNode {
     var textScale: CGFloat = 1.0
     var textSize: Int = 18
     
+    var finalTextSize: CGFloat {
+        return CGFloat(self.textSize) * self.textScale
+    }
+    
     required override init() {
         super.init()
     }

--- a/godtools/TractClasses/TractProperties.swift
+++ b/godtools/TractClasses/TractProperties.swift
@@ -9,6 +9,7 @@
 import UIKit
 
 class TractProperties: XMLNode {
+    let defaultBodyFontSize: CGFloat = 18.0
     
     var primaryColor = GTAppDefaultStyle.primaryColor.getRGBAColor()
     var primaryTextColor = GTAppDefaultStyle.primaryTextColorString.getRGBAColor()
@@ -41,6 +42,7 @@ class TractProperties: XMLNode {
         properties.primaryColor = self.primaryColor
         properties.primaryTextColor = self.primaryTextColor
         properties.textColor = self.textColor
+        properties.font = .gtRegular(size: defaultBodyFontSize)
         return properties
     }
 

--- a/godtools/Views/TractElements/BaseTractElement+StaticFunctions.swift
+++ b/godtools/Views/TractElements/BaseTractElement+StaticFunctions.swift
@@ -50,6 +50,10 @@ extension BaseTractElement {
         return BaseTractElement.isElement(element, kindOf: TractModal.self)
     }
     
+    static func isLabelElement(_ element: BaseTractElement) -> Bool {
+        return BaseTractElement.isElement(element, kindOf: TractLabel.self)
+    }
+    
     static func isElement(_ element: BaseTractElement, kindOf tractClass: AnyClass) -> Bool {
         var elementCopy: BaseTractElement? = element
         

--- a/godtools/Views/TractElements/BaseTractElement.swift
+++ b/godtools/Views/TractElements/BaseTractElement.swift
@@ -255,7 +255,8 @@ class BaseTractElement: UIView {
     
     func loadElementProperties(_ properties: [String: Any]) {
         self.properties = propertiesKind().init()
-        self.properties.setupDefaultProperties(properties: getParentProperties())
+        self.properties.setupParentProperties(properties: getParentProperties())
+        self.properties.setupDefaultProperties()
         self.properties.load(properties)
     }
     

--- a/godtools/Views/TractElements/TractHeader.swift
+++ b/godtools/Views/TractElements/TractHeader.swift
@@ -18,7 +18,7 @@ class TractHeader: BaseTractElement {
     }
     
     override func loadStyles() {
-        self.backgroundColor = self.manifestProperties.primaryColor.withAlphaComponent(0.9)
+        self.backgroundColor = self.page!.pageProperties().primaryColor
     }
     
     override func loadElementProperties(_ properties: [String : Any]) {

--- a/godtools/Views/TractElements/TractHeader.swift
+++ b/godtools/Views/TractElements/TractHeader.swift
@@ -23,7 +23,6 @@ class TractHeader: BaseTractElement {
     
     override func loadElementProperties(_ properties: [String : Any]) {
         super.loadElementProperties(properties)
-        self.properties.textColor = .gtWhite
     }
     
     override func loadFrameProperties() {

--- a/godtools/Views/TractElements/TractHeaderProperties.swift
+++ b/godtools/Views/TractElements/TractHeaderProperties.swift
@@ -18,6 +18,11 @@ class TractHeaderProperties: TractProperties {
         self.properties = ["backgroundColor"]
     }
     
+    override func setupDefaultProperties() {
+        self.textScale = 3
+        self.textColor = .gtWhite
+    }
+    
     // MARK: - View Properties
     
     var includesNumber = false

--- a/godtools/Views/TractElements/TractHeaderProperties.swift
+++ b/godtools/Views/TractElements/TractHeaderProperties.swift
@@ -18,10 +18,6 @@ class TractHeaderProperties: TractProperties {
         self.properties = ["backgroundColor"]
     }
     
-    override func setupDefaultProperties() {
-        self.textColor = .gtWhite
-    }
-    
     // MARK: - View Properties
     
     var includesNumber = false

--- a/godtools/Views/TractElements/TractHeaderProperties.swift
+++ b/godtools/Views/TractElements/TractHeaderProperties.swift
@@ -19,7 +19,6 @@ class TractHeaderProperties: TractProperties {
     }
     
     override func setupDefaultProperties() {
-        self.textScale = 3
         self.textColor = .gtWhite
     }
     

--- a/godtools/Views/TractElements/TractHeadingProperties.swift
+++ b/godtools/Views/TractElements/TractHeadingProperties.swift
@@ -9,5 +9,11 @@
 import UIKit
 
 class TractHeadingProperties: TractProperties {
-
+    let defaultHeadingFontSize: CGFloat = 30.0
+    
+    override func getTextProperties() -> TractTextContentProperties {
+        let properties = super.getTextProperties()
+        properties.font = .gtRegular(size: defaultHeadingFontSize)
+        return properties
+    }
 }

--- a/godtools/Views/TractElements/TractNumber.swift
+++ b/godtools/Views/TractElements/TractNumber.swift
@@ -24,7 +24,7 @@ class TractNumber: BaseTractElement {
     
     override func loadElementProperties(_ properties: [String: Any]) {
         self.properties = propertiesKind().init()
-        self.properties.setupDefaultProperties(properties: getParentProperties())
+        self.properties.setupParentProperties(properties: getParentProperties())
         self.properties.load(properties)
     }
     

--- a/godtools/Views/TractElements/TractParagraph+UI.swift
+++ b/godtools/Views/TractElements/TractParagraph+UI.swift
@@ -13,7 +13,6 @@ extension TractParagraph {
     
     func buildModalParagraph() -> TractTextContentProperties {
         let properties = super.textStyle()
-        properties.font = .gtRegular(size: 18.0)
         properties.width = self.elementFrame.finalWidth()
         properties.xMargin = BaseTractElement.xMargin
         properties.textColor = .gtWhite
@@ -32,7 +31,6 @@ extension TractParagraph {
         
         let properties = super.textStyle()
         properties.width = self.elementFrame.finalWidth()
-        properties.font = .gtRegular(size: 18.0)
         properties.xMargin = xMargin
         return properties
     }

--- a/godtools/Views/TractElements/TractTextContent+UI.swift
+++ b/godtools/Views/TractElements/TractTextContent+UI.swift
@@ -23,11 +23,12 @@ extension TractTextContent {
     
     func buildStandardLabel() {
         let properties = textProperties()
+        let font = UIFont (name: properties.font.fontName, size: properties.finalTextSize)
         
         self.label = GTLabel(frame: properties.getFrame())
         self.label.text = properties.value
         self.label.textAlignment = properties.textAlign
-        self.label.font = properties.font
+        self.label.font = font
         self.label.textColor = properties.textColor
         
         if properties.height == 0 {

--- a/godtools/Views/TractElements/TractTextContent+UI.swift
+++ b/godtools/Views/TractElements/TractTextContent+UI.swift
@@ -27,7 +27,7 @@ extension TractTextContent {
         self.label = GTLabel(frame: properties.getFrame())
         self.label.text = properties.value
         self.label.textAlignment = properties.textAlign
-        self.label.font = properties.font
+        self.label.font = properties.scaledFont()
         self.label.textColor = properties.textColor
         
         if properties.height == 0 {
@@ -53,11 +53,11 @@ extension TractTextContent {
         self.label = GTLabel(frame: labelFrame)
         self.label.text = properties.value
         self.label.textAlignment = .center
-        self.label.font = properties.font
+        self.label.font = properties.scaledFont()
         self.label.textColor = properties.textColor
         self.label.numberOfLines = 1
         
         self.height = self.label.frame.size.height + self.elementFrame.yMarginBottom
     }
-    
+
 }

--- a/godtools/Views/TractElements/TractTextContent+UI.swift
+++ b/godtools/Views/TractElements/TractTextContent+UI.swift
@@ -23,12 +23,11 @@ extension TractTextContent {
     
     func buildStandardLabel() {
         let properties = textProperties()
-        let font = UIFont (name: properties.font.fontName, size: properties.finalTextSize)
         
         self.label = GTLabel(frame: properties.getFrame())
         self.label.text = properties.value
         self.label.textAlignment = properties.textAlign
-        self.label.font = font
+        self.label.font = properties.font
         self.label.textColor = properties.textColor
         
         if properties.height == 0 {

--- a/godtools/Views/TractElements/TractTextContent+UI.swift
+++ b/godtools/Views/TractElements/TractTextContent+UI.swift
@@ -28,7 +28,7 @@ extension TractTextContent {
         self.label.text = properties.value
         self.label.textAlignment = properties.textAlign
         self.label.font = properties.scaledFont()
-        self.label.textColor = properties.textColor
+        self.label.textColor = properties.colorFor(self.parent!)
         
         if properties.height == 0 {
             self.label.lineBreakMode = .byWordWrapping
@@ -54,7 +54,7 @@ extension TractTextContent {
         self.label.text = properties.value
         self.label.textAlignment = .center
         self.label.font = properties.scaledFont()
-        self.label.textColor = properties.textColor
+        self.label.textColor = properties.colorFor(self.parent!)
         self.label.numberOfLines = 1
         
         self.height = self.label.frame.size.height + self.elementFrame.yMarginBottom

--- a/godtools/Views/TractElements/TractTextContent.swift
+++ b/godtools/Views/TractElements/TractTextContent.swift
@@ -23,7 +23,7 @@ class TractTextContent: BaseTractElement {
     
     override func loadElementProperties(_ properties: [String: Any]) {
         let textProperties = self.parent!.textStyle()
-        textProperties.setupDefaultProperties(properties: getParentProperties())
+        textProperties.setupParentProperties(properties: getParentProperties())
         textProperties.load(properties)
         self.properties = textProperties
     }

--- a/godtools/Views/TractElements/TractTextContentProperties.swift
+++ b/godtools/Views/TractElements/TractTextContentProperties.swift
@@ -106,7 +106,7 @@ class TractTextContentProperties: TractProperties {
     var font: UIFont {
         get {
             if _font == nil {
-                return UIFont.gtRegular(size: 16.0)
+                return UIFont.gtRegular(size: 18.0)
             } else {
                 return _font!
             }

--- a/godtools/Views/TractElements/TractTextContentProperties.swift
+++ b/godtools/Views/TractElements/TractTextContentProperties.swift
@@ -15,11 +15,11 @@ class TractTextContentProperties: TractProperties {
     var i18nId: String = ""
     var textAlign: NSTextAlignment = .left
     // textColor
-    var textScale: CGFloat = 1.0
+    // textScale
     var value: String = ""
     
     override func defineProperties() {
-        self.properties = ["i18nId", "textScale", "value"]
+        self.properties = ["i18nId", "value"]
     }
     
     // MARK: - XML Custom Properties

--- a/godtools/Views/TractElements/TractTextContentProperties.swift
+++ b/godtools/Views/TractElements/TractTextContentProperties.swift
@@ -59,6 +59,9 @@ class TractTextContentProperties: TractProperties {
     }
     
     func scaledFont() -> UIFont {
+        if textScale == 1.0 {
+            return font
+        }
         return UIFont(name: font.fontName, size: font.pointSize * self.textScale) ?? font
     }
     

--- a/godtools/Views/TractElements/TractTextContentProperties.swift
+++ b/godtools/Views/TractElements/TractTextContentProperties.swift
@@ -15,7 +15,7 @@ class TractTextContentProperties: TractProperties {
     var i18nId: String = ""
     var textAlign: NSTextAlignment = .left
     // textColor
-    // textScale
+    var textScale: CGFloat = 1.0
     var value: String = ""
     
     override func defineProperties() {
@@ -25,13 +25,16 @@ class TractTextContentProperties: TractProperties {
     // MARK: - XML Custom Properties
     
     override func customProperties() -> [String]? {
-        return ["textAlign"]
+        return ["textAlign", "textScale"]
     }
     
     override func performCustomProperty(propertyName: String, value: String) {
         switch propertyName {
         case "textAlign":
             setupTextAlign(value)
+        case "textScale":
+            setupTextScale(value)
+            
         default: break
         }
     }
@@ -47,6 +50,16 @@ class TractTextContentProperties: TractProperties {
         default:
             self.textAlign = .left
         }
+    }
+    
+    private func setupTextScale(_ string: String) {
+        let stringValue = string as NSString
+        let floatValue = stringValue.floatValue
+        self.textScale = CGFloat(floatValue)
+    }
+    
+    func scaledFont() -> UIFont {
+        return UIFont(name: font.fontName, size: font.pointSize * self.textScale) ?? font
     }
     
     // MARK: - View Properties

--- a/godtools/Views/TractElements/TractTextContentProperties.swift
+++ b/godtools/Views/TractElements/TractTextContentProperties.swift
@@ -14,7 +14,7 @@ class TractTextContentProperties: TractProperties {
     
     var i18nId: String = ""
     var textAlign: NSTextAlignment = .left
-    // textColor
+    var localTextColor: UIColor?
     var textScale: CGFloat = 1.0
     var value: String = ""
     
@@ -25,7 +25,7 @@ class TractTextContentProperties: TractProperties {
     // MARK: - XML Custom Properties
     
     override func customProperties() -> [String]? {
-        return ["textAlign", "textScale"]
+        return ["textAlign", "textScale", "textColor"]
     }
     
     override func performCustomProperty(propertyName: String, value: String) {
@@ -34,7 +34,8 @@ class TractTextContentProperties: TractProperties {
             setupTextAlign(value)
         case "textScale":
             setupTextScale(value)
-            
+        case "textColor":
+            self.localTextColor = value.getRGBAColor()
         default: break
         }
     }
@@ -65,6 +66,20 @@ class TractTextContentProperties: TractProperties {
         return UIFont(name: font.fontName, size: font.pointSize * self.textScale) ?? font
     }
     
+    func colorFor(_ element: BaseTractElement) -> UIColor {
+        if localTextColor != nil {
+            return localTextColor!
+        }
+        
+        if BaseTractElement.isHeaderElement(element) ||
+            BaseTractElement.isHeadingElement(element) ||
+            BaseTractElement.isTitleElement(element) ||
+            BaseTractElement.isLabelElement(element) {
+            return primaryColor
+        }
+        
+        return textColor
+    }
     // MARK: - View Properties
     
     var finalWidth: CGFloat {

--- a/godtools/Views/TractElements/TractTextContentProperties.swift
+++ b/godtools/Views/TractElements/TractTextContentProperties.swift
@@ -71,11 +71,15 @@ class TractTextContentProperties: TractProperties {
             return localTextColor!
         }
         
-        if BaseTractElement.isHeaderElement(element) ||
-            BaseTractElement.isHeadingElement(element) ||
-            BaseTractElement.isTitleElement(element) ||
+        if BaseTractElement.isHeadingElement(element) ||
             BaseTractElement.isLabelElement(element) {
             return primaryColor
+        }
+        
+        if BaseTractElement.isHeaderElement(element) ||
+            BaseTractElement.isTitleElement(element) ||
+            BaseTractElement.isNumberElement(element) {
+            return primaryTextColor
         }
         
         return textColor


### PR DESCRIPTION
- make colors inherited from the top level downward (manifest, page, text:content)
- a local text color should override anything set above it
- font scaling support works now too, only on lowest level content:text node
- default text size = 18, except for headings, now 30