### PR TITLE
The values in OneSky do not have a protocol. 

### DIFF
--- a/godtools/Views/TractElements/TractButton+Actions.swift
+++ b/godtools/Views/TractElements/TractButton+Actions.swift
@@ -23,9 +23,19 @@ extension TractButton {
                 }
             }
         } else if properties.type == .url {
-            if let url = URL(string: properties.url) {
+            let propertiesString = properties.url
+            let stringWithProtocol = prependProtocolToURLStringIfNecessary(propertiesString)
+            if let url = URL(string: stringWithProtocol) {
                 UIApplication.shared.openURL(url)
             }
         }
+    }
+    
+    private func prependProtocolToURLStringIfNecessary(_ original: String) -> String {
+        if original.hasPrefix("http://") || original.hasPrefix("https://") {
+            return original
+        }
+        
+        return "http://\(original)"
     }
 }


### PR DESCRIPTION
So I added a method to add http:// to those that don't have one.

Without a protocol, the call to: UIApplication.shared.openURL(url) will do nothing