### PR TITLE
GT-1079 - Use Translated Message in Loading Screen

### DIFF
--- a/godtools/App/Features/Tools/LoadingToolView.swift
+++ b/godtools/App/Features/Tools/LoadingToolView.swift
@@ -73,6 +73,10 @@ class LoadingToolView: UIViewController {
             }
             self?.presentAlertMessage(alertMessage: alertMessage)
         }
+        
+        viewModel.message.addObserver(self) { [weak self] (message: String) in
+            self?.messageLabel.text = message
+        }
     }
     
     @objc func handleClose(barButtonItem: UIBarButtonItem) {


### PR DESCRIPTION
The translated loading phrase is getting fetched in the View Model, but never gets applied to the View.