### PR TITLE
Fix issues when deleting a resource or a translation

### DIFF
--- a/godtools/AppDelegate.swift
+++ b/godtools/AppDelegate.swift
@@ -27,7 +27,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 UIApplication.shared.isNetworkActivityIndicatorVisible = false
         }
         
-        print(NSHomeDirectory())
+        #if DEBUG
+            print(NSHomeDirectory())
+        #endif
         
         return true
     }

--- a/godtools/AppDelegate.swift
+++ b/godtools/AppDelegate.swift
@@ -27,6 +27,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 UIApplication.shared.isNetworkActivityIndicatorVisible = false
         }
         
+        print(NSHomeDirectory())
+        
         return true
     }
     

--- a/godtools/Managers/LanguagesManager.swift
+++ b/godtools/Managers/LanguagesManager.swift
@@ -80,8 +80,8 @@ class LanguagesManager: GTDataManager {
             for translation in language.translations {
                 translation.isDownloaded = false
             }
+            TranslationFileRemover().deleteUnusedPages()
         }
-        TranslationFileRemover().deleteUnusedPages()
     }
 
     private func saveToDisk(_ languages: [LanguageResource]) {

--- a/godtools/Managers/TranslationFileRemover.swift
+++ b/godtools/Managers/TranslationFileRemover.swift
@@ -16,6 +16,7 @@ class TranslationFileRemover: GTDataManager {
             do {
                 if page.translations.filter({ $0.isDownloaded }).count == 0 {
                     try FileManager.default.removeItem(atPath: "\(resourcesPath)/\(page.filename)")
+                    realm.delete(page)
                 }
             } catch {
                 Crashlytics().recordError(error, withAdditionalUserInfo: ["customMessage": "Error deleting file \(page.filename) no longer referenced by any translations"])

--- a/godtools/Managers/TranslationZipImporter.swift
+++ b/godtools/Managers/TranslationZipImporter.swift
@@ -188,7 +188,6 @@ class TranslationZipImporter: GTDataManager {
         
         let files = try FileManager.default.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil, options: .skipsHiddenFiles)
         
-        print(files.count)
         safelyWriteToRealm {
             for file in files {
                 let filename = file.lastPathComponent

--- a/godtools/Managers/TranslationZipImporter.swift
+++ b/godtools/Managers/TranslationZipImporter.swift
@@ -188,12 +188,13 @@ class TranslationZipImporter: GTDataManager {
         
         let files = try FileManager.default.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil, options: .skipsHiddenFiles)
         
+        print(files.count)
         safelyWriteToRealm {
             for file in files {
                 let filename = file.lastPathComponent
                 if let referencedFile = findEntity(ReferencedFile.self, byAttribute: "filename", withValue: filename) {
                     referencedFile.translations.append(translation)
-                    return
+                    continue
                 }
                 
                 let referencedFile = ReferencedFile()

--- a/godtools/Managers/TranslationZipImporter.swift
+++ b/godtools/Managers/TranslationZipImporter.swift
@@ -192,8 +192,8 @@ class TranslationZipImporter: GTDataManager {
             for file in files {
                 let filename = file.lastPathComponent
                 if let referencedFile = findEntity(ReferencedFile.self, byAttribute: "filename", withValue: filename) {
-                    referencedFile.filename = file.lastPathComponent
                     referencedFile.translations.append(translation)
+                    return
                 }
                 
                 let referencedFile = ReferencedFile()


### PR DESCRIPTION
The referenced file counts were being done incorrectly. This led to deleting one language or resource deleting files that belong to something else. This could mean images missing or even crashes when XML pages were missing.