### PR TITLE
GT-1061 Updates to LocalizationServices

### DIFF
--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		457C8586242E50D70025E079 /* GoogleService-Info-Debug.plist in Resources */ = {isa = PBXBuildFile; fileRef = 457C8585242E50D70025E079 /* GoogleService-Info-Debug.plist */; };
 		4586C04624631C3900927A42 /* ADBMobileConfig.json in Resources */ = {isa = PBXBuildFile; fileRef = 4586C04424631C3900927A42 /* ADBMobileConfig.json */; };
 		4586C04724631C3900927A42 /* ADBMobileConfig_debug.json in Resources */ = {isa = PBXBuildFile; fileRef = 4586C04524631C3900927A42 /* ADBMobileConfig_debug.json */; };
+		458AA38425D4252000E71B32 /* LocalizationBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 458AA38325D4252000E71B32 /* LocalizationBundle.swift */; };
 		45A7BAF5252CBC5B00D70465 /* LocaleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45A7BAF4252CBC5B00D70465 /* LocaleTests.swift */; };
 		45AD1A9F25938A4E00A096A0 /* TutorialView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 45AD174F25938A4D00A096A0 /* TutorialView.xib */; };
 		45AD1AA025938A4E00A096A0 /* TutorialViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45AD175025938A4D00A096A0 /* TutorialViewModel.swift */; };
@@ -837,6 +838,7 @@
 		457C8585242E50D70025E079 /* GoogleService-Info-Debug.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info-Debug.plist"; sourceTree = "<group>"; };
 		4586C04424631C3900927A42 /* ADBMobileConfig.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = ADBMobileConfig.json; sourceTree = "<group>"; };
 		4586C04524631C3900927A42 /* ADBMobileConfig_debug.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = ADBMobileConfig_debug.json; sourceTree = "<group>"; };
+		458AA38325D4252000E71B32 /* LocalizationBundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizationBundle.swift; sourceTree = "<group>"; };
 		45A7BAF4252CBC5B00D70465 /* LocaleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocaleTests.swift; sourceTree = "<group>"; };
 		45AD174F25938A4D00A096A0 /* TutorialView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = TutorialView.xib; sourceTree = "<group>"; };
 		45AD175025938A4D00A096A0 /* TutorialViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TutorialViewModel.swift; sourceTree = "<group>"; };
@@ -3711,6 +3713,7 @@
 			isa = PBXGroup;
 			children = (
 				45AD1EE225938A9800A096A0 /* LocaleLocalizationBundle.swift */,
+				458AA38325D4252000E71B32 /* LocalizationBundle.swift */,
 				45AD1EE425938A9800A096A0 /* LocalizationBundleLoader.swift */,
 				45AD1EE325938A9800A096A0 /* LocalizationServices.swift */,
 			);
@@ -4879,6 +4882,7 @@
 				45AD1F1E25938A9800A096A0 /* ToolPageModalViewModelType.swift in Sources */,
 				45AD1AF325938A4E00A096A0 /* ShareAStoryWithUsWebContent.swift in Sources */,
 				45AD200925938A9800A096A0 /* TranslationDownloader.swift in Sources */,
+				458AA38425D4252000E71B32 /* LocalizationBundle.swift in Sources */,
 				45AD1F5725938A9800A096A0 /* MobileContentXmlNodeType.swift in Sources */,
 				45AD1FBB25938A9800A096A0 /* TractRemoteShareSubscriberError.swift in Sources */,
 				45AD1F0F25938A9800A096A0 /* ToolPageContentStackContainerViewModel.swift in Sources */,

--- a/godtools/App/Services/Localization/LocaleLocalizationBundle.swift
+++ b/godtools/App/Services/Localization/LocaleLocalizationBundle.swift
@@ -10,20 +10,35 @@ import Foundation
 
 class LocaleLocalizationBundle {
     
-    let localeBundle: Bundle?
-    let localeBaseLanguageBundle: Bundle?
+    let locale: Locale
+    let bundleLoader: LocalizationBundleLoader
+    let localeBundle: LocalizationBundle?
     
     required init(localeIdentifier: String, bundleLoader: LocalizationBundleLoader) {
         
-        localeBundle = bundleLoader.bundleForResource(resourceName: localeIdentifier)
-        
         let locale: Locale = Locale(identifier: localeIdentifier)
         
-        if !locale.isBaseLanguage, let languageCode = locale.languageCode, !languageCode.isEmpty {
-            localeBaseLanguageBundle = bundleLoader.bundleForResource(resourceName: languageCode)
+        self.locale = locale
+        self.bundleLoader = bundleLoader
+        
+        if let bundle = bundleLoader.bundleForResource(resourceName: localeIdentifier) {
+            localeBundle = LocalizationBundle(bundle: bundle)
         }
         else {
-            localeBaseLanguageBundle = nil
+            localeBundle = nil
         }
+    }
+    
+    func getBaseLanguageBundle() -> LocalizationBundle? {
+        
+        guard !locale.isBaseLanguage else {
+            return localeBundle
+        }
+        
+        if let languageCode = locale.languageCode, !languageCode.isEmpty, let bundle = bundleLoader.bundleForResource(resourceName: languageCode) {
+            return LocalizationBundle(bundle: bundle)
+        }
+        
+        return nil
     }
 }

--- a/godtools/App/Services/Localization/LocalizationBundle.swift
+++ b/godtools/App/Services/Localization/LocalizationBundle.swift
@@ -1,0 +1,35 @@
+//
+//  LocalizationBundle.swift
+//  godtools
+//
+//  Created by Levi Eggert on 2/10/21.
+//  Copyright © 2021 Cru. All rights reserved.
+//
+
+import Foundation
+
+class LocalizationBundle {
+    
+    let bundle: Bundle
+    
+    required init(bundle: Bundle) {
+        
+        self.bundle = bundle
+    }
+    
+    func stringForKey(key: String) -> String? {
+                
+        let localizedString: String = bundle.localizedString(forKey: key, value: nil, table: nil)
+        
+        if localizedString.isEmpty || localizedString.lowercased() == key.lowercased() {
+            return nil
+        }
+        
+        return localizedString
+    }
+    
+    func stringForKeyElseKey(key: String) -> String {
+        
+        return stringForKey(key: key) ?? key
+    }
+}

--- a/godtools/App/Services/Localization/LocalizationServices.swift
+++ b/godtools/App/Services/Localization/LocalizationServices.swift
@@ -18,7 +18,27 @@ class LocalizationServices {
             
     }
     
+    func stringForLanguage(language: LanguageModel, key: String) -> String {
+        
+        let localeLocalizationBundle: LocaleLocalizationBundle = LocaleLocalizationBundle(
+            localeIdentifier: language.code,
+            bundleLoader: bundleLoader
+        )
+        
+        if let localizedStringForLanguage = localeLocalizationBundle.localeBundle?.stringForKey(key: key) {
+            return localizedStringForLanguage
+        }
+        else if let localizedStringForBaseLanguage = localeLocalizationBundle.getBaseLanguageBundle()?.stringForKey(key: key) {
+            return localizedStringForBaseLanguage
+        }
+        
+        return stringForMainBundle(key: key)
+    }
+    
     func stringForMainBundle(key: String) -> String {
+        
+        // TODO: Would like to do some refactoring here and remove the stringForBundleOrder function because this requires that all bundles be loaded which creates more overhead. ~Levi
+        // Instead, use the LocalizationBundle stringForKey method to first see if a localized string can be found and if not, load the next bundle.
         
         let systemLocaleIdentifier: String
         
@@ -37,11 +57,11 @@ class LocalizationServices {
         var bundleOrder: [Bundle] = Array()
         
         if let systemBundle = systemLocalizationBundle.localeBundle {
-            bundleOrder.append(systemBundle)
+            bundleOrder.append(systemBundle.bundle)
         }
         
-        if let systemBaseLanguageBundle = systemLocalizationBundle.localeBaseLanguageBundle {
-            bundleOrder.append(systemBaseLanguageBundle)
+        if let systemBaseLanguageBundle = systemLocalizationBundle.getBaseLanguageBundle() {
+            bundleOrder.append(systemBaseLanguageBundle.bundle)
         }
         
         bundleOrder.append(Bundle.main)


### PR DESCRIPTION
- Added a LocalizationBundle Class which wraps NSBundle.  I did this because NSBundle will return the localized key if the phrase cannot be found.  The LocalizationBundle wrapper will return null instead.  This way we can fallback to base language bundles if needed if a phrase cannot be found.

- Added ```stringForLanguage(language: LanguageModel, key: String)``` to LocalizationServices which will attempt to fallback to the LanguageModel's base language and then the system language if that localized phrase cannot be found.