### PR TITLE
Fix open cards on lang

### DIFF
--- a/godtools/Views/TractElements/BaseTractElement.swift
+++ b/godtools/Views/TractElements/BaseTractElement.swift
@@ -136,6 +136,7 @@ class BaseTractElement: UIView {
         self.elementFrame.y = yPosition
         loadFrameProperties()
         buildFrame()
+        setupParallelElement()
         buildChildrenForData(children)
         setupView(properties: [String: Any]())
     }

--- a/godtools/Views/TractElements/TractCard+Animations.swift
+++ b/godtools/Views/TractElements/TractCard+Animations.swift
@@ -18,7 +18,6 @@ extension TractCard {
     static let bounceDuration: Double = 0.15
     
     func openingAnimation(yTransformation: CGFloat = -50.0, delay: Double = 0.0, cycleNumber: Int = 1, bounceNumber: Int = 1 ) {
-        
         UIView.animate(withDuration: TractCard.bounceDuration,
                        delay: delay,
                        options: .curveEaseOut,

--- a/godtools/Views/TractElements/TractCard.swift
+++ b/godtools/Views/TractElements/TractCard.swift
@@ -145,6 +145,7 @@ class TractCard: BaseTractElement {
         case .show:
             self.cardsParentView.lastCardOpened = self
             showCardWithoutAnimation()
+            showTexts()
         case .hide:
             hideCardWithoutAnimation()
         default:

--- a/godtools/Views/TractElements/TractPageContainer.swift
+++ b/godtools/Views/TractElements/TractPageContainer.swift
@@ -45,4 +45,10 @@ class TractPageContainer: BaseTractElement {
     override func loadStyles() {
         self.clipsToBounds = true
     }
+    
+    override func setupParallelElement() {
+        if (self.parent!.parallelElement != nil) {
+            self.parallelElement = self.parent!.parallelElement!.elements?[0]
+        }
+    }
 }


### PR DESCRIPTION
When changing language on tracts the state of the open cards was not persisted; the bug was introduced with the changes for supporting iPhone X. This PR fix that bug.