### PR TITLE
Listeners are space separated, not comma separated

### DIFF
--- a/godtools/XMLManagement/XMLPage.swift
+++ b/godtools/XMLManagement/XMLPage.swift
@@ -30,7 +30,7 @@ class XMLPage: NSObject {
                 return listeners
             }
             
-            for listener in listenersString.components(separatedBy: ",") {
+            for listener in listenersString.components(separatedBy: " ") {
                 listeners.append(listener)
             }
         }


### PR DESCRIPTION
per the content spec: https://github.com/CruGlobal/mobile-content-api/blob/master/public/xmlns/content.xsd#L124