### PR TITLE
Disabled download button

### DIFF
--- a/godtools/Base.lproj/Localizable.strings
+++ b/godtools/Base.lproj/Localizable.strings
@@ -73,6 +73,7 @@
 "done" = "Done";
 "remove" = "Remove";
 "clear" = "Clear";
+"unavailable" = "Unavailable";
 
 // Alerts
 "error" = "Error";

--- a/godtools/ViewControllers/Platform/ToolDetailViewController.swift
+++ b/godtools/ViewControllers/Platform/ToolDetailViewController.swift
@@ -50,7 +50,9 @@ class ToolDetailViewController: BaseViewController {
     }
     
     private func displayButton() {
-        if resource!.shouldDownload {
+        if resource!.numberOfAvailableLanguages() == 0 {
+            mainButton.designAsUnavailableButton()
+        } else if resource!.shouldDownload {
             mainButton.designAsDeleteButton()
         } else {
             mainButton.designAsDownloadButton()

--- a/godtools/Views/Buttons/GTButton.swift
+++ b/godtools/Views/Buttons/GTButton.swift
@@ -47,17 +47,21 @@ class GTButton: UIButton {
     
     @IBInspectable var translationKey: String = "" {
         didSet {
-            self.setTitle(translationKey.localized, for: .normal)
+            let state = self.isEnabled ? UIControlState.normal : UIControlState.disabled
+            
+            self.setTitle(translationKey.localized, for: state)
         }
     }
     
     func designAsUnavailableButton() {
+        self.designAsToolDetailButton()
+        
         self.color = .gtWhite
         self.tintColor = .gtWhite
         self.borderWidth = 0.0
         self.borderColor = .clear
         self.backgroundColor = .gtGrey
-        self.setImage(#imageLiteral(resourceName: "download_white"), for: .disabled)
+        self.setImage(#imageLiteral(resourceName: "download_white"), for: .normal)
         self.translationKey = "unavailable"
         
         self.isEnabled = false
@@ -76,8 +80,6 @@ class GTButton: UIButton {
         self.setImage(#imageLiteral(resourceName: "download_white"), for: .normal)
         self.translationKey = "download"
         
-        self.isEnabled = true
-        
         self.layoutSubviews()
     }
     
@@ -92,8 +94,6 @@ class GTButton: UIButton {
         self.setImage(#imageLiteral(resourceName: "delete_red"), for: .normal)
         self.translationKey = "remove"
         
-        self.isEnabled = true
-        
         self.layoutSubviews()
     }
     
@@ -104,9 +104,7 @@ class GTButton: UIButton {
         self.borderWidth = 1.0
         self.borderColor = .gtWhite
         self.backgroundColor = .clear
-        
-        self.isEnabled = true
-        
+                
         self.layoutSubviews()
     }
     

--- a/godtools/Views/Buttons/GTButton.swift
+++ b/godtools/Views/Buttons/GTButton.swift
@@ -51,6 +51,20 @@ class GTButton: UIButton {
         }
     }
     
+    func designAsUnavailableButton() {
+        self.color = .gtWhite
+        self.tintColor = .gtWhite
+        self.borderWidth = 0.0
+        self.borderColor = .clear
+        self.backgroundColor = .gtGrey
+        self.setImage(#imageLiteral(resourceName: "download_white"), for: .disabled)
+        self.translationKey = "unavailable"
+        
+        self.isEnabled = false
+        
+        self.layoutSubviews()
+    }
+    
     func designAsDownloadButton() {
         self.designAsToolDetailButton()
         
@@ -61,6 +75,8 @@ class GTButton: UIButton {
         self.backgroundColor = .gtGreen
         self.setImage(#imageLiteral(resourceName: "download_white"), for: .normal)
         self.translationKey = "download"
+        
+        self.isEnabled = true
         
         self.layoutSubviews()
     }
@@ -76,6 +92,8 @@ class GTButton: UIButton {
         self.setImage(#imageLiteral(resourceName: "delete_red"), for: .normal)
         self.translationKey = "remove"
         
+        self.isEnabled = true
+        
         self.layoutSubviews()
     }
     
@@ -87,6 +105,8 @@ class GTButton: UIButton {
         self.borderColor = .gtWhite
         self.backgroundColor = .clear
         
+        self.isEnabled = true
+        
         self.layoutSubviews()
     }
     
@@ -95,6 +115,8 @@ class GTButton: UIButton {
         self.titleLabel?.font = UIFont.gtRegular(size: 15.0)
         self.imageEdgeInsets = UIEdgeInsetsMake(0.0, 0.0, 0.0, 10.0)
         self.titleEdgeInsets = UIEdgeInsetsMake(0.0, 10.0, 0.0, 0.0)
+        
+        self.isEnabled = true
         
         self.increaseTitleWidth()
     }

--- a/godtools/Views/Cells/HomeToolTableViewCell.swift
+++ b/godtools/Views/Cells/HomeToolTableViewCell.swift
@@ -62,7 +62,7 @@ class HomeToolTableViewCell: UITableViewCell {
         selectionStyle = isAvailableInPrimaryLanguage ? .default : .none
         isAvailable = isAvailableInPrimaryLanguage
         
-        if (resource.shouldDownload || resource.translations.filter({ $0.isPublished }).count == 0) {
+        if (resource.shouldDownload || resource.numberOfAvailableLanguages() == 0 {
             setCellAsDisplayOnly()
         }
         

--- a/godtools/Views/Cells/HomeToolTableViewCell.swift
+++ b/godtools/Views/Cells/HomeToolTableViewCell.swift
@@ -62,7 +62,7 @@ class HomeToolTableViewCell: UITableViewCell {
         selectionStyle = isAvailableInPrimaryLanguage ? .default : .none
         isAvailable = isAvailableInPrimaryLanguage
         
-        if (resource.shouldDownload || resource.numberOfAvailableLanguages() == 0 {
+        if resource.shouldDownload || resource.numberOfAvailableLanguages() == 0 {
             setCellAsDisplayOnly()
         }
         

--- a/godtools/Views/Cells/HomeToolTableViewCell.swift
+++ b/godtools/Views/Cells/HomeToolTableViewCell.swift
@@ -62,7 +62,7 @@ class HomeToolTableViewCell: UITableViewCell {
         selectionStyle = isAvailableInPrimaryLanguage ? .default : .none
         isAvailable = isAvailableInPrimaryLanguage
         
-        if (resource.shouldDownload) {
+        if (resource.shouldDownload || resource.translations.filter({ $0.isPublished }).count == 0) {
             setCellAsDisplayOnly()
         }
         


### PR DESCRIPTION
When a resource exists, but has no published translations: 
 - don't show the download button on the add tools table view
 - show a disabled "unavailable" button on the tool detail view.