### PR TITLE
Update share links

### DIFF
--- a/godtools/ViewControllers/Tract/TractViewController.swift
+++ b/godtools/ViewControllers/Tract/TractViewController.swift
@@ -217,7 +217,8 @@ class TractViewController: BaseViewController {
             shareURLString = shareURLString.appending("/").appending("\(currentPage)")
         }
         
-        return shareURLString.appending("?icid=gtshare")
+        // the space is intentional to separate any punctuation in the share message from the end of the URL
+        return shareURLString.appending("?icid=gtshare ")
     }
     
     // Notifications


### PR DESCRIPTION
Removes cases that were temporarily added to prevent broken links that would have been b/c new tools were added to the app that weren't in knowgod.com. Now, the new knowgod.com is available so all the sharing links work.