### PR TITLE
Moved semantic declaration outside of if conditional

### DIFF
--- a/godtools/App/Features/Tools/Views/ToolCellViewModel.swift
+++ b/godtools/App/Features/Tools/Views/ToolCellViewModel.swift
@@ -184,13 +184,12 @@ class ToolCellViewModel: NSObject, ToolCellViewModelType {
              
         let toolName: String
         let languageBundle: Bundle
+        let semanticContentAttribute: UISemanticContentAttribute
         
         if let primaryLanguage = languageSettingsService.primaryLanguage.value, let primaryTranslation = resourcesCache.getResourceLanguageTranslation(resourceId: resource.id, languageId: primaryLanguage.id) {
             
             toolName = primaryTranslation.translatedName
             languageBundle = localizationServices.bundleLoader.bundleForResource(resourceName: primaryLanguage.code) ?? Bundle.main
-            
-            let semanticContentAttribute: UISemanticContentAttribute;
             
             switch primaryLanguage.languageDirection {
             case .leftToRight:
@@ -198,22 +197,18 @@ class ToolCellViewModel: NSObject, ToolCellViewModelType {
             case .rightToLeft:
                 semanticContentAttribute = .forceRightToLeft
             }
-            
-            toolSemanticContentAttribute.accept(value: semanticContentAttribute)
         }
         else if let englishTranslation = resourcesCache.getResourceLanguageTranslation(resourceId: resource.id, languageCode: "en") {
             
             toolName = englishTranslation.translatedName
             languageBundle = localizationServices.bundleLoader.englishBundle ?? Bundle.main
-            
-            toolSemanticContentAttribute.accept(value: .forceLeftToRight)
+            semanticContentAttribute = .forceLeftToRight
         }
         else {
             
             toolName = resource.name
             languageBundle = localizationServices.bundleLoader.englishBundle ?? Bundle.main
-            
-            toolSemanticContentAttribute.accept(value: .forceLeftToRight)
+            semanticContentAttribute = .forceLeftToRight
         }
         
         title.accept(value: toolName)
@@ -221,5 +216,6 @@ class ToolCellViewModel: NSObject, ToolCellViewModelType {
         category.accept(value: localizationServices.stringForBundle(bundle: languageBundle, key: "tool_category_\(resource.attrCategory)"))
         aboutTitle.accept(value: localizationServices.stringForBundle(bundle: languageBundle, key: "about"))
         openTitle.accept(value: localizationServices.stringForBundle(bundle: languageBundle, key: "open"))
+        toolSemanticContentAttribute.accept(value: semanticContentAttribute)
     }
 }


### PR DESCRIPTION
Hey @reldredge71 one more change I'd like to propose, so I moved the declaration for ```let semanticContentAttribute: UISemanticContentAttribute``` outside of the if conditional.  The reason being, now ```toolSemanticContentAttribute.accept``` is called in one place and we are forcing ```semanticContentAttribute``` to be set because it is immutable ```let```.  So now if we were to add another ```else if``` to our conditional chain we would force ```semanticContentAttribute``` to be set.  
I think this is a good example of where imperative programming is less favorable. 