### PR TITLE
Default background-image-align to center

### DIFF
--- a/godtools/Views/TractElements/BaseTractElement+Functions.swift
+++ b/godtools/Views/TractElements/BaseTractElement+Functions.swift
@@ -72,8 +72,8 @@ extension BaseTractElement {
             }
         }
         
-        var xPosition: CGFloat = 0.0
-        var yPosition: CGFloat = 0.0
+        var xPosition: CGFloat = (viewWidth - imageWidth) / CGFloat(2.0)
+        var yPosition: CGFloat = (viewHeight - imageHeight) / CGFloat(2.0)
         
         if aligns.contains(.top) {
             yPosition = 0.0
@@ -85,11 +85,6 @@ extension BaseTractElement {
             xPosition = viewWidth - imageWidth
         } else if aligns.contains(.start) {
             xPosition = 0.0
-        }
-        
-        if aligns.contains(.center) {
-            xPosition = (viewWidth - imageWidth) / CGFloat(2.0)
-            yPosition = (viewHeight - imageHeight) / CGFloat(2.0)
         }
         
         imageView.frame = CGRect(x: xPosition,


### PR DESCRIPTION
background image alignment should default to center for both manifest and pages.

Also applying center alignment after top/bottom start/end would pave over those alignment options. a valid alignment would be: `start center` which centers the image vertically and aligns it to the start edge