### PR TITLE
Fix cards problem when text of hero component is large and there are many cards

### DIFF
--- a/godtools/Views/TractElements/BaseTractElement.swift
+++ b/godtools/Views/TractElements/BaseTractElement.swift
@@ -197,12 +197,12 @@ class BaseTractElement: UIView {
     
     func getPreviousElement() -> BaseTractElement? {
         guard let index = getElementPosition() else {
-            return nil
+            return self.elements?.last
         }
         if index > 0 {
             return self.parent!.elements?[index - 1]
         }
-        return nil
+        return self.elements?.last
     }
     
     func getFollowingElement() -> BaseTractElement? {
@@ -226,12 +226,15 @@ class BaseTractElement: UIView {
     func buildChildrenForData(_ data: [XMLIndexer]) {
         var currentYPosition: CGFloat = startingYPos()
         var maxYPosition: CGFloat = 0.0
-        var elements = [BaseTractElement]()
         var elementNumber: Int = 0
+        
+        if self.elements == nil {
+            self.elements = [BaseTractElement]()
+        }
         
         for dictionary in data {
             let element = buildElementForDictionary(dictionary, startOnY: currentYPosition, elementNumber: elementNumber)
-            elements.append(element)
+            self.elements!.append(element)
             
             if element.isKind(of: TractCallToAction.self) {
                 self.didFindCallToAction = true
@@ -251,7 +254,7 @@ class BaseTractElement: UIView {
         if self.isKind(of: TractPage.self) && !self.didFindCallToAction && !(self.tractConfigurations!.pagination?.didReachEnd())! {
             let element = TractCallToAction(children: [XMLIndexer](), startOnY: currentYPosition, parent: self)
             currentYPosition = element.elementFrame.yEndPosition()
-            elements.append(element)
+            self.elements!.append(element)
         }
         
         if self.horizontalContainer {
@@ -259,8 +262,6 @@ class BaseTractElement: UIView {
         } else {
             self.height = currentYPosition
         }
-        
-        self.elements = elements
     }
     
     func setupView(properties: Dictionary<String, Any>) {

--- a/godtools/Views/TractElements/BaseTractElement.swift
+++ b/godtools/Views/TractElements/BaseTractElement.swift
@@ -197,12 +197,12 @@ class BaseTractElement: UIView {
     
     func getPreviousElement() -> BaseTractElement? {
         guard let index = getElementPosition() else {
-            return self.elements?.last
+            return self.parent?.elements?.last
         }
         if index > 0 {
-            return self.parent!.elements?[index - 1]
+            return self.parent?.elements?[index - 1]
         }
-        return self.elements?.last
+        return self.parent?.elements?.last
     }
     
     func getFollowingElement() -> BaseTractElement? {

--- a/godtools/Views/TractElements/TractCards+ChildSetup.swift
+++ b/godtools/Views/TractElements/TractCards+ChildSetup.swift
@@ -11,11 +11,11 @@ import SWXMLHash
 
 extension TractCards {
     
-    func splitCardsByKind(data: [XMLIndexer]) -> (normal: [XMLIndexer], hidden: [XMLIndexer]) {
+    func splitCardsByKind() -> (normal: [XMLIndexer], hidden: [XMLIndexer]) {
         var normalCards = [XMLIndexer]()
         var hiddenCards = [XMLIndexer]()
         
-        for dictionary in data {
+        for dictionary in self.cardsData! {
             let contentElements = self.xmlManager.getContentElements(dictionary)
             let card = TractCardProperties()
             card.load(contentElements.properties)

--- a/godtools/Views/TractElements/TractCards+UI.swift
+++ b/godtools/Views/TractElements/TractCards+UI.swift
@@ -11,4 +11,28 @@ import UIKit
 
 extension TractCards {
     
+    func getHeightOfClosedCards() -> CGFloat {
+        let cards = splitCardsByKind()
+        return CGFloat(cards.normal.count) * TractCards.constantYPaddingTop
+    }
+    
+    func getMaxFreeHeight() -> CGFloat {
+        let element = getPreviousElement()
+        if element != nil && element!.isKind(of: TractHero.self) {
+            let maxHeight = BaseTractElement.screenHeight - element!.elementFrame.y - TractHero.marginBottom
+            return maxHeight - getHeightOfClosedCards()
+        }
+        return 0.0
+    }
+    
+    func setCardsYPosition() {
+        let element = getPreviousElement()
+        if element != nil && element!.isKind(of: TractHero.self) {
+            let initialYPosition = getMaxFreeHeight()
+            if initialYPosition < self.elementFrame.y {
+                self.elementFrame.y = initialYPosition + TractPage.navbarHeight
+            }
+        }
+    }
+    
 }

--- a/godtools/Views/TractElements/TractCards.swift
+++ b/godtools/Views/TractElements/TractCards.swift
@@ -97,29 +97,5 @@ class TractCards: BaseTractElement {
     func cardsProperties() -> TractCardsProperties {
         return self.properties as! TractCardsProperties
     }
-    
-    func getHeightOfClosedCards() -> CGFloat {
-        let cards = splitCardsByKind()
-        return CGFloat(cards.normal.count) * TractCards.constantYPaddingTop
-    }
-    
-    func getMaxHeroHeight() -> CGFloat {
-        let element = getPreviousElement()
-        if element != nil && element!.isKind(of: TractHero.self) {
-            let maxHeight = BaseTractElement.screenHeight - element!.elementFrame.y - TractHero.marginBottom
-            return maxHeight - getHeightOfClosedCards()
-        }
-        return 0.0
-    }
-    
-    func setCardsYPosition() {
-        let element = getPreviousElement()
-        if element != nil && element!.isKind(of: TractHero.self) {
-            let initialYPosition = getMaxHeroHeight()
-            if initialYPosition < self.elementFrame.y {
-                self.elementFrame.y = initialYPosition + TractPage.navbarHeight
-            }
-        }
-    }
 
 }

--- a/godtools/Views/TractElements/TractCards.swift
+++ b/godtools/Views/TractElements/TractCards.swift
@@ -106,9 +106,8 @@ class TractCards: BaseTractElement {
     func getMaxHeroHeight() -> CGFloat {
         let element = getPreviousElement()
         if element != nil && element!.isKind(of: TractHero.self) {
-            let maxHeight = BaseTractElement.screenHeight
-            let initialPosition = maxHeight - getHeightOfClosedCards()
-            return maxHeight - (maxHeight - initialPosition) - parent!.startingYPos() - TractHero.marginBottom - TractPage.navbarHeight
+            let maxHeight = BaseTractElement.screenHeight - element!.elementFrame.y - TractHero.marginBottom
+            return maxHeight - getHeightOfClosedCards()
         }
         return 0.0
     }

--- a/godtools/Views/TractElements/TractCards.swift
+++ b/godtools/Views/TractElements/TractCards.swift
@@ -45,8 +45,21 @@ class TractCards: BaseTractElement {
         return TractCardsProperties.self
     }
     
+    override func setupElement(data: XMLIndexer, startOnY yPosition: CGFloat) {
+        self.elementFrame.y = yPosition
+        
+        let contentElements = self.xmlManager.getContentElements(data)
+        
+        self.cardsData = contentElements.children
+        loadElementProperties(contentElements.properties)
+        loadFrameProperties()
+        buildFrame()
+        setupParallelElement()
+        buildChildrenForData(contentElements.children)
+        setupView(properties: contentElements.properties)
+    }
+    
     override func buildChildrenForData(_ data: [XMLIndexer]) {
-        self.cardsData = data
         self.elements = [BaseTractElement]()
         let cards = splitCardsByKind()
         buildCards(cards.normal)

--- a/godtools/Views/TractElements/TractCards.swift
+++ b/godtools/Views/TractElements/TractCards.swift
@@ -118,7 +118,7 @@ class TractCards: BaseTractElement {
         if element != nil && element!.isKind(of: TractHero.self) {
             let initialYPosition = getMaxHeroHeight()
             if initialYPosition < self.elementFrame.y {
-                self.elementFrame.y = initialYPosition
+                self.elementFrame.y = initialYPosition + TractPage.navbarHeight
             }
         }
     }

--- a/godtools/Views/TractElements/TractCards.swift
+++ b/godtools/Views/TractElements/TractCards.swift
@@ -32,6 +32,7 @@ class TractCards: BaseTractElement {
     
     // MARK: - Dynamic settings
     
+    var cardsData: [XMLIndexer]?
     var lastCard: BaseTractElement?
     var isOnInitialPosition = true
     var animationYPos: CGFloat {
@@ -45,8 +46,9 @@ class TractCards: BaseTractElement {
     }
     
     override func buildChildrenForData(_ data: [XMLIndexer]) {
+        self.cardsData = data
         self.elements = [BaseTractElement]()
-        let cards = splitCardsByKind(data: data)
+        let cards = splitCardsByKind()
         buildCards(cards.normal)
         buildHiddenCards(cards.hidden)
     }
@@ -54,6 +56,7 @@ class TractCards: BaseTractElement {
     override func loadFrameProperties() {
         let yExternalPosition = self.elementFrame.y > TractCards.minYPosition ? self.elementFrame.y : TractCards.minYPosition
         
+        setCardsYPosition()
         self.elementFrame.x = 0.0
         self.elementFrame.width = self.width
         self.elementFrame.height = self.height
@@ -80,6 +83,31 @@ class TractCards: BaseTractElement {
     
     func cardsProperties() -> TractCardsProperties {
         return self.properties as! TractCardsProperties
+    }
+    
+    func getHeightOfClosedCards() -> CGFloat {
+        let cards = splitCardsByKind()
+        return CGFloat(cards.normal.count) * TractCards.constantYPaddingTop
+    }
+    
+    func getMaxHeroHeight() -> CGFloat {
+        let element = getPreviousElement()
+        if element != nil && element!.isKind(of: TractHero.self) {
+            let maxHeight = BaseTractElement.screenHeight
+            let initialPosition = maxHeight - getHeightOfClosedCards()
+            return maxHeight - (maxHeight - initialPosition) - parent!.startingYPos() - TractHero.marginBottom - TractPage.navbarHeight
+        }
+        return 0.0
+    }
+    
+    func setCardsYPosition() {
+        let element = getPreviousElement()
+        if element != nil && element!.isKind(of: TractHero.self) {
+            let initialYPosition = getMaxHeroHeight()
+            if initialYPosition < self.elementFrame.y {
+                self.elementFrame.y = initialYPosition
+            }
+        }
     }
 
 }

--- a/godtools/Views/TractElements/TractHero.swift
+++ b/godtools/Views/TractElements/TractHero.swift
@@ -64,7 +64,7 @@ class TractHero: BaseTractElement {
         self.scrollView.contentSize = CGSize(width: contentWidth, height: contentHeight)
         self.scrollView.frame = CGRect(x: 0.0, y: 0.0, width: contentWidth, height: self.heroHeight)
         self.scrollView.showsVerticalScrollIndicator = false
-        self.scrollView.backgroundColor = .clear
+        self.scrollView.backgroundColor = .red
         
         self.containerView.frame = CGRect(x: 0.0,
                                           y: 0.0,
@@ -77,9 +77,7 @@ class TractHero: BaseTractElement {
         let element = getFollowingElement()
         if element != nil && element!.isKind(of: TractCards.self) {
             let cardsElement = element as! TractCards
-            let initialPosition = cardsElement.elementFrame.y + (cardsElement.elements?[0].elementFrame.y)!
-            let maxHeight = BaseTractElement.screenHeight
-            self.heroHeight = maxHeight - (maxHeight - initialPosition) - parent!.startingYPos() - TractHero.marginBottom
+            self.heroHeight = cardsElement.getMaxHeroHeight()
             self.elementFrame.height = self.heroHeight
             self.frame = self.elementFrame.getFrame()
         }

--- a/godtools/Views/TractElements/TractHero.swift
+++ b/godtools/Views/TractElements/TractHero.swift
@@ -64,7 +64,6 @@ class TractHero: BaseTractElement {
         self.scrollView.contentSize = CGSize(width: contentWidth, height: contentHeight)
         self.scrollView.frame = CGRect(x: 0.0, y: 0.0, width: contentWidth, height: self.heroHeight)
         self.scrollView.showsVerticalScrollIndicator = false
-        self.scrollView.backgroundColor = .red
         
         self.containerView.frame = CGRect(x: 0.0,
                                           y: 0.0,

--- a/godtools/Views/TractElements/TractHero.swift
+++ b/godtools/Views/TractElements/TractHero.swift
@@ -76,7 +76,7 @@ class TractHero: BaseTractElement {
         let element = getFollowingElement()
         if element != nil && element!.isKind(of: TractCards.self) {
             let cardsElement = element as! TractCards
-            self.heroHeight = cardsElement.getMaxHeroHeight()
+            self.heroHeight = cardsElement.getMaxFreeHeight()
             self.elementFrame.height = self.heroHeight
             self.frame = self.elementFrame.getFrame()
         }


### PR DESCRIPTION
On iPhone 4 and 5, currently, if the text of the `<hero>` is large and there are too many `<card>` inside of `<cards>`, the first `<card>` will not be able to have a touch gesture because the `<cards>` element gets its position down, and those `<card>` objects have a -y position (this problem may also happen in iPhone 6 and 7 if the problem with the heights overlaps).

The solution is that the position y of the `<cards>` object should be updated taking the new height of the `<hero>` component (that new height is calculated after the `<cards>` object was added, so, this required operations between elements of the same level).