### PR TITLE
Fix downloads ux

### DIFF
--- a/godtools/Managers/TranslationZipImporter.swift
+++ b/godtools/Managers/TranslationZipImporter.swift
@@ -149,13 +149,16 @@ class TranslationZipImporter: GTDataManager {
                 guard let language = translation.language else {
                     return
                 }
+                guard let resource = translation.downloadedResource else {
+                    return
+                }
                 if !language.isPrimary() {
                     return
                 }
                 NotificationCenter.default.post(name: .downloadProgressViewUpdateNotification,
                                                 object: nil,
                                                 userInfo: [GTConstants.kDownloadProgressProgressKey: progress,
-                                                           GTConstants.kDownloadProgressResourceIdKey: translation.downloadedResource!.remoteId])
+                                                           GTConstants.kDownloadProgressResourceIdKey: resource.remoteId])
             }
             .responseData()
     }


### PR DESCRIPTION
Track English download when resource is not available in primary language

This will prevent weird UI/UX b/c w/o this change the AddTools screen will not show any update or pop b/c all notifications are filtered out.

fixes: https://jira.cru.org/browse/GT-440