### PR TITLE
only send slack notification if tests fail

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -16,7 +16,8 @@ platform :ios do
     run_tests(
         workspace: ENV["CRU_XCWORKSPACE"],
         scheme: ENV["CRU_TEST_SCHEME"],
-        devices: ENV["CRU_TEST_DEVICES"].split(',')
+        devices: ENV["CRU_TEST_DEVICES"].split(','),
+        slack_only_on_failure: true
     )
   end
 


### PR DESCRIPTION
this will reduce the noise in the godtools slack channel

see: https://docs.fastlane.tools/actions/run_tests/#parameters