### PR TITLE
Gt 708 tool info to always show the most information

### DIFF
--- a/godtools/ViewControllers/Platform/ToolDetailViewModel.swift
+++ b/godtools/ViewControllers/Platform/ToolDetailViewModel.swift
@@ -48,6 +48,10 @@ class ToolDetailViewModel: ToolDetailViewModelType {
             languageOrder.append(deviceLanguage)
         }
         
+        if let englishLanguage = languagesManager.loadFromDisk(id: "en") {
+            languageOrder.append(englishLanguage)
+        }
+        
         for language in languageOrder {
             if let translation = resource.getTranslationForLanguage(language) {
                 if let description = translation.localizedDescription, !description.isEmpty {


### PR DESCRIPTION
Previously this was loading the preferred language from disk and using that translation for the about details.  If the preferred language did not exist it would fall back to the tool description.

Changed so if the preferred language does not exist it will fall back to the device language.  If neither exist it will fall back to the tool description.