### PR TITLE
Fix header background setting

### DIFF
--- a/godtools/Views/TractElements/TractHeader.swift
+++ b/godtools/Views/TractElements/TractHeader.swift
@@ -28,8 +28,7 @@ class TractHeader: BaseTractElement {
             return
         }
         
-        let backgroundColor = page.pageProperties().backgroundColor
-        
+        let backgroundColor = page.pageProperties().primaryColor
         self.backgroundColor = backgroundColor
     }
     


### PR DESCRIPTION
In recent commit, it was mistakenly set to "page background" which is always white. It should have been set to "page primary color" which is set at the page or manifest level.

This was a small refactoring mistake.