### PR TITLE
Take the fact that the view slides behind the nav bar when moving cards.

### DIFF
--- a/godtools/FlowControllers/BaseFlowController.swift
+++ b/godtools/FlowControllers/BaseFlowController.swift
@@ -128,18 +128,11 @@ extension BaseFlowController: BaseViewControllerDelegate {
     }
     
     func changeNavigationColors(backgroundColor: UIColor, controlColor: UIColor) {
-        print("bg: %@, cont: %@", backgroundColor, controlColor)
         let navigationController: UINavigationController = (self.currentViewController?.navigationController)!
         
-//        if backgroundColor.colorWithoutTransparency() != nil {
-//            configureNavigationColor(navigationController: navigationController, color: backgroundColor.colorWithoutTransparency()!)
-//        } else {
-            configureNavigationColor(navigationController: navigationController, color: backgroundColor)
-//        }
-        
+        configureNavigationColor(navigationController: navigationController, color: backgroundColor)
         navigationController.navigationBar.tintColor = controlColor
     }
-    
 }
 
 extension BaseFlowController: MenuViewControllerDelegate {

--- a/godtools/Views/TractElements/TractCard+Actions.swift
+++ b/godtools/Views/TractElements/TractCard+Actions.swift
@@ -130,7 +130,7 @@ extension TractCard {
     func disableScrollview() {
         let properties = cardProperties()
         
-        if properties.cardState != .open {
+        if properties.cardState != .open && properties.cardState != .enable {
             let startPoint = CGPoint(x: 0, y: -self.scrollView.contentInset.top)
             self.scrollView.isScrollEnabled = false
             self.scrollView.setContentOffset(startPoint, animated: true)
@@ -140,7 +140,7 @@ extension TractCard {
     func enableScrollview() {
         let properties = cardProperties()
         
-        if properties.cardState == .open {
+        if properties.cardState == .open || properties.cardState == .enable {
             self.scrollView.isScrollEnabled = true
         }
     }

--- a/godtools/Views/TractElements/TractCard+UI.swift
+++ b/godtools/Views/TractElements/TractCard+UI.swift
@@ -42,7 +42,7 @@ extension TractCard {
         }
         
         let width = self.scrollView.frame.size.width - 6.0
-        let height: CGFloat = 60.0
+        let height: CGFloat = TractCard.transparentViewHeight
         let xPosition: CGFloat = 3.0
         let yPosition = self.scrollView.frame.size.height - height - 1.0
         let transparentViewFrame = CGRect(x: xPosition, y: yPosition, width: width, height: height)

--- a/godtools/Views/TractElements/TractCard.swift
+++ b/godtools/Views/TractElements/TractCard.swift
@@ -21,7 +21,7 @@ class TractCard: BaseTractElement {
     static let yTopMarginConstant: CGFloat = 8.0
     static let yBottomMarginConstant: CGFloat = 120.0
     static let xPaddingConstant: CGFloat = 28.0
-    static let contentBottomPadding: CGFloat = 50.0
+    static let contentBottomPadding: CGFloat = 70.0
     
     // MARK: - Positions and Sizes
     
@@ -32,8 +32,11 @@ class TractCard: BaseTractElement {
     }
     
     var internalHeight: CGFloat {
-        let internalHeight = self.height > self.externalHeight ? self.height + TractCard.contentBottomPadding : self.externalHeight
-        return internalHeight
+        if self.height > self.externalHeight {
+            return self.height + TractCard.contentBottomPadding + TractPage.navbarHeight
+        } else {
+            return self.externalHeight
+        }
     }
     
     var translationY: CGFloat {
@@ -110,7 +113,7 @@ class TractCard: BaseTractElement {
     }
     
     func cardHeight() -> CGFloat {
-        return self.getMaxHeight() - TractCard.yBottomMarginConstant
+        return self.getMaxHeight() - TractCard.yBottomMarginConstant - TractPage.navbarHeight
     }
 
 }

--- a/godtools/Views/TractElements/TractCard.swift
+++ b/godtools/Views/TractElements/TractCard.swift
@@ -21,19 +21,20 @@ class TractCard: BaseTractElement {
     static let yTopMarginConstant: CGFloat = 8.0
     static let yBottomMarginConstant: CGFloat = 120.0
     static let xPaddingConstant: CGFloat = 28.0
-    static let contentBottomPadding: CGFloat = 70.0
+    static let contentBottomPadding: CGFloat = 8.0
+    static let transparentViewHeight: CGFloat = 60.0
     
     // MARK: - Positions and Sizes
     
     var yDownPosition: CGFloat = 0.0
     
     var externalHeight: CGFloat {
-        return (self.parent?.height)! - TractCard.yTopMarginConstant - TractCard.yBottomMarginConstant
+        return (self.parent?.height)! - TractCard.yTopMarginConstant - TractCard.yBottomMarginConstant - TractPage.navbarHeight
     }
     
     var internalHeight: CGFloat {
         if self.height > self.externalHeight {
-            return self.height + TractCard.contentBottomPadding + TractPage.navbarHeight
+            return self.height + TractCard.transparentViewHeight + TractCard.contentBottomPadding
         } else {
             return self.externalHeight
         }
@@ -66,14 +67,14 @@ class TractCard: BaseTractElement {
             self.isHidden = true
             properties.cardState = .hidden
         }
-        
+    }
+    
+    override func render() -> UIView {
         setupScrollView()
         setBordersAndShadows()
         disableScrollview()
         setupSwipeGestures()
-    }
-    
-    override func render() -> UIView {
+        
         for element in self.elements! {
             self.containerView.addSubview(element.render())
         }
@@ -102,8 +103,8 @@ class TractCard: BaseTractElement {
     }
     
     override func updateFrameHeight() {
-        self.height = cardHeight()
-        super.updateFrameHeight()
+        self.elementFrame.height = cardHeight()
+        self.frame = self.elementFrame.getFrame()
     }
     
     // MARK: - Helpers

--- a/godtools/Views/TractElements/TractCards+Animations.swift
+++ b/godtools/Views/TractElements/TractCards+Animations.swift
@@ -12,11 +12,13 @@ import UIKit
 extension TractCards {
     
     func transformToOpenUpCardsAnimation() {
+        let yPos = -self.elementFrame.y + TractPage.navbarHeight
+        
         UIView.animate(withDuration: 0.35,
                        delay: 0.0,
                        options: UIViewAnimationOptions.curveEaseInOut,
                        animations: {
-                        self.transform = CGAffineTransform(translationX: 0, y: -self.elementFrame.y) },
+                        self.transform = CGAffineTransform(translationX: 0, y: yPos) },
                        completion: nil )
     }
     

--- a/godtools/Views/TractElements/TractCards+ChildSetup.swift
+++ b/godtools/Views/TractElements/TractCards+ChildSetup.swift
@@ -40,7 +40,7 @@ extension TractCards {
                 - (deltaChange * TractCards.constantYPaddingBottom)
             
             let element = TractCard(data: dictionary, startOnY: yPosition, parent: self)
-            element.yDownPosition = yDownPosition
+            element.yDownPosition = yDownPosition - TractPage.navbarHeight
             element.cardProperties().cardNumber = cardNumber
             self.elements?.append(element)
             

--- a/godtools/Views/TractElements/TractCards.swift
+++ b/godtools/Views/TractElements/TractCards.swift
@@ -29,13 +29,13 @@ class TractCards: BaseTractElement {
     
     override var height: CGFloat {
         get {
-            return self.getMaxHeight()
+            return self.getMaxHeight() - TractPage.navbarHeight
         }
         set { } // Unused
     }
     
     var initialCardPosition: CGFloat {
-        return self.height - self.elementFrame.y
+        return self.height - self.elementFrame.y + TractPage.navbarHeight
     }
     
     // MARK: - Setup


### PR DESCRIPTION
 - cards should not slide behind nav bar.

This means cards starting yPos should be adjusted by the nav bar height, but the height should also be reduced by the nav bar height
The internal heights also need adjusted so that the scrolls work well