### PR TITLE
Gt 449 right to left content rendering

### DIFF
--- a/godtools/GeneralExtensions/String.swift
+++ b/godtools/GeneralExtensions/String.swift
@@ -70,21 +70,6 @@ extension String {
         return finalValue
     }
     
-    func naturalTextAlignment() -> NSTextAlignment {
-        let tagSchemes = Array.init(arrayLiteral: NSLinguisticTagSchemeLanguage)
-        let tagger = NSLinguisticTagger(tagSchemes: tagSchemes, options: 0)
-        
-        tagger.string = self
-        
-        let language = tagger.tag(at: 0, scheme: NSLinguisticTagSchemeLanguage, tokenRange: nil, sentenceRange: nil)
-        
-        if language == "ar" || language == "he" {
-            return .right
-        }
-        
-        return .left
-    }
-    
     var dashCased: String? {
         let pattern = "([a-z0-9])([A-Z])"
         

--- a/godtools/GeneralExtensions/String.swift
+++ b/godtools/GeneralExtensions/String.swift
@@ -70,6 +70,21 @@ extension String {
         return finalValue
     }
     
+    func naturalTextAlignment() -> NSTextAlignment {
+        let tagSchemes = Array.init(arrayLiteral: NSLinguisticTagSchemeLanguage)
+        let tagger = NSLinguisticTagger(tagSchemes: tagSchemes, options: 0)
+        
+        tagger.string = self
+        
+        let language = tagger.tag(at: 0, scheme: NSLinguisticTagSchemeLanguage, tokenRange: nil, sentenceRange: nil)
+        
+        if language == "ar" || language == "he" {
+            return .right
+        }
+        
+        return .left
+    }
+    
     var dashCased: String? {
         let pattern = "([a-z0-9])([A-Z])"
         

--- a/godtools/Managers/GTDataManager+Migrations.swift
+++ b/godtools/Managers/GTDataManager+Migrations.swift
@@ -12,7 +12,7 @@ import RealmSwift
 extension GTDataManager {
     static func config() -> Realm.Configuration  {
         return Realm.Configuration(
-            schemaVersion: 5,
+            schemaVersion: 6,
             migrationBlock: { migration, oldSchemaVersion in
                 if oldSchemaVersion < 1 {
                     migration.enumerateObjects(ofType: DownloadedResource.className(), { (old, new) in
@@ -44,6 +44,14 @@ extension GTDataManager {
                         
                         if stringId == "38" {
                             migration.delete(old!)
+                        }
+                    })
+                }
+                
+                if oldSchemaVersion < 6 {
+                    migration.enumerateObjects(ofType: Language.className(), { (old, new) in
+                        if let code = old?["code"] as? String {
+                            new!["direction"] = ["ar", "he", "ur", "fa"].contains(code) ? "rtl" : "ltr"
                         }
                     })
                 }

--- a/godtools/Managers/LanguageResource.swift
+++ b/godtools/Managers/LanguageResource.swift
@@ -12,6 +12,7 @@ import Spine
 class LanguageResource: Resource {
 
     var code: String?
+    var direction: String?
     
     override class var resourceType: ResourceType {
         return "language"
@@ -20,6 +21,7 @@ class LanguageResource: Resource {
     override class var fields: [Field] {
         return fieldsFromDictionary([
             "code" : Attribute(),
+            "direction" : Attribute()
             ])
     }
 }

--- a/godtools/Managers/LanguagesManager.swift
+++ b/godtools/Managers/LanguagesManager.swift
@@ -141,6 +141,11 @@ class LanguagesManager: GTDataManager {
             for remoteLanguage in languages {
                 if let cachedlanguage = findEntityByRemoteId(Language.self, remoteId: remoteLanguage.id!) {
                     cachedlanguage.code = remoteLanguage.code!
+                    
+                    if let direction = remoteLanguage.direction {
+                        cachedlanguage.direction = direction
+                    }
+                    
                     cachedLanguages.append(cachedlanguage)
                     continue
                 }

--- a/godtools/Models/Language.swift
+++ b/godtools/Models/Language.swift
@@ -37,4 +37,8 @@ class Language: Object {
         
         return nameInLocale
     }
+    
+    func isRightToLeft() -> Bool {
+        return code == "ar" || code == "he"
+    }
 }

--- a/godtools/Models/Language.swift
+++ b/godtools/Models/Language.swift
@@ -15,6 +15,7 @@ class Language: Object {
     dynamic var code = ""
     dynamic var remoteId = ""
     dynamic var shouldDownload = false
+    dynamic var direction = ""
     
     let translations = List<Translation>()
     
@@ -39,6 +40,6 @@ class Language: Object {
     }
     
     func isRightToLeft() -> Bool {
-        return code == "ar" || code == "he"
+        return direction == "rtl"
     }
 }

--- a/godtools/Views/TractElements/TractTextContent+UI.swift
+++ b/godtools/Views/TractElements/TractTextContent+UI.swift
@@ -26,9 +26,26 @@ extension TractTextContent {
         
         self.label = GTLabel(frame: properties.getFrame())
         self.label.text = properties.value
-        self.label.textAlignment = properties.value.naturalTextAlignment()
-        self.label.font = properties.scaledFont(language: self.tractConfigurations!.language!)
-        self.label.textColor = properties.colorFor(self, pageProperties: page!.pageProperties())
+        
+        if let tractConfigurations = tractConfigurations, let language = tractConfigurations.language {
+            let alignment = properties.textAlign
+            label.textAlignment = alignment
+            if language.isRightToLeft() {
+                switch alignment {
+                case .left:
+                    label.textAlignment = .right
+                case .right:
+                    label.textAlignment = .left
+                default:
+                    label.textAlignment = alignment
+                }
+            }
+            self.label.font = properties.scaledFont(language: language)
+        }
+        
+        if let page = page {
+            self.label.textColor = properties.colorFor(self, pageProperties: page.pageProperties())
+        }
         
         if properties.bold && properties.italic {
             self.label.font = self.label.font.setBoldItalic()

--- a/godtools/Views/TractElements/TractTextContent+UI.swift
+++ b/godtools/Views/TractElements/TractTextContent+UI.swift
@@ -26,7 +26,7 @@ extension TractTextContent {
         
         self.label = GTLabel(frame: properties.getFrame())
         self.label.text = properties.value
-        self.label.textAlignment = properties.textAlign
+        self.label.textAlignment = properties.value.naturalTextAlignment()
         self.label.font = properties.scaledFont(language: self.tractConfigurations!.language!)
         self.label.textColor = properties.colorFor(self, pageProperties: page!.pageProperties())
         

--- a/godtools/Views/TractElements/TractTextContent+UI.swift
+++ b/godtools/Views/TractElements/TractTextContent+UI.swift
@@ -30,6 +30,14 @@ extension TractTextContent {
         if let tractConfigurations = tractConfigurations, let language = tractConfigurations.language {
             let alignment = properties.textAlign
             label.textAlignment = alignment
+            
+            /* When the language that this label belongs to is rendered right to left, the text alignment
+             needs to be inverted. label.textAlignment has already taken into account the renderer's default
+             of "start" and a possible overriding value of "center" or "end" set by the text-align attribute.
+             
+             Up to this point we are assuming that textAlignment is set correctly and that the language is left to right.
+             If we find out here the language is right to left, we simply need to invert the value. left becomes right
+             and vice versa.*/
             if language.isRightToLeft() {
                 switch alignment {
                 case .left:


### PR DESCRIPTION
Problem: iOS does not inspect runtime text and determine which direction it should render, Android seems to. `NSTextAlignment.natural` only applies to system strings defined at build time, not dynamically created runtime labels/strings like we use in the content renderer.

My first attempt was to use NSLinguisiticTagger to inspect the runtime content strings and determine the language. It worked, but only about 85% of the time when trying render Arabic.

This solution is to use an attribute added to the API in PR: (https://github.com/CruGlobal/mobile-content-api/pull/138) which specifies the direction the text ought to be rendered in. This attribute is added at stored and used to determine the direction.

Every label in the renderer is defaulted to `NSTextAlignment.left` unless _text-align=center_ or _text-align=end_ are specified. When that attribute is set to one of those values, the renderer uses `.center` and `.right` respectively.

When isRightToLeft for the given language is true, the render flips the case so that _text-align=end_ becomes `.left` and the default case becomes `.right`. _text-align=center_ is always `.center`.