### PR TITLE
Somehow languages are not being saved before resources are inspected.

### DIFF
--- a/godtools/Managers/Translations/TranslationsManager.swift
+++ b/godtools/Managers/Translations/TranslationsManager.swift
@@ -25,9 +25,17 @@ class TranslationsManager: GTDataManager {
     }
     
     func purgeTranslationsOlderThan(_ latest: Translation) {
+        guard let language = latest.language else {
+            return
+        }
+        
+        guard let resource = latest.downloadedResource else {
+            return
+        }
+        
         let predicate = NSPredicate(format: "language.remoteId = %@ AND downloadedResource.remoteId = %@ AND version < %d AND isDownloaded = %@",
-                                    latest.language!.remoteId,
-                                    latest.downloadedResource!.remoteId,
+                                    language.remoteId,
+                                    resource.remoteId,
                                     latest.version,
                                     NSNumber(booleanLiteral: latest.isDownloaded))
         

--- a/godtools/ViewControllers/Platform/HomeViewController.swift
+++ b/godtools/ViewControllers/Platform/HomeViewController.swift
@@ -86,10 +86,12 @@ class HomeViewController: BaseViewController {
     }
     
     @objc private func loadLatestResources() {
-        _ = DownloadedResourceManager().loadFromRemote()
-            .then { (resources) -> Promise<Void> in
-                TranslationZipImporter().catchupMissedDownloads()
-                return Promise(value: ())
+        _ = LanguagesManager().loadFromRemote().then { (languages) -> Promise<Void> in
+            return DownloadedResourceManager().loadFromRemote()
+                .then { (resources) -> Promise<Void> in
+                    TranslationZipImporter().catchupMissedDownloads()
+                    return Promise(value: ())
+            }
             }.always {
                 self.refreshControl.endRefreshing()
                 self.reloadView()


### PR DESCRIPTION
- Fixing that bug by ensuring they are there. An early return here isn't the end of the world.