### PR TITLE
Gt 756 levi

### DIFF
--- a/godtools/App/Services/AppsFlyer/AppsFlyer.swift
+++ b/godtools/App/Services/AppsFlyer/AppsFlyer.swift
@@ -19,12 +19,11 @@ class AppsFlyer: NSObject, AppsFlyerType {
     private var isConfigured: Bool = false
     
     required init(config: ConfigType, deepLinkingService: DeepLinkingServiceType) {
+        
         self.config = config
         self.deepLinkingService = deepLinkingService
         
         super.init()
-        
-        AppsFlyerLib.shared().delegate = self
     }
     
     var appsFlyerLib: AppsFlyerLib {
@@ -49,6 +48,7 @@ class AppsFlyer: NSObject, AppsFlyerType {
                 
         appsFlyerLib.appsFlyerDevKey = config.appsFlyerDevKey
         appsFlyerLib.appleAppID = config.appleAppId
+        appsFlyerLib.delegate = self
         
         if config.isDebug {
             appsFlyerLib.useUninstallSandbox = true


### PR DESCRIPTION
Hey @reldredge71 I was thinking for accessing the shared AppsFlyerLib let's do something like this.  Keep a single reference to it in AppsFlyer and then anytime we access it ensure that it has been configured first.