### PR TITLE
GT-358: Add gestures to cards element

### DIFF
--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -209,6 +209,7 @@
 		ECC194B61EEAF15500A56332 /* ManifestProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECC194B51EEAF15500A56332 /* ManifestProperties.swift */; };
 		ECC194B81EEAF3BA00A56332 /* XMLNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECC194B71EEAF3BA00A56332 /* XMLNode.swift */; };
 		ECC194C01EEB32FA00A56332 /* XMLPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECC194BF1EEB32FA00A56332 /* XMLPage.swift */; };
+		ECED9F541F0EA06E0006EA5E /* TractCards+Gestures.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECED9F531F0EA06E0006EA5E /* TractCards+Gestures.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -461,6 +462,7 @@
 		ECC194B51EEAF15500A56332 /* ManifestProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ManifestProperties.swift; path = TractClasses/ManifestProperties.swift; sourceTree = "<group>"; };
 		ECC194B71EEAF3BA00A56332 /* XMLNode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = XMLNode.swift; path = XMLManagement/XMLNode.swift; sourceTree = "<group>"; };
 		ECC194BF1EEB32FA00A56332 /* XMLPage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = XMLPage.swift; path = XMLManagement/XMLPage.swift; sourceTree = "<group>"; };
+		ECED9F531F0EA06E0006EA5E /* TractCards+Gestures.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "TractCards+Gestures.swift"; path = "Views/TractElements/TractCards+Gestures.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1072,6 +1074,7 @@
 		ECBE2E451EF03CA400A13849 /* TractCards */ = {
 			isa = PBXGroup;
 			children = (
+				ECED9F531F0EA06E0006EA5E /* TractCards+Gestures.swift */,
 				ECBE2E471EF03CD500A13849 /* TractCards+ChildSetup.swift */,
 				ECBE2E491EF03F6800A13849 /* TractCards+UI.swift */,
 				0F7741DF1EBB8BF300888D20 /* TractCards+Animations.swift */,
@@ -1587,6 +1590,7 @@
 				0FB1B20A1EB151300033DAB9 /* TransparentButton.swift in Sources */,
 				0F806C671EB3E69D00F3ED2B /* TractHeader.swift in Sources */,
 				EC00B0061F016CED00A0A61F /* TractCard+UITextFieldDelegate.swift in Sources */,
+				ECED9F541F0EA06E0006EA5E /* TractCards+Gestures.swift in Sources */,
 				4F462A3A1EB0E28900C03447 /* TractParagraph.swift in Sources */,
 				4F57328D1EA69CF00082035C /* AppDelegate.swift in Sources */,
 				0FB73E6D1EA90669000BA60D /* BaseViewController.swift in Sources */,

--- a/godtools/Views/TractElements/TractCard+Actions.swift
+++ b/godtools/Views/TractElements/TractCard+Actions.swift
@@ -81,6 +81,8 @@ extension TractCard {
         
         showCardAnimation()
         enableScrollview()
+        
+        self.cardsParentView.lastCardOpened = self
     }
     
     func hideCard() {

--- a/godtools/Views/TractElements/TractCard.swift
+++ b/godtools/Views/TractElements/TractCard.swift
@@ -142,6 +142,7 @@ class TractCard: BaseTractElement {
         
         switch cardElement.currentAnimation {
         case .show:
+            self.cardsParentView.lastCardOpened = self
             showCardWithoutAnimation()
         case .hide:
             hideCardWithoutAnimation()

--- a/godtools/Views/TractElements/TractCards+Actions.swift
+++ b/godtools/Views/TractElements/TractCards+Actions.swift
@@ -39,6 +39,7 @@ extension TractCards {
     
     func resetEnvironment() {
         changeToPreviewCards()
+        self.lastCardOpened = nil
         
         for element in elements! {
             let elementCard = element as! TractCard

--- a/godtools/Views/TractElements/TractCards+Gestures.swift
+++ b/godtools/Views/TractElements/TractCards+Gestures.swift
@@ -1,0 +1,51 @@
+//
+//  TractCards+Gestures.swift
+//  godtools
+//
+//  Created by Pablo Marti on 7/6/17.
+//  Copyright © 2017 Cru. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+extension TractCards {
+    
+    func setupSwipeGestures() {
+        let swipeUp = UISwipeGestureRecognizer(target: self, action: #selector(handleSwipeGesture))
+        swipeUp.direction = .up
+        self.addGestureRecognizer(swipeUp)
+        
+        let swipeDown = UISwipeGestureRecognizer(target: self, action: #selector(handleSwipeGesture))
+        swipeDown.direction = .down
+        self.addGestureRecognizer(swipeDown)
+    }
+    
+    func setupPressGestures() {
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(handlePressGesture))
+        tapGesture.numberOfTapsRequired = 1
+        tapGesture.numberOfTouchesRequired = 1
+        
+        let frame = CGRect(x: 0.0,
+                           y: self.height - TractCards.tapViewHeightConstant,
+                           width: self.width,
+                           height: TractCards.tapViewHeightConstant)
+        self.tapView.frame = frame
+        self.tapView.addGestureRecognizer(tapGesture)
+        self.tapView.isUserInteractionEnabled = true
+        self.addSubview(self.tapView)
+    }
+    
+    func handleSwipeGesture(sender: UISwipeGestureRecognizer) {
+        if sender.direction == .up {
+            self.lastCardOpened?.processSwipeUp()
+        } else if sender.direction == .down {
+            self.lastCardOpened?.processSwipeDown()
+        }
+    }
+    
+    func handlePressGesture(sender: UITapGestureRecognizer) {
+        self.lastCardOpened?.processSwipeUp()
+    }
+    
+}

--- a/godtools/Views/TractElements/TractCards.swift
+++ b/godtools/Views/TractElements/TractCards.swift
@@ -18,6 +18,7 @@ class TractCards: BaseTractElement {
     static let constantYPaddingTop: CGFloat = 45
     static let constantYPaddingBottom: CGFloat = 16
     static let constantYBottomSpace: CGFloat = 6
+    static let tapViewHeightConstant: CGFloat = 300
     
     override var height: CGFloat {
         get {
@@ -32,8 +33,10 @@ class TractCards: BaseTractElement {
     
     // MARK: - Dynamic settings
     
+    var tapView: UIView = UIView()
     var cardsData: [XMLIndexer]?
     var lastCard: BaseTractElement?
+    var lastCardOpened: TractCard?
     var isOnInitialPosition = true
     var animationYPos: CGFloat {
         return self.isOnInitialPosition == true ? 0.0 : -self.elementFrame.y + TractPage.navbarHeight
@@ -57,6 +60,8 @@ class TractCards: BaseTractElement {
         setupParallelElement()
         buildChildrenForData(contentElements.children)
         setupView(properties: contentElements.properties)
+        setupSwipeGestures()
+        setupPressGestures()
     }
     
     override func buildChildrenForData(_ data: [XMLIndexer]) {


### PR DESCRIPTION
Now it is possible to do the swipe up and down not just in the `<card>` element but also in `<cards>`, so if the user does the swipe in the free space between the open card and the closed cards, it will work. Also, now there is a press gesture recognizer in that same area so if the last card touching area is too small it would not be a problem.