### PR TITLE
Prevent crash when navigation controller is nil.

### DIFF
--- a/godtools/ViewControllers/Tract/TractViewController.swift
+++ b/godtools/ViewControllers/Tract/TractViewController.swift
@@ -157,7 +157,11 @@ class TractViewController: BaseViewController {
     }
     
     @objc fileprivate func setupNavigationBarFrame() {
-        let navigationBar = navigationController!.navigationBar
+        guard let navController = navigationController else {
+            return
+        }
+        
+        let navigationBar = navController.navigationBar
         
         let xOrigin: CGFloat = 0.0
         let yOrigin: CGFloat = 0.0


### PR DESCRIPTION
Not totally sure the cases that cause this failure, but it's been reported in crashlytics a couple times.

https://fabric.io/cru/ios/apps/org.cru.godtools.beta/issues/5956b1f0be077a4dccd947b4?time=last-seven-days