### PR TITLE
GT-1034 -- Fix Burmese font in Card Body Paragraphs

### DIFF
--- a/godtools/App/Services/FontService/FontService.swift
+++ b/godtools/App/Services/FontService/FontService.swift
@@ -34,10 +34,12 @@ class FontService {
             }
         }
         else if primaryLanguageCode == "my" {
+            let fontScaleAdjustment = CGFloat(0.9)
+            
             if weight == UIFont.Weight.semibold || weight == UIFont.Weight.bold {
                 font = FontLibrary.notoSansMyanmarBold.font(size: size)
             } else {
-                font = FontLibrary.notoSansMyanmar.font(size: size)
+                font = FontLibrary.notoSansMyanmar.font(size: size * fontScaleAdjustment)
             }
         }
         else {


### PR DESCRIPTION
The particular font we're using for Burmese renders larger than some of the other languages we have in the app.  In some places, the text starts to overlap with the background image.  This PR adds an adjustment to the font size only for Burmese to help it take up less space but still be readable.