### PR TITLE
GT-1142 Fix to tool page call to action placement of arrow

### DIFF
--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -744,6 +744,7 @@
 		45AD22DA2593E60900A096A0 /* LanguageAvailabilityType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45AD176825938A4D00A096A0 /* LanguageAvailabilityType.swift */; };
 		45AD22DF2593E63D00A096A0 /* Locale+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45AD18BB25938A4E00A096A0 /* Locale+Extensions.swift */; };
 		45AD22E42593E68D00A096A0 /* TutorialSupportedLanguages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45AD175625938A4D00A096A0 /* TutorialSupportedLanguages.swift */; };
+		45B116C22625FC6D007A7127 /* LanguageDirection+SemanticContentAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B116C12625FC6D007A7127 /* LanguageDirection+SemanticContentAttribute.swift */; };
 		45B6480925E581660098BAF1 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		45B6480A25E581660098BAF1 /* (null) in Resources */ = {isa = PBXBuildFile; };
 		45B6480B25E581660098BAF1 /* (null) in Sources */ = {isa = PBXBuildFile; };
@@ -1609,6 +1610,7 @@
 		45AD223B2593C90000A096A0 /* FirebaseCrashlyticsService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FirebaseCrashlyticsService.swift; sourceTree = "<group>"; };
 		45AD22A02593CE8900A096A0 /* ColorPalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorPalette.swift; sourceTree = "<group>"; };
 		45AD22B22593D1FB00A096A0 /* UIImage+CreateImageWithColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+CreateImageWithColor.swift"; sourceTree = "<group>"; };
+		45B116C12625FC6D007A7127 /* LanguageDirection+SemanticContentAttribute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LanguageDirection+SemanticContentAttribute.swift"; sourceTree = "<group>"; };
 		45B879CD260C2CA800807821 /* MobileContentPagesNavigationModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileContentPagesNavigationModel.swift; sourceTree = "<group>"; };
 		45C5386024B8EFA700CABDAC /* godtoolsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = godtoolsUITests.swift; sourceTree = "<group>"; };
 		45C93AA4261D310900592FFF /* ArticleManifestXmlParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArticleManifestXmlParser.swift; sourceTree = "<group>"; };
@@ -3289,6 +3291,7 @@
 				45AD18B825938A4E00A096A0 /* UIViewController+Containment.swift */,
 				45AD18B525938A4E00A096A0 /* UIViewController+NavBackItem.swift */,
 				45AD18B225938A4E00A096A0 /* UIViewController+NavItem.swift */,
+				45B116C12625FC6D007A7127 /* LanguageDirection+SemanticContentAttribute.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -5222,6 +5225,7 @@
 				45AD205325938AC300A096A0 /* AdobeAnalyticsType.swift in Sources */,
 				455FF6AB2603DC690028B95B /* CardsNode.swift in Sources */,
 				455FF6F42603DC6A0028B95B /* MobileContentBackgroundImageRenderer.swift in Sources */,
+				45B116C22625FC6D007A7127 /* LanguageDirection+SemanticContentAttribute.swift in Sources */,
 				45AD1FED25938A9800A096A0 /* OpenTutorialCalloutUserDefaultsCache.swift in Sources */,
 				45FF25D1260BD97900D771B6 /* TrainingPageViewModel.swift in Sources */,
 				45AD1B7325938A4F00A096A0 /* OnboardingTutorialProvider.swift in Sources */,

--- a/godtools/App/Features/ToolTraining/ToolTrainingViewModel.swift
+++ b/godtools/App/Features/ToolTraining/ToolTrainingViewModel.swift
@@ -148,7 +148,12 @@ class ToolTrainingViewModel: NSObject, ToolTrainingViewModelType {
     
     func tipPageWillAppear(page: Int, window: UIViewController, safeArea: UIEdgeInsets) -> MobileContentView? {
                 
-        let renderPageResult: Result<MobileContentView, Error> = renderer.renderPage(page: page, window: window, safeArea: safeArea)
+        let renderPageResult: Result<MobileContentView, Error> = renderer.renderPage(
+            page: page,
+            window: window,
+            safeArea: safeArea,
+            primaryRendererLanguage: renderer.language
+        )
         
         switch renderPageResult {
         

--- a/godtools/App/Services/Renderer/MobileContent/Renderer/MobileContentRenderer.swift
+++ b/godtools/App/Services/Renderer/MobileContent/Renderer/MobileContentRenderer.swift
@@ -114,7 +114,7 @@ class MobileContentRenderer {
     
     // MARK: - Rendering
     
-    func renderPage(page: Int, window: UIViewController, safeArea: UIEdgeInsets) -> Result<MobileContentView, Error> {
+    func renderPage(page: Int, window: UIViewController, safeArea: UIEdgeInsets, primaryRendererLanguage: LanguageModel) -> Result<MobileContentView, Error> {
         
         let pageNode: PageNode?
         let parseError: Error?
@@ -156,7 +156,8 @@ class MobileContentRenderer {
                 resourcesCache: resourcesCache,
                 resource: resource,
                 language: language,
-                pageViewFactories: pageViewFactories
+                pageViewFactories: pageViewFactories,
+                primaryRendererLanguage: primaryRendererLanguage
             )
             
             if let renderableView = recurseAndRender(node: pageNode, pageModel: pageModel, containerNode: nil) {

--- a/godtools/App/Services/Renderer/MobileContent/Renderer/MobileContentRendererPageModel.swift
+++ b/godtools/App/Services/Renderer/MobileContent/Renderer/MobileContentRendererPageModel.swift
@@ -20,10 +20,11 @@ class MobileContentRendererPageModel {
     let resource: ResourceModel
     let language: LanguageModel
     let pageViewFactories: [MobileContentPageViewFactoryType]
+    let primaryRendererLanguage: LanguageModel
     
     private weak var weakWindow: UIViewController?
     
-    required init(pageNode: PageNode, page: Int, numberOfPages: Int, window: UIViewController, safeArea: UIEdgeInsets, manifest: MobileContentXmlManifest, resourcesCache: ManifestResourcesCache, resource: ResourceModel, language: LanguageModel, pageViewFactories: [MobileContentPageViewFactoryType]) {
+    required init(pageNode: PageNode, page: Int, numberOfPages: Int, window: UIViewController, safeArea: UIEdgeInsets, manifest: MobileContentXmlManifest, resourcesCache: ManifestResourcesCache, resource: ResourceModel, language: LanguageModel, pageViewFactories: [MobileContentPageViewFactoryType], primaryRendererLanguage: LanguageModel) {
         
         self.pageNode = pageNode
         self.page = page
@@ -36,6 +37,7 @@ class MobileContentRendererPageModel {
         self.resource = resource
         self.language = language
         self.pageViewFactories = pageViewFactories
+        self.primaryRendererLanguage = primaryRendererLanguage
     }
     
     var window: UIViewController {
@@ -46,16 +48,6 @@ class MobileContentRendererPageModel {
         }
         
         return window
-    }
-    
-    var languageDirectionSemanticContentAttribute: UISemanticContentAttribute {
-        
-        switch language.languageDirection {
-            case .leftToRight:
-                return .forceLeftToRight
-            case .rightToLeft:
-                return .forceRightToLeft
-        }
     }
     
     var isLastPage: Bool {

--- a/godtools/App/Services/Renderer/MobileContent/Views/ContentTabs/MobileContentTabsViewModel.swift
+++ b/godtools/App/Services/Renderer/MobileContent/Views/ContentTabs/MobileContentTabsViewModel.swift
@@ -20,6 +20,6 @@ class MobileContentTabsViewModel: MobileContentTabsViewModelType {
     }
     
     var languageDirectionSemanticContentAttribute: UISemanticContentAttribute {
-        return pageModel.languageDirectionSemanticContentAttribute
+        return pageModel.language.languageDirection.semanticContentAttribute
     }
 }

--- a/godtools/App/Services/Renderer/MobileContent/Views/Pages/MobileContentPagesViewModel.swift
+++ b/godtools/App/Services/Renderer/MobileContent/Views/Pages/MobileContentPagesViewModel.swift
@@ -39,6 +39,16 @@ class MobileContentPagesViewModel: NSObject, MobileContentPagesViewModelType {
         super.init()
     }
     
+    var primaryRenderer: MobileContentRenderer {
+        
+        guard let primaryRenderer = renderers.first else {
+            assertionFailure("ViewModel does not contain any renderers.  Should have at least 1 renderer.")
+            return renderers.first!
+        }
+        
+        return primaryRenderer
+    }
+    
     func viewDidFinishLayout(window: UIViewController, safeArea: UIEdgeInsets) {
         
         self.window = window
@@ -84,7 +94,12 @@ class MobileContentPagesViewModel: NSObject, MobileContentPagesViewModelType {
             return nil
         }
         
-        let renderPageResult: Result<MobileContentView, Error> = renderer.renderPage(page: page, window: window, safeArea: safeArea)
+        let renderPageResult: Result<MobileContentView, Error> = renderer.renderPage(
+            page: page,
+            window: window,
+            safeArea: safeArea,
+            primaryRendererLanguage: primaryRenderer.language
+        )
         
         switch renderPageResult {
         

--- a/godtools/App/Services/Renderer/Tool/Views/CallToAction/ToolPageCallToActionView.swift
+++ b/godtools/App/Services/Renderer/Tool/Views/CallToAction/ToolPageCallToActionView.swift
@@ -44,6 +44,7 @@ class ToolPageCallToActionView: MobileContentView {
         let nib: UINib = UINib(nibName: String(describing: ToolPageCallToActionView.self), bundle: nil)
         let contents: [Any]? = nib.instantiate(withOwner: self, options: nil)
         if let rootNibView = (contents as? [UIView])?.first {
+            rootNibView.semanticContentAttribute = viewModel.languageDirectionSemanticContentAttribute
             addSubview(rootNibView)
             rootNibView.backgroundColor = .clear
             rootNibView.frame = bounds
@@ -56,13 +57,12 @@ class ToolPageCallToActionView: MobileContentView {
     }
     
     private func setupBinding() {
-        
-        semanticContentAttribute = viewModel.languageDirectionSemanticContentAttribute
-        
+                
         titleLabel.text = viewModel.title
         titleLabel.textColor = viewModel.titleColor
+        titleLabel.textAlignment = viewModel.titleTextAlignment
         
-        nextButton.semanticContentAttribute = viewModel.languageDirectionSemanticContentAttribute
+        nextButton.semanticContentAttribute = viewModel.nextButtonSemanticContentAttribute
         nextButton.setImage(viewModel.nextButtonImage, for: .normal)
         nextButton.setImageColor(color: viewModel.nextButtonColor)
     }

--- a/godtools/App/Services/Renderer/Tool/Views/CallToAction/ToolPageCallToActionViewModel.swift
+++ b/godtools/App/Services/Renderer/Tool/Views/CallToAction/ToolPageCallToActionViewModel.swift
@@ -22,7 +22,7 @@ class ToolPageCallToActionViewModel: ToolPageCallToActionViewModelType {
     }
     
     var languageDirectionSemanticContentAttribute: UISemanticContentAttribute {
-        return pageModel.languageDirectionSemanticContentAttribute
+        return pageModel.primaryRendererLanguage.languageDirection.semanticContentAttribute
     }
     
     var title: String? {
@@ -31,6 +31,16 @@ class ToolPageCallToActionViewModel: ToolPageCallToActionViewModelType {
     
     var titleFont: UIFont {
         return fontService.getFont(size: 18, weight: .regular)
+    }
+    
+    var titleTextAlignment: NSTextAlignment {
+        
+        switch pageModel.language.languageDirection {
+        case .leftToRight:
+            return .left
+        case .rightToLeft:
+            return .right
+        }
     }
     
     var titleColor: UIColor {
@@ -52,5 +62,9 @@ class ToolPageCallToActionViewModel: ToolPageCallToActionViewModelType {
         }
         
         return buttonImage.imageFlippedForRightToLeftLayoutDirection()
+    }
+    
+    var nextButtonSemanticContentAttribute: UISemanticContentAttribute {
+        return languageDirectionSemanticContentAttribute
     }
 }

--- a/godtools/App/Services/Renderer/Tool/Views/CallToAction/ToolPageCallToActionViewModelType.swift
+++ b/godtools/App/Services/Renderer/Tool/Views/CallToAction/ToolPageCallToActionViewModelType.swift
@@ -13,7 +13,9 @@ protocol ToolPageCallToActionViewModelType {
     var languageDirectionSemanticContentAttribute: UISemanticContentAttribute { get }
     var title: String? { get }
     var titleFont: UIFont { get }
+    var titleTextAlignment: NSTextAlignment { get }
     var titleColor: UIColor { get }
     var nextButtonColor: UIColor { get }
     var nextButtonImage: UIImage? { get }
+    var nextButtonSemanticContentAttribute: UISemanticContentAttribute { get }
 }

--- a/godtools/App/Services/Renderer/Tool/Views/Card/ToolPageCardViewModel.swift
+++ b/godtools/App/Services/Renderer/Tool/Views/Card/ToolPageCardViewModel.swift
@@ -152,7 +152,7 @@ class ToolPageCardViewModel: ToolPageCardViewModelType {
     }
     
     var languageDirectionSemanticContentAttribute: UISemanticContentAttribute {
-        return pageModel.languageDirectionSemanticContentAttribute
+        return pageModel.language.languageDirection.semanticContentAttribute
     }
     
     var dismissListeners: [String] {

--- a/godtools/App/Services/Renderer/Tool/Views/Header/ToolPageHeaderViewModel.swift
+++ b/godtools/App/Services/Renderer/Tool/Views/Header/ToolPageHeaderViewModel.swift
@@ -36,7 +36,7 @@ class ToolPageHeaderViewModel: ToolPageHeaderViewModelType {
     }
     
     var languageDirectionSemanticContentAttribute: UISemanticContentAttribute {
-        return pageModel.languageDirectionSemanticContentAttribute
+        return pageModel.language.languageDirection.semanticContentAttribute
     }
     
     var backgroundColor: UIColor {

--- a/godtools/App/Share/Extensions/LanguageDirection+SemanticContentAttribute.swift
+++ b/godtools/App/Share/Extensions/LanguageDirection+SemanticContentAttribute.swift
@@ -1,0 +1,22 @@
+//
+//  LanguageDirection+SemanticContentAttribute.swift
+//  godtools
+//
+//  Created by Levi Eggert on 4/13/21.
+//  Copyright © 2021 Cru. All rights reserved.
+//
+
+import UIKit
+
+extension LanguageDirection {
+    
+    var semanticContentAttribute: UISemanticContentAttribute {
+        
+        switch self {
+            case .leftToRight:
+                return .forceLeftToRight
+            case .rightToLeft:
+                return .forceRightToLeft
+        }
+    }
+}


### PR DESCRIPTION
A tool's call to action arrow is now placed based on the primary language.  So if primary language is a right to left language, it is placed on the left side of the device and points to the left.  If a primary language is left to right the arrow is placed on the right side of the screen and points right.  Basically it will point in the direction of page navigation.