### PR TITLE
GT-932 Sending remote share navigation event when language changes

### DIFF
--- a/godtools/Features/Tract/TractViewModel.swift
+++ b/godtools/Features/Tract/TractViewModel.swift
@@ -297,6 +297,8 @@ class TractViewModel: NSObject, TractViewModelType {
         trackTappedLanguage(language: primaryLanguage)
                 
         selectedTractLanguage.accept(value: TractLanguage(languageType: .primary, language: primaryLanguage))
+        
+        sendRemoteShareNavigationEventForPage(page: tractPage)
     }
     
     func parallelLanguagedTapped() {
@@ -310,6 +312,8 @@ class TractViewModel: NSObject, TractViewModelType {
         trackTappedLanguage(language: parallelLanguage)
                 
         selectedTractLanguage.accept(value: TractLanguage(languageType: .parallel, language: parallelLanguage))
+        
+        sendRemoteShareNavigationEventForPage(page: tractPage)
     }
     
     private func trackTappedLanguage(language: LanguageModel) {


### PR DESCRIPTION
Fixed issue where tool wasn't toggling between primary and parallel language during a remote share session