### PR TITLE
Continue to next language instead of returning from function.

### DIFF
--- a/godtools/Managers/LanguagesManager.swift
+++ b/godtools/Managers/LanguagesManager.swift
@@ -125,7 +125,7 @@ class LanguagesManager: GTDataManager {
             for remoteLanguage in languages {
                 if let cachedlanguage = findEntityByRemoteId(Language.self, remoteId: remoteLanguage.id!) {
                     cachedlanguage.code = remoteLanguage.code!
-                    return
+                    continue
                 }
                 
                 let newCachedLanguage = Language()


### PR DESCRIPTION
I think I was thinking that this would just return out from the block, but I'm not sure. At any rate, this prevents new languages from being saved, which is an insta-crash whenever something new is published.