### PR TITLE
GT-1069: Add Hindi as Tutorial Supported Language

### DIFF
--- a/godtools/App/Features/Tutorial/Models/TutorialSupportedLanguages.swift
+++ b/godtools/App/Features/Tutorial/Models/TutorialSupportedLanguages.swift
@@ -20,7 +20,8 @@ class TutorialSupportedLanguages: SupportedLanguagesType {
             Locale(identifier: "zh-Hans"),
             Locale(identifier: "ru"),
             Locale(identifier: "id"),
-            Locale(identifier: "fr")
+            Locale(identifier: "fr"),
+            Locale(identifier: "hi")
         ]
     }
 }


### PR DESCRIPTION
OneSky now has onboarding text translated into Hindi.  I set Hindi as one of the Tutorial Supported Languages, si now onboarding appears when the device language is set to Hindi.