### PR TITLE
Gt 411 language indicator add tools

### DIFF
--- a/godtools/Models/DownloadedResource.swift
+++ b/godtools/Models/DownloadedResource.swift
@@ -34,14 +34,14 @@ class DownloadedResource: Object {
     }
     
     func isAvailableInLanguage(_ language: Language?) -> Bool {
-        return queryStatusWithRegardToLanuguage(language, downloaded: false)
+        return isTranslationAvailableInLanguage(language, mustItBeDownloaded: false)
     }
     
     func isDownloadedInLanguage(_ language: Language?) -> Bool {
-        return queryStatusWithRegardToLanuguage(language, downloaded: true)
+        return isTranslationAvailableInLanguage(language, mustItBeDownloaded: true)
     }
     
-    private func queryStatusWithRegardToLanuguage(_ language: Language?, downloaded: Bool) -> Bool {
+    private func isTranslationAvailableInLanguage(_ language: Language?, mustItBeDownloaded: Bool) -> Bool {
         guard let language = language else {
             return false
         }
@@ -49,7 +49,7 @@ class DownloadedResource: Object {
         
         var predicate: NSPredicate
             
-        if downloaded {
+        if mustItBeDownloaded {
             predicate = NSPredicate(format: "language.remoteId = %@ AND isPublished = true AND isDownloaded = true", languageId)
         } else {
             predicate = NSPredicate(format: "language.remoteId = %@ AND isPublished = true", languageId)

--- a/godtools/Models/DownloadedResource.swift
+++ b/godtools/Models/DownloadedResource.swift
@@ -71,7 +71,7 @@ class DownloadedResource: Object {
             return name
         }
         
-        if isAvailableInLanguage(language) {
+        if isDownloadedInLanguage(language) {
             guard let translation = getTranslationForLanguage(language) else {
                 return name
             }

--- a/godtools/Models/DownloadedResource.swift
+++ b/godtools/Models/DownloadedResource.swift
@@ -34,12 +34,30 @@ class DownloadedResource: Object {
     }
     
     func isAvailableInLanguage(_ language: Language?) -> Bool {
+        return queryStatusWithRegardToLanuguage(language, downloaded: false)
+    }
+    
+    func isDownloadedInLanguage(_ language: Language?) -> Bool {
+        return queryStatusWithRegardToLanuguage(language, downloaded: true)
+    }
+    
+    private func queryStatusWithRegardToLanuguage(_ language: Language?, downloaded: Bool) -> Bool {
         guard let language = language else {
             return false
         }
+        let languageId = language.remoteId
         
-        let predicate = NSPredicate(format: "language.remoteId = %@ AND isPublished = true AND isDownloaded = true", language.remoteId)
-        return translations.filter(predicate).count > 0
+        var predicate: NSPredicate
+            
+        if downloaded {
+            predicate = NSPredicate(format: "language.remoteId = %@ AND isPublished = true AND isDownloaded = true", languageId)
+        } else {
+            predicate = NSPredicate(format: "language.remoteId = %@ AND isPublished = true", languageId)
+        }
+        
+        let matchingTranslations = translations.filter(predicate).count > 0
+        
+        return matchingTranslations
     }
     
     func getTranslationForLanguage(_ language: Language) -> Translation? {

--- a/godtools/ViewControllers/Tract/TractViewControllerDataManagement.swift
+++ b/godtools/ViewControllers/Tract/TractViewControllerDataManagement.swift
@@ -18,7 +18,7 @@ extension TractViewController {
             return false
         }
         
-        return resource!.isAvailableInLanguage(parallelLanguage)
+        return resource!.isDownloadedInLanguage(parallelLanguage)
     }
     
     func determinePrimaryLabel() -> String {

--- a/godtools/Views/Cells/HomeToolTableViewCell.swift
+++ b/godtools/Views/Cells/HomeToolTableViewCell.swift
@@ -50,7 +50,7 @@ class HomeToolTableViewCell: UITableViewCell {
         self.resource = resource
         self.cellDelegate = delegate
         
-        let isAvailableInPrimaryLanguage = resource.isAvailableInLanguage(primaryLanguage)
+        let isAvailableInPrimaryLanguage = resource.isDownloadedInLanguage(primaryLanguage)
         
         configureLabels(resource: resource,
                         isAvailableInPrimaryLanguage: isAvailableInPrimaryLanguage,
@@ -76,8 +76,11 @@ class HomeToolTableViewCell: UITableViewCell {
         titleLabel.isEnabled = isAvailableInPrimaryLanguage
         titleLabel.text = resource.localizedName(language: primaryLanguage)
         
-        languageLabel.text = resource.isAvailableInLanguage(parallelLanguage) ? parallelLanguage!.localizedName() : nil
+        let isAvailableInParallelLanguage = resource.isAvailableInLanguage(parallelLanguage)
+        let parallelLanguageName = parallelLanguage!.localizedName()
         
+        languageLabel.text = isAvailableInParallelLanguage ? parallelLanguageName : nil
+
         numberOfViewsLabel.text = String.localizedStringWithFormat("total_views".localized, resource.totalViews)
     }
     


### PR DESCRIPTION
The parallel language name indicator is missing when adding a tool. This PR fixes that by clarifying the difference b/w a translation being "available" and "downloaded"

Downloaded means it is downloaded to the device
Available means it can be downloaded to the device. It may or may not actually be downloaded to the device, however.