### PR TITLE
Adobe analytics async

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,11 @@
 # God Tools
-[![Coverage Status](https://coveralls.io/repos/github/CruGlobal/godtools-swift/badge.svg?branch=develop)](https://coveralls.io/github/CruGlobal/godtools-swift?branch=develop)
 
-## Building the project
-### Normally
-A build server is setup for this project. The build server does the following:
+# Note to developers:
 
- * Anytime you create a Pull Request the tests will automatically run and be reported on your PR.
- * Anytime you merge a Pull Request into the develop branch beta builds will be delivered to Crashlytics (for your testers) and TestFlight (for your early access users). It will rerun the tests, commit a build number bump and tag the build for you.
- * Anytime you merge a Pull Request into master to will rerun the tests, generate your screenshots, build the app for release, upload all the data in the `fastlane/metadata` folder and upload the build. It does not automatically submit the app for review. You will need to go to iTunes Connect to submit it.
+The develop branch should be treated as unstable. Two libraries (RealmSwift and SWXMLHash) were updated to newer minor release versions in support of XCode 9 and Swift 4(?). One of these libraries has a bug, or is being used improperly, and the result is that many key user interactions are extremely laggy.
 
-**Note: If you need to change this behavior talk to one of the project admins about updating the Fastlane scripts**
+The branch `develop-xcode8` is the branch that has been most recently release as app v5.0.6 . This version has the latest Adobe Analytics code running in a background queue for optimal performance. `develop` also has the commits to do Adobe in the background, but also has the broken libraries.
 
-### Locally
-Setup:
- * Run `cp fastlane/.env.local.sample fastlane/.env.local`
- * Read the comments in `fastlane/.env.local` and fill out the missing values for your environment.
- * Run `bundle install`. Needs to be rerun after Gemfile changes.
+Any additional hot-fixes should be done off `develop-xcode8` and built with a machine running XCode 8. Developers should research and fix the broken or poorly used library in the main develop branch prior to another full engagement on the project. Direct any questions to @ryancarlson
 
-Run Tests:
-`bundle exec fastlane run_tests --env local`
-
-Run Beta Distribution:
-`bundle exec fastlane beta --env local`
-
-Run AppStore Distribution:
-`bundle exec fastlane production --env local`
-
-**Note: If you run these scripts locally on a regular basis read `fastlane/README.md` for tips on how to speed these scripts up.**
 

--- a/godtools/Analtyics/GodToolsAnaltyics.swift
+++ b/godtools/Analtyics/GodToolsAnaltyics.swift
@@ -116,8 +116,8 @@ class GodToolsAnaltyics {
     private func recordScreenViewInAdobe(screenName: String) {
         var properties: [String: String] = [:]
         
-        properties[AdobeAnalyticsConstants.Keys.screenName] = "\(screenName)"
-        properties[AdobeAnalyticsConstants.Keys.previousScreenName] = "\(previousScreenName)"
+        properties[AdobeAnalyticsConstants.Keys.screenName] = screenName
+        properties[AdobeAnalyticsConstants.Keys.previousScreenName] = previousScreenName
         properties[AdobeAnalyticsConstants.Keys.appName] = AdobeAnalyticsConstants.Values.godTools
         properties[AdobeAnalyticsConstants.Keys.loggedInStatus] = AdobeAnalyticsConstants.Values.notLoggedIn
         properties[AdobeAnalyticsConstants.Keys.marketingCloudID] = ADBMobile.visitorMarketingCloudID()

--- a/godtools/Analtyics/GodToolsAnaltyics.swift
+++ b/godtools/Analtyics/GodToolsAnaltyics.swift
@@ -27,6 +27,8 @@ class GodToolsAnaltyics {
     let tracker = GAI.sharedInstance().tracker(withTrackingId: Config().googleAnalyticsApiKey)
     
     var previousScreenName = ""
+    var adobeAnalyticsBackgroundQueue = DispatchQueue(label: "org.cru.godtools.adobeAnalytics",
+                                                      qos: .background)
     
     private static var sharedInstance: GodToolsAnaltyics?
     
@@ -54,7 +56,10 @@ class GodToolsAnaltyics {
                                                object: nil)
         
         recordAdwordsConversion()
-        configureAdobeAnalytics()
+        
+        adobeAnalyticsBackgroundQueue.async { [unowned self] () in
+            self.configureAdobeAnalytics()
+        }
     }
     
     private func recordAdwordsConversion() {
@@ -102,7 +107,10 @@ class GodToolsAnaltyics {
         
         tracker?.send(screenViewInfo)
         
-        recordScreenViewInAdobe(screenName: screenName)
+        adobeAnalyticsBackgroundQueue.async { [unowned self] () in
+            self.recordScreenViewInAdobe(screenName: screenName)
+        }
+
     }
     
     private func recordScreenViewInAdobe(screenName: String) {


### PR DESCRIPTION
This PR moves all Adobe Analytics operations to a background queue as to not interfere with any interactions on the main thread.

There is also an update in the readme describing the current state of the branches.

After merging this branch, the develop branch will still contain code unsuitable for release. Hotfixes should be done from develop-xcode8