### PR TITLE
Gt 378 call to action button color

### DIFF
--- a/godtools/Views/TractElements/TractCallToAction+UI.swift
+++ b/godtools/Views/TractElements/TractCallToAction+UI.swift
@@ -17,9 +17,11 @@ extension TractCallToAction {
         let origin = CGPoint(x: xPosition, y: yPosition)
         let size = CGSize(width: self.buttonSizeConstant, height: self.buttonSizeConstant)
         let buttonFrame = CGRect(origin: origin, size: size)
-        let button = UIButton(frame: buttonFrame)
+        let button = UIButton(type: .system)
+        button.frame = buttonFrame
         let image = UIImage(named: "right_arrow_blue")
-        button.setBackgroundImage(image, for: UIControlState.normal)
+        button.setImage(image, for: UIControlState.normal)
+        button.tintColor = callToActionProperties().controlColor
         button.addTarget(self, action: #selector(moveToNextView), for: UIControlEvents.touchUpInside)
         self.addSubview(button)
     }

--- a/godtools/Views/TractElements/TractCallToAction+UI.swift
+++ b/godtools/Views/TractElements/TractCallToAction+UI.swift
@@ -17,13 +17,25 @@ extension TractCallToAction {
         let origin = CGPoint(x: xPosition, y: yPosition)
         let size = CGSize(width: self.buttonSizeConstant, height: self.buttonSizeConstant)
         let buttonFrame = CGRect(origin: origin, size: size)
-        let button = UIButton(type: .system)
-        button.frame = buttonFrame
-        let image = UIImage(named: "right_arrow_blue")
-        button.setImage(image, for: UIControlState.normal)
-        button.tintColor = callToActionProperties().controlColor
-        button.addTarget(self, action: #selector(moveToNextView), for: UIControlEvents.touchUpInside)
+        
+        let button = createButton(with: buttonFrame)
+        
         self.addSubview(button)
     }
     
+    private func createButton(with frame: CGRect) -> UIButton {
+        let button = UIButton(type: .system)
+        button.frame = frame
+        
+        let image = UIImage(named: "right_arrow_blue")
+        
+        let controlColor = callToActionProperties().controlColor;
+        let pagePrimaryColor = page?.pageProperties().primaryColor;
+        
+        button.setImage(image, for: UIControlState.normal)
+        button.tintColor = controlColor != nil ? controlColor : pagePrimaryColor
+        button.addTarget(self, action: #selector(moveToNextView), for: UIControlEvents.touchUpInside)
+        
+        return button
+    }
 }

--- a/godtools/Views/TractElements/TractCallToActionProperties.swift
+++ b/godtools/Views/TractElements/TractCallToActionProperties.swift
@@ -11,9 +11,14 @@ import UIKit
 class TractCallToActionProperties: TractProperties {
     
     var events: String?
+    var controlColor = UIColor.gtBlue
     
     override func defineProperties() {
         self.properties = ["events"]
+    }
+    
+    override func customProperties() -> [String]? {
+        return ["controlColor"]
     }
     
     override func getTextProperties() -> TractTextContentProperties {
@@ -26,4 +31,9 @@ class TractCallToActionProperties: TractProperties {
         return textProperties
     }
 
+    override func performCustomProperty(propertyName: String, value: String) {
+        if propertyName == "controlColor" {
+            controlColor = value.getRGBAColor()
+        }
+    }
 }

--- a/godtools/Views/TractElements/TractCallToActionProperties.swift
+++ b/godtools/Views/TractElements/TractCallToActionProperties.swift
@@ -11,7 +11,7 @@ import UIKit
 class TractCallToActionProperties: TractProperties {
     
     var events: String?
-    var controlColor = UIColor.gtBlue
+    var controlColor: UIColor?
     
     override func defineProperties() {
         self.properties = ["events"]

--- a/godtools/Views/TractElements/TractHeader.swift
+++ b/godtools/Views/TractElements/TractHeader.swift
@@ -24,7 +24,13 @@ class TractHeader: BaseTractElement {
     }
     
     override func loadStyles() {
-        self.backgroundColor = self.page!.pageProperties().primaryColor
+        guard let page = page else {
+            return
+        }
+        
+        let backgroundColor = page.pageProperties().backgroundColor
+        
+        self.backgroundColor = backgroundColor
     }
     
     override func loadElementProperties(_ properties: [String : Any]) {


### PR DESCRIPTION
Allows the call to action button color to be customized. If the optional control-color attribute is not set, then the fallback will be to page.primary-color and manifest.primary-color in that order.

Tested on stage: w/ control-color set, with page.primary-color set, with manifest.primary-color set. See KGP in stage for different scenarios.