### PR TITLE
GT-1071: Fix Content Images in Renderer

### DIFF
--- a/godtools/App/Flows/ToolsFlow.swift
+++ b/godtools/App/Flows/ToolsFlow.swift
@@ -556,6 +556,7 @@ class ToolsFlow: Flow {
         let localizationServices: LocalizationServices = appDiContainer.localizationServices
         let followUpsService: FollowUpsService = appDiContainer.followUpsService
         let cardJumpService: CardJumpService = appDiContainer.getCardJumpService()
+        let devicePrimaryLanguage = appDiContainer.languageSettingsService.primaryLanguage.value ?? primaryLanguage
         
         let toolPageViewFactory = ToolPageViewFactory(
             analytics: analytics,
@@ -582,6 +583,7 @@ class ToolsFlow: Flow {
         let primaryRenderer = MobileContentRenderer(
             resource: resource,
             language: primaryLanguage,
+            primaryLanguage: devicePrimaryLanguage,
             manifest: MobileContentXmlManifest(translationManifest: primaryTranslationManifest),
             pageNodes: [],
             translationsFileCache: translationsFileCache,
@@ -599,6 +601,7 @@ class ToolsFlow: Flow {
             let parallelRenderer = MobileContentRenderer(
                 resource: resource,
                 language: parallelLanguage,
+                primaryLanguage: devicePrimaryLanguage,
                 manifest: MobileContentXmlManifest(translationManifest: parallelTranslationManifest),
                 pageNodes: [],
                 translationsFileCache: translationsFileCache,
@@ -686,9 +689,12 @@ class ToolsFlow: Flow {
         
         let pageViewFactories: [MobileContentPageViewFactoryType] = [trainingViewFactory]
         
+        let devicePrimaryLanguage = appDiContainer.languageSettingsService.primaryLanguage.value ?? event.pageModel.language
+        
         let renderer = MobileContentRenderer(
             resource: event.pageModel.resource,
             language: event.pageModel.language,
+            primaryLanguage: devicePrimaryLanguage,
             manifest: event.pageModel.manifest,
             pageNodes: pageNodes,
             translationsFileCache: appDiContainer.translationsFileCache,

--- a/godtools/App/Services/Renderer/MobileContent/Renderer/MobileContentRenderer.swift
+++ b/godtools/App/Services/Renderer/MobileContent/Renderer/MobileContentRenderer.swift
@@ -22,6 +22,7 @@ class MobileContentRenderer {
     private let translationsFileCache: TranslationsFileCache
     private let pageViewFactories: [MobileContentPageViewFactoryType]
     private let rendererType: RendererType
+    private let primaryLanguage: LanguageModel
     
     private var pageNodes: [Int: PageNode] = Dictionary()
     private var pageListeners: [PageListenerEventName: PageNumber] = Dictionary()
@@ -31,13 +32,14 @@ class MobileContentRenderer {
     let resource: ResourceModel
     let language: LanguageModel
     
-    required init(resource: ResourceModel, language: LanguageModel, manifest: MobileContentXmlManifest, pageNodes: [PageNode], translationsFileCache: TranslationsFileCache, pageViewFactories: [MobileContentPageViewFactoryType], mobileContentAnalytics: MobileContentAnalytics, fontService: FontService) {
+    required init(resource: ResourceModel, language: LanguageModel, primaryLanguage: LanguageModel, manifest: MobileContentXmlManifest, pageNodes: [PageNode], translationsFileCache: TranslationsFileCache, pageViewFactories: [MobileContentPageViewFactoryType], mobileContentAnalytics: MobileContentAnalytics, fontService: FontService) {
         
         self.translationsFileCache = translationsFileCache
         self.manifest = manifest
         self.resourcesCache = ManifestResourcesCache(manifest: manifest, translationsFileCache: translationsFileCache)
         self.resource = resource
         self.language = language
+        self.primaryLanguage = primaryLanguage
 
         // pageViewFactories
         let mobileContentPageViewFactory = MobileContentPageViewFactory(
@@ -156,6 +158,7 @@ class MobileContentRenderer {
                 resourcesCache: resourcesCache,
                 resource: resource,
                 language: language,
+                primaryLanguage: primaryLanguage,
                 pageViewFactories: pageViewFactories
             )
             

--- a/godtools/App/Services/Renderer/MobileContent/Renderer/MobileContentRendererPageModel.swift
+++ b/godtools/App/Services/Renderer/MobileContent/Renderer/MobileContentRendererPageModel.swift
@@ -19,11 +19,12 @@ class MobileContentRendererPageModel {
     let resourcesCache: ManifestResourcesCache
     let resource: ResourceModel
     let language: LanguageModel
+    let primaryLanguage: LanguageModel
     let pageViewFactories: [MobileContentPageViewFactoryType]
     
     private weak var weakWindow: UIViewController?
     
-    required init(pageNode: PageNode, page: Int, numberOfPages: Int, window: UIViewController, safeArea: UIEdgeInsets, manifest: MobileContentXmlManifest, resourcesCache: ManifestResourcesCache, resource: ResourceModel, language: LanguageModel, pageViewFactories: [MobileContentPageViewFactoryType]) {
+    required init(pageNode: PageNode, page: Int, numberOfPages: Int, window: UIViewController, safeArea: UIEdgeInsets, manifest: MobileContentXmlManifest, resourcesCache: ManifestResourcesCache, resource: ResourceModel, language: LanguageModel, primaryLanguage: LanguageModel, pageViewFactories: [MobileContentPageViewFactoryType]) {
         
         self.pageNode = pageNode
         self.page = page
@@ -35,6 +36,7 @@ class MobileContentRendererPageModel {
         self.resourcesCache = resourcesCache
         self.resource = resource
         self.language = language
+        self.primaryLanguage = primaryLanguage
         self.pageViewFactories = pageViewFactories
     }
     

--- a/godtools/App/Services/Renderer/MobileContent/Views/ContentImage/MobileContentImageViewModel.swift
+++ b/godtools/App/Services/Renderer/MobileContent/Views/ContentImage/MobileContentImageViewModel.swift
@@ -18,7 +18,7 @@ class MobileContentImageViewModel: MobileContentImageViewModelType {
         
         self.imageNode = imageNode
         self.pageModel = pageModel
-        self.languageDirection = pageModel.language.languageDirection
+        self.languageDirection = pageModel.primaryLanguage.languageDirection
     }
     
     var image: UIImage? {


### PR DESCRIPTION
Because the Renderer has changed since 1071 was merged in, this change should do basically the same behavior for the images that was there before 1071 was worked on:  the direction of the images is determined by the device primary language, rather than the resource language.  Other content should remain connected to the direction of the resource language.