### PR TITLE
Share url fix

### DIFF
--- a/godtools/Info.plist
+++ b/godtools/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>5.0.2</string>
 	<key>CFBundleVersion</key>
-	<string>29</string>
+	<string>30</string>
 	<key>Fabric</key>
 	<dict>
 		<key>APIKey</key>

--- a/godtools/ViewControllers/Tract/TractViewController.swift
+++ b/godtools/ViewControllers/Tract/TractViewController.swift
@@ -206,8 +206,15 @@ class TractViewController: BaseViewController {
             return
         }
         
-        let path = "www.knowgod.com/\(languageCode)/\(resourceCode)/\(self.currentPage)"
-        let activityController = UIActivityViewController(activityItems: [String.localizedStringWithFormat("tract_share_message".localized, path)], applicationActivities: nil)
+        var shareURLString = "https://www.knowgod.com/\(languageCode)/\(resourceCode)"
+        
+        if currentPage > 0 {
+            shareURLString = shareURLString.appending("/").appending("\(currentPage)")
+        }
+        
+        shareURLString = shareURLString.appending(" ")
+        
+        let activityController = UIActivityViewController(activityItems: [String.localizedStringWithFormat("tract_share_message".localized, shareURLString)], applicationActivities: nil)
         present(activityController, animated: true, completion: nil)
     }
     


### PR DESCRIPTION
Do not append 0 to share URL for first page:
 - the website does not use 0 for the first page.
 - also tack on a space for padding so that trailing punctuation does not interfere with the link