### PR TITLE
Fixed favorites and all tools lists top spacing issue with navigation bar

### DIFF
--- a/godtools/App/Features/Tools/Views/FavoritingToolMessageView/FavoritingToolMessageView.swift
+++ b/godtools/App/Features/Tools/Views/FavoritingToolMessageView/FavoritingToolMessageView.swift
@@ -28,6 +28,7 @@ class FavoritingToolMessageView: UIView, NibBased {
     func configure(viewModel: FavoritingToolMessageViewModelType) {
         self.viewModel = viewModel
         messageLabel.text = viewModel.message
+        layoutIfNeeded()
     }
     
     @objc func handleClose(button: UIButton) {

--- a/godtools/App/Features/Tools/Views/OpenTutorialView/OpenTutorialView.swift
+++ b/godtools/App/Features/Tools/Views/OpenTutorialView/OpenTutorialView.swift
@@ -32,6 +32,7 @@ class OpenTutorialView: UIView, NibBased {
         self.viewModel = viewModel
         showTutorialLabel.text = viewModel.showTutorialTitle
         openTutorialButton.setTitle(viewModel.openTutorialTitle, for: .normal)
+        layoutIfNeeded()
     }
     
     @objc func handleClose(button: UIButton) {


### PR DESCRIPTION
The top spacing between the favorites tools list and all tools list wasn't adjusting correctly when closing the messaging for open tutorial and favoriting found above those lists.  This fix corrects that by forcing the view to relayout after setting the message label.