### PR TITLE
Return cell immediately if section exceeds number of resources in the array

### DIFF
--- a/godtools/Managers/ToolsManager.swift
+++ b/godtools/Managers/ToolsManager.swift
@@ -123,7 +123,7 @@ extension ToolsManager: UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: ToolsManager.toolCellIdentifier) as! HomeToolTableViewCell
         if indexPath.section >= resources.count {
-            return cell
+            return UITableViewCell()
         }
         
         let resource = resources[indexPath.section]

--- a/godtools/Managers/ToolsManager.swift
+++ b/godtools/Managers/ToolsManager.swift
@@ -122,6 +122,10 @@ extension ToolsManager: UITableViewDataSource {
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: ToolsManager.toolCellIdentifier) as! HomeToolTableViewCell
+        if indexPath.section >= resources.count {
+            return cell
+        }
+        
         let resource = resources[indexPath.section]
         let languagesManager = LanguagesManager()
         


### PR DESCRIPTION
I'm not sure how this would happen, probably some sort of race condition. This fix would prevent a crash, and the result would be whatever was in the dequeued cell would be returned. This may produce undefined behavior, but at least the crash is avoided.