### PR TITLE
Set uses non-exempt encryption flag to false.

### DIFF
--- a/godtools/Info.plist
+++ b/godtools/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>


### PR DESCRIPTION
This will allow testflight builds to get submitted w/o having to wait for someone to say "no we aren't using encryption" through ITC.