### PR TITLE
GT-756-track-app-launch Added trackAppLaunch back to AppsFlyerAnalytics

### DIFF
--- a/godtools/App/AppDelegate.swift
+++ b/godtools/App/AppDelegate.swift
@@ -14,7 +14,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
     private let appDiContainer: AppDiContainer = AppDiContainer()
     private var appFlow: AppFlow?
-    private var appsFlyer: AppsFlyerType?
     
     var window: UIWindow?
     
@@ -33,9 +32,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         self.appFlow = appFlow
         
         appDiContainer.appsFlyer.configure()
-        
-        appsFlyer = appDiContainer.appsFlyer
-        
+                
         appDiContainer.analytics.adobeAnalytics.configure()
         appDiContainer.analytics.adobeAnalytics.collectLifecycleData()
         
@@ -78,7 +75,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func applicationDidBecomeActive(_ application: UIApplication) {
         AppEvents.activateApp()
         appFlow?.applicationDidBecomeActive(application)
-        appsFlyer?.appDidBecomeActive()
+        appDiContainer.analytics.appsFlyerAnalytics.trackAppLaunch()
         //on app launch, sync Adobe Analytics auth state
         appDiContainer.analytics.adobeAnalytics.fetchAttributesThenSyncIds()
         appDiContainer.analytics.firebaseAnalytics.fetchAttributesThenSetUserId()
@@ -89,7 +86,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
     
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
-        appsFlyer?.handleOpenUrl(url: url, options: options)
+        
+        appDiContainer.appsFlyer.handleOpenUrl(url: url, options: options)
         
         return ApplicationDelegate.shared.application(app, open: url, options: options)
     }
@@ -136,21 +134,21 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             appDiContainer.deepLinkingService.processDeepLink(url: url)
         }
         
-        appsFlyer?.continueUserActivity(userActivity: userActivity)
+        appDiContainer.appsFlyer.continueUserActivity(userActivity: userActivity)
         
         return true
     }
     
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
-        appsFlyer?.registerUninstall(deviceToken: deviceToken)
+        appDiContainer.appsFlyer.registerUninstall(deviceToken: deviceToken)
     }
     
     func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable : Any]) {
-        appsFlyer?.handlePushNotification(userInfo: userInfo)
+        appDiContainer.appsFlyer.handlePushNotification(userInfo: userInfo)
     }
     
     func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable : Any], fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
         
-        appsFlyer?.handlePushNotification(userInfo: userInfo)
+        appDiContainer.appsFlyer.handlePushNotification(userInfo: userInfo)
     }
 }

--- a/godtools/App/Services/Analytics/AppsFlyer/AppsFlyerAnalyticsType.swift
+++ b/godtools/App/Services/Analytics/AppsFlyer/AppsFlyerAnalyticsType.swift
@@ -11,5 +11,6 @@ import UIKit
 protocol AppsFlyerAnalyticsType: MobileContentAnalyticsSystem {
     
     func configure(adobeAnalytics: AdobeAnalyticsType)
+    func trackAppLaunch()
     func trackEvent(eventName: String, data: [String: Any]?)
 }

--- a/godtools/App/Services/AppsFlyer/AppsFlyer.swift
+++ b/godtools/App/Services/AppsFlyer/AppsFlyer.swift
@@ -53,11 +53,6 @@ class AppsFlyer: NSObject, AppsFlyerType {
         }
     }
     
-    func appDidBecomeActive() {
-        appsFlyerLib.start()
-        appsFlyerLib.isStopped = false
-    }
-    
     func handleOpenUrl(url: URL, options: [UIApplication.OpenURLOptionsKey : Any]) {
         appsFlyerLib.handleOpen(url, options: options)
     }

--- a/godtools/App/Services/AppsFlyer/AppsFlyerType.swift
+++ b/godtools/App/Services/AppsFlyer/AppsFlyerType.swift
@@ -13,7 +13,6 @@ protocol AppsFlyerType {
     var appsFlyerLib: AppsFlyerLib { get }
     
     func configure()
-    func appDidBecomeActive()
     func handleOpenUrl(url: URL, options: [UIApplication.OpenURLOptionsKey : Any])
     func continueUserActivity(userActivity: NSUserActivity)
     func registerUninstall (deviceToken: Data)


### PR DESCRIPTION
Hey @reldredge71 I ended up moving the trackAppLaunch() functionality back into AppsFlyerAnalytics.  I remember before that had to fire in the correct order, that's why the serialQueue was in there.

Also I removed the AppsFlyer optional reference from AppDelegate.  We can just access the reference directly on appDiContainer which is nicer because the appDiContainer is not optional.