### PR TITLE
GT-616: Add travis_wait to prevent Travis timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,9 @@ jobs:
   - name: "Create TestFlight Build"
     if: branch = master and type = push
 
-    script: fastlane ios beta
+    script: 
+    - travis_wait 45 fastlane ios beta
+    - fastlane refresh_dsyms
 
   - name: "Release Build"
     if: tag =~ ^v(\d+\.){1,}\d+


### PR DESCRIPTION
Increased the wait increment to 45 minutes, as the build takes more than 30 minutes to complete the upload.