### PR TITLE
Fix for segmented control switching back to English

### DIFF
--- a/godtools/ViewControllers/Tract/TractViewController.swift
+++ b/godtools/ViewControllers/Tract/TractViewController.swift
@@ -58,6 +58,12 @@ class TractViewController: BaseViewController {
         setupSwipeGestures()
         defineObservers()
         UIApplication.shared.isIdleTimerDisabled = true
+        
+        if parallelLanguageIsAvailable() && determinePrimaryLabel() != determineParallelLabel() {
+            configureLanguageSegmentedControl()
+            self.navigationItem.titleView = languageSegmentedControl
+        }
+
     }
     
     deinit {
@@ -100,13 +106,6 @@ class TractViewController: BaseViewController {
         }
         
         self.addShareButton()
-    }
-
-    override func displayScreenTitle() {
-        if parallelLanguageIsAvailable() && determinePrimaryLabel() != determineParallelLabel() {
-            configureLanguageSegmentedControl()
-            self.navigationItem.titleView = languageSegmentedControl
-        }
     }
     
     fileprivate func setupContainerView() {


### PR DESCRIPTION
This was caused because of creating language segmented control over and over again on every ```viewWillAppear``` event.
```BaseViewController``` is calling ```displayScreenTitle``` in ```viewWillAppear```. Sometimes it may be desirable (if title should really change in pushing/pulling something on navigation stack that can change this title), but I think in this case is not.
This is a bad practice. ```viewWillAppear``` is fired in various cases, among others when some other screen (like calling system settings, sending sms, mail, or some other app) disappears from the screen after action and control is turned back to the app. I think that even showing alert fires it.
Anyways, this is used only in this ```TractViewController```, but I think that settings for the language cannot happen unless you leave that controller to home in which case loading ```TractViewController``` will create language segmented control again.