### PR TITLE
GT-1009: Fix Sharing Link for Parallel Language

### DIFF
--- a/godtools/App/Features/ShareTool/ShareToolMenu/ShareToolMenuViewModel.swift
+++ b/godtools/App/Features/ShareTool/ShareToolMenu/ShareToolMenuViewModel.swift
@@ -11,9 +11,6 @@ import Foundation
 class ShareToolMenuViewModel: ShareToolMenuViewModelType {
     
     private let localizationServices: LocalizationServices
-    private let resource: ResourceModel
-    private let language: LanguageModel
-    private let pageNumber: Int
     
     private weak var flowDelegate: FlowDelegate?
     
@@ -22,13 +19,10 @@ class ShareToolMenuViewModel: ShareToolMenuViewModelType {
     let cancelTitle: String
     let hidesRemoteShareToolAction: Bool
     
-    required init(flowDelegate: FlowDelegate, localizationServices: LocalizationServices, resource: ResourceModel, language: LanguageModel, pageNumber: Int, hidesRemoteShareToolAction: Bool) {
+    required init(flowDelegate: FlowDelegate, localizationServices: LocalizationServices, hidesRemoteShareToolAction: Bool) {
         
         self.flowDelegate = flowDelegate
         self.localizationServices = localizationServices
-        self.resource = resource
-        self.language = language
-        self.pageNumber = pageNumber
         self.hidesRemoteShareToolAction = hidesRemoteShareToolAction
         
         shareToolTitle = localizationServices.stringForMainBundle(key: "share_tool_menu.send_tool")
@@ -38,7 +32,7 @@ class ShareToolMenuViewModel: ShareToolMenuViewModelType {
     
     func shareToolTapped() {
         
-        flowDelegate?.navigate(step: .shareToolTappedFromShareToolMenu(resource: resource, language: language, pageNumber: pageNumber))
+        flowDelegate?.navigate(step: .shareToolTappedFromShareToolMenu)
     }
     
     func remoteShareToolTapped() {

--- a/godtools/App/Flows/FlowStep.swift
+++ b/godtools/App/Flows/FlowStep.swift
@@ -57,7 +57,7 @@ enum FlowStep {
     case closeTappedFromToolTraining
     
     // share tool menu
-    case shareToolTappedFromShareToolMenu(resource: ResourceModel, language: LanguageModel, pageNumber: Int)
+    case shareToolTappedFromShareToolMenu
     case remoteShareToolTappedFromShareToolMenu
     case closeTappedFromShareToolScreenTutorial
     case shareLinkTappedFromShareToolScreenTutorial

--- a/godtools/App/Flows/ShareToolMenuFlow.swift
+++ b/godtools/App/Flows/ShareToolMenuFlow.swift
@@ -37,9 +37,6 @@ class ShareToolMenuFlow: Flow {
         let viewModel = ShareToolMenuViewModel(
             flowDelegate: self,
             localizationServices: appDiContainer.localizationServices,
-            resource: resource,
-            language: selectedLanguage,
-            pageNumber: pageNumber,
             hidesRemoteShareToolAction: hidesRemoteShareToolAction
         )
         let view = ShareToolMenuView(viewModel: viewModel)
@@ -51,11 +48,11 @@ class ShareToolMenuFlow: Flow {
         
         switch step {
             
-        case .shareToolTappedFromShareToolMenu(let resource, let language, let pageNumber):
+        case .shareToolTappedFromShareToolMenu:
             
             let viewModel = ShareToolViewModel(
                 resource: resource,
-                language: language,
+                language: selectedLanguage,
                 pageNumber: pageNumber,
                 localizationServices: appDiContainer.localizationServices,
                 analytics: appDiContainer.analytics


### PR DESCRIPTION
When generating the link for sharing a tool, the primary language code is always used.  If trying to share the tool in a parallel language, the parallel language code should be used instead.  I found where the link is getting generated and I found out that we can pass in a property called selectedLanguage, which will be equal to either the primary or secondary language, depending on which tab is open.