### PR TITLE
Use a guard let statement instead of force unwrap on translation.language

### DIFF
--- a/godtools/Managers/TranslationZipImporter.swift
+++ b/godtools/Managers/TranslationZipImporter.swift
@@ -146,7 +146,10 @@ class TranslationZipImporter: GTDataManager {
         
         return Alamofire.request(buildURL(translationId: translationId) ?? "")
             .downloadProgress { (progress) in
-                if !translation.language!.isPrimary() {
+                guard let language = translation.language else {
+                    return
+                }
+                if !language.isPrimary() {
                     return
                 }
                 NotificationCenter.default.post(name: .downloadProgressViewUpdateNotification,


### PR DESCRIPTION
Force unwrapping is probably causing the issue: https://fabric.io/cru/ios/apps/org.cru.godtools/issues/5992cddfbe077a4dcc1c73a4?time=last-thirty-days