### PR TITLE
Replacing comma in language name and wrapping in parentheses

### DIFF
--- a/godtools/App/Features/ToolDetails/ToolDetailViewModel.swift
+++ b/godtools/App/Features/ToolDetails/ToolDetailViewModel.swift
@@ -144,7 +144,8 @@ class ToolDetailViewModel: NSObject, ToolDetailViewModelType {
         
         let languages: [LanguageModel] =  dataDownloader.resourcesCache.getResourceLanguages(resourceId: resource.id)
         let languageNames: [String] = languages.map({LanguageViewModel(language: $0, localizationServices: localizationServices).translatedLanguageName})
-        let sortedLanguageNames: String = languageNames.sorted(by: { $0 < $1 }).joined(separator: ", ")
+        let sortedLanguageNames: [String] = languageNames.sorted(by: { $0 < $1 })
+        let languageDetailsValue: String = sortedLanguageNames.joined(separator: ", ")
         
         let numberOfLanguages: Int = languages.count
         
@@ -170,7 +171,7 @@ class ToolDetailViewModel: NSObject, ToolDetailViewModelType {
         toolDetailsControls.accept(value: [aboutDetailsControl, languageDetailsControl])
         selectedDetailControl.accept(value: aboutDetailsControl)
         
-        languageDetails.accept(value: sortedLanguageNames)
+        languageDetails.accept(value: languageDetailsValue)
     }
     
     private var analyticsScreenName: String {

--- a/godtools/App/Share/ViewModels/LanguageViewModel.swift
+++ b/godtools/App/Share/ViewModels/LanguageViewModel.swift
@@ -20,6 +20,8 @@ class LanguageViewModel {
         let localizedKey: String = "language_name_" + language.code
         let localizedName: String = localizationServices.stringForBundle(bundle: Bundle.main, key: localizedKey)
         
+        let translatedLanguageName: String
+        
         if !localizedName.isEmpty && localizedName != localizedKey {
             translatedLanguageName = localizedName
         }
@@ -29,5 +31,16 @@ class LanguageViewModel {
         else {
             translatedLanguageName = language.name
         }
+        
+        var transformedLanguageName: String = translatedLanguageName
+                
+        if transformedLanguageName.contains(", ") {
+            let names: [String] = translatedLanguageName.components(separatedBy: ", ")
+            if names.count == 2 {
+                transformedLanguageName = names[0] + " (" + names[1] + ")"
+            }
+        }
+                
+        self.translatedLanguageName = transformedLanguageName
     }
 }


### PR DESCRIPTION
Changes to LanguageViewModel which converts a language name in the following example: 
"Chinese, Simplified" to "Chinese (Simplified)".  Strips the ", " and surrounds the last part in parentheses. 