### PR TITLE
Fix screen name reporting for first view of tract controller

### DIFF
--- a/godtools/ViewControllers/Tract/TractViewController.swift
+++ b/godtools/ViewControllers/Tract/TractViewController.swift
@@ -49,7 +49,6 @@ class TractViewController: BaseViewController {
         getResourceData()
         setupSwipeGestures()
         defineObservers()
-        sendPageToAnalytics()
     }
     
     deinit {
@@ -250,6 +249,13 @@ class TractViewController: BaseViewController {
         }
         
         return CGFloat(self.currentPage) * parentWidth / CGFloat(numPages - 1)
+    }
+    
+    override func screenName() -> String {
+        guard let resource = self.resource else {
+            return super.screenName()
+        }
+        return "\(resource.code)-\(self.currentPage)"
     }
     
 }

--- a/godtools/ViewControllers/Tract/TractViewControllerActions.swift
+++ b/godtools/ViewControllers/Tract/TractViewControllerActions.swift
@@ -43,13 +43,8 @@ extension TractViewController: MFMailComposeViewControllerDelegate {
     }
     
     func sendPageToAnalytics() {
-        guard let resource = self.resource else {
-            return
-        }
-        
-        let screenName = "\(resource.code)-\(self.currentPage)"
+        let screenName = self.screenName()
         sendScreenViewNotification(screenName: screenName)
-        
     }
     
 }


### PR DESCRIPTION
It was being reported twice b/c the code was trigger both in:
1. TractViewController.viewDidLoad() - this one worked properly because the method it called built the view name "resource"-"pageNum"
2. BaseViewController.viewWillAppear() - this one did not work, because TractViewController did not override the screenName() method with the logic to build the name. It fell back to "unknown" as defined in BaseViewController.screenName().

This fix eliminates the call in viewDidLoad() and just allows the call in BaseViewController.viewWillAppear() to be triggered. It also moves the logic to build the view name to the overridden screenName() method that is used for all views of a tract now. the viewWillAppear() call now uses the screenName() logic to build the right name.