### PR TITLE
Show onboarding screens on first launch

### DIFF
--- a/godtools/Constants/GTConstants.swift
+++ b/godtools/Constants/GTConstants.swift
@@ -14,6 +14,7 @@ struct GTConstants {
     static let kDownloadProgressResourceIdKey = "org.cru.godtools.downloadProgressResourceIdKey"
     static let kDownloadBannerResourceIdKey = "org.cru.godtools.downloadBannerResourceIdKey"
     
+    static let kOnboardingScreensShownKey = "org.cru.godtools.onboardingScreensShownKey"
     static let kFirstLaunchKey = "org.cru.godtools.firstLaunchKey"
     static let kDownloadDeviceLocaleKey = "org.cru.godtools.downloadDeviceLocaleKey"
     static let kAlreadyAccessTract = "org.cru.godtools.defaults.tract.alreadyAccess"

--- a/godtools/ViewControllers/Platform/HomeViewController.swift
+++ b/godtools/ViewControllers/Platform/HomeViewController.swift
@@ -40,7 +40,7 @@ class HomeViewController: BaseViewController {
         self.defineObservers()
         addRefreshControl()
         
-        if LanguagesManager().loadPrimaryLanguageFromDisk() == nil {
+        if onboardingShouldDisplay() {
             self.displayOnboarding()
         }
     }
@@ -145,8 +145,15 @@ class HomeViewController: BaseViewController {
         let onboardingViewController = OnboardingViewController(nibName: String(describing:OnboardingViewController.self), bundle: nil)
         onboardingViewController.modalPresentationStyle = .overCurrentContext
         self.present(onboardingViewController, animated: true, completion: nil)
+        UserDefaults.standard.set(true, forKey: GTConstants.kOnboardingScreensShownKey)
     }
 
+    private func onboardingShouldDisplay() -> Bool {
+        let hasAlreadyShown = UserDefaults.standard.bool(forKey: GTConstants.kOnboardingScreensShownKey)
+        
+        return !hasAlreadyShown
+    }
+    
     // MARK: - Analytics
     
     override func screenName() -> String {


### PR DESCRIPTION
This was broken when logic was added to preset the primary language on first launch.