### PR TITLE
Analytics name fix

### DIFF
--- a/godtools/ViewControllers/Tract/TractViewController.swift
+++ b/godtools/ViewControllers/Tract/TractViewController.swift
@@ -49,6 +49,7 @@ class TractViewController: BaseViewController {
         getResourceData()
         setupSwipeGestures()
         defineObservers()
+        sendPageToAnalytics()
     }
     
     deinit {

--- a/godtools/ViewControllers/Tract/TractViewControllerActions.swift
+++ b/godtools/ViewControllers/Tract/TractViewControllerActions.swift
@@ -43,8 +43,13 @@ extension TractViewController: MFMailComposeViewControllerDelegate {
     }
     
     func sendPageToAnalytics() {
-        let screenName = "\(self.resource?.code)-\(self.currentPage)"
+        guard let resource = self.resource else {
+            return
+        }
+        
+        let screenName = "\(resource.code)-\(self.currentPage)"
         sendScreenViewNotification(screenName: screenName)
+        
     }
     
 }


### PR DESCRIPTION
- unwrap optional resource when reporting name
- report the first view "0" when a tract is first loaded