### PR TITLE
GT-627: Simplified AddTools VC refresh after download complete to fix crash.

### DIFF
--- a/godtools/Managers/ToolsManager.swift
+++ b/godtools/Managers/ToolsManager.swift
@@ -15,7 +15,7 @@ import RealmSwift
     @objc optional func didSelectTableViewRow(cell: HomeToolTableViewCell)
     func infoButtonWasPressed(resource: DownloadedResource)
     @objc optional func downloadButtonWasPressed(resource: DownloadedResource)
-    @objc optional func translationDownloadCompleted(at index: Int, isPrimary: Bool)
+    @objc optional func translationDownloadCompleted(at index: Int)
 }
 
 class ToolsManager: GTDataManager {
@@ -75,9 +75,7 @@ extension ToolsManager {
             return
         }
 
-        let isPrimary = notifcation.userInfo?["isPrimary"] as? Bool ?? false
-
-        delegate!.translationDownloadCompleted?(at: index, isPrimary: isPrimary)
+        delegate!.translationDownloadCompleted?(at: index)
     }
 }
 

--- a/godtools/Managers/TranslationZipImporter.swift
+++ b/godtools/Managers/TranslationZipImporter.swift
@@ -123,15 +123,7 @@ class TranslationZipImporter: GTDataManager {
         return downloadFromRemote(translation: translation).then { zipFileData -> Promise<Void> in
             self.handleZippedData(zipData: zipFileData, translation: translation)
             
-            guard let language = translation.language else {
-                return .value(())
-            }
-            
-            let isAvailableInPrimary = self.isTranslationAvailableInPrimaryLanguage(translation: translation)
-            
-            if language.isPrimary() || language.isParallel() || (!isAvailableInPrimary && language.code == "en") {
-                self.primaryDownloadComplete(translation: translation, isPrimary: language.isPrimary() || (!isAvailableInPrimary && language.code == "en"))
-            }
+            self.primaryDownloadComplete(translation: translation)
             
             return .value(())
             }.ensure {
@@ -266,10 +258,10 @@ class TranslationZipImporter: GTDataManager {
                               .appendingPathComponent(translationId)
     }
     
-    private func primaryDownloadComplete(translation: Translation, isPrimary: Bool) {
+    private func primaryDownloadComplete(translation: Translation) {
         NotificationCenter.default.post(name: .downloadPrimaryTranslationCompleteNotification,
                                         object: nil,
-                                        userInfo: [GTConstants.kDownloadProgressResourceIdKey: translation.downloadedResource!.remoteId, "isPrimary": isPrimary])
+                                        userInfo: [GTConstants.kDownloadProgressResourceIdKey: translation.downloadedResource!.remoteId])
     }
     
     private func createResourcesDirectoryIfNecessary() {

--- a/godtools/ViewControllers/Platform/AddToolsViewController.swift
+++ b/godtools/ViewControllers/Platform/AddToolsViewController.swift
@@ -116,15 +116,9 @@ extension AddToolsViewController: ToolsManagerDelegate {
         refreshView()
     }
     
-    func translationDownloadCompleted(at index: Int, isPrimary: Bool) {
-        // Tool should only be removed if the primary language is being downloaded
-        guard isPrimary else {
-            return
-        }
-        
-        ToolsManager.shared.resources.remove(at: index)
+    func translationDownloadCompleted(at index: Int) {
+        toolsManager.loadResourceList()
         DispatchQueue.main.async {
-            self.tableView.deleteSections(IndexSet(integer: index), with: .fade)
             self.refreshView()
         }
     }


### PR DESCRIPTION
Will just reload resource list when download completes and then refresh table view.