### PR TITLE
GT-1093 Support for hidden pages in content renderer

### DIFF
--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -857,6 +857,7 @@
 		45FA43A3260983870056FD49 /* MobileContentTabViewModelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45FA43A2260983870056FD49 /* MobileContentTabViewModelType.swift */; };
 		45FA696C24251CA00006878C /* TutorialLanguageAvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45FA696B24251CA00006878C /* TutorialLanguageAvailabilityTests.swift */; };
 		45FA696F24251D360006878C /* MockSupportedLanguages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45FA6960242517590006878C /* MockSupportedLanguages.swift */; };
+		45FEAFC3264462A500775894 /* MobileContentRendererType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45FEAFC2264462A500775894 /* MobileContentRendererType.swift */; };
 		45FF259C260BB95F00D771B6 /* MobileContentPagePositionsType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45FF259B260BB95F00D771B6 /* MobileContentPagePositionsType.swift */; };
 		45FF25A2260BB9DB00D771B6 /* MobileContentPagePositions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45FF25A1260BB9DB00D771B6 /* MobileContentPagePositions.swift */; };
 		45FF25AD260BBB9800D771B6 /* ToolPagePositions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45FF25AC260BBB9800D771B6 /* ToolPagePositions.swift */; };
@@ -1762,6 +1763,7 @@
 		45FA43A2260983870056FD49 /* MobileContentTabViewModelType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileContentTabViewModelType.swift; sourceTree = "<group>"; };
 		45FA6960242517590006878C /* MockSupportedLanguages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSupportedLanguages.swift; sourceTree = "<group>"; };
 		45FA696B24251CA00006878C /* TutorialLanguageAvailabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TutorialLanguageAvailabilityTests.swift; sourceTree = "<group>"; };
+		45FEAFC2264462A500775894 /* MobileContentRendererType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileContentRendererType.swift; sourceTree = "<group>"; };
 		45FF259B260BB95F00D771B6 /* MobileContentPagePositionsType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileContentPagePositionsType.swift; sourceTree = "<group>"; };
 		45FF25A1260BB9DB00D771B6 /* MobileContentPagePositions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileContentPagePositions.swift; sourceTree = "<group>"; };
 		45FF25AC260BBB9800D771B6 /* ToolPagePositions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolPagePositions.swift; sourceTree = "<group>"; };
@@ -2228,6 +2230,7 @@
 				4555C3B326069C59007E61BE /* MobileContentPageViewFactory.swift */,
 				4555C3D92606A1CE007E61BE /* MobileContentPageViewFactoryType.swift */,
 				455FF6282603DC690028B95B /* MobileContentRenderer.swift */,
+				45FEAFC2264462A500775894 /* MobileContentRendererType.swift */,
 				4555C3ED2606AAFA007E61BE /* MobileContentRendererPageModel.swift */,
 				455FF6292603DC690028B95B /* MobileContentRendererVersion.swift */,
 				45FF25B6260BBF8500D771B6 /* Events */,
@@ -5962,6 +5965,7 @@
 				45CBA059261FDFD90036BEB3 /* LessonPageView.swift in Sources */,
 				45AD1B1125938A4E00A096A0 /* ArticleCategoryCell.swift in Sources */,
 				45AD20B125938EE500A096A0 /* FileCacheLocationType.swift in Sources */,
+				45FEAFC3264462A500775894 /* MobileContentRendererType.swift in Sources */,
 				45AD1BAF25938A4F00A096A0 /* OnboardingFlow.swift in Sources */,
 				45AD1B8725938A4F00A096A0 /* OnboardingTutorialUsageCell.swift in Sources */,
 				45AD1AA425938A4E00A096A0 /* SupportedLanguagesType.swift in Sources */,

--- a/godtools/App/Features/Lessons/Lesson/LessonViewModel.swift
+++ b/godtools/App/Features/Lessons/Lesson/LessonViewModel.swift
@@ -14,14 +14,14 @@ class LessonViewModel: MobileContentPagesViewModel, LessonViewModelType {
     
     let progress: ObservableValue<AnimatableValue<CGFloat>> = ObservableValue(value: AnimatableValue(value: 0, animated: false))
     
-    required init(flowDelegate: FlowDelegate, renderers: [MobileContentRenderer], resource: ResourceModel, primaryLanguage: LanguageModel, page: Int?) {
+    required init(flowDelegate: FlowDelegate, renderers: [MobileContentRendererType], resource: ResourceModel, primaryLanguage: LanguageModel, page: Int?) {
         
         self.flowDelegate = flowDelegate
         
         super.init(flowDelegate: flowDelegate, renderers: renderers, primaryLanguage: primaryLanguage, page: page)
     }
     
-    required init(flowDelegate: FlowDelegate, renderers: [MobileContentRenderer], primaryLanguage: LanguageModel, page: Int?) {
+    required init(flowDelegate: FlowDelegate, renderers: [MobileContentRendererType], primaryLanguage: LanguageModel, page: Int?) {
         fatalError("init(flowDelegate:renderers:primaryLanguage:page:) has not been implemented")
     }
     

--- a/godtools/App/Features/Tool/ToolViewModel.swift
+++ b/godtools/App/Features/Tool/ToolViewModel.swift
@@ -26,7 +26,7 @@ class ToolViewModel: MobileContentPagesViewModel, ToolViewModelType {
     
     private weak var flowDelegate: FlowDelegate?
     
-    required init(flowDelegate: FlowDelegate, renderers: [MobileContentRenderer], resource: ResourceModel, primaryLanguage: LanguageModel, tractRemoteSharePublisher: TractRemoteSharePublisher, tractRemoteShareSubscriber: TractRemoteShareSubscriber, localizationServices: LocalizationServices, fontService: FontService, viewsService: ViewsService, analytics: AnalyticsContainer, toolOpenedAnalytics: ToolOpenedAnalytics, liveShareStream: String?, trainingTipsEnabled: Bool, page: Int?) {
+    required init(flowDelegate: FlowDelegate, renderers: [MobileContentRendererType], resource: ResourceModel, primaryLanguage: LanguageModel, tractRemoteSharePublisher: TractRemoteSharePublisher, tractRemoteShareSubscriber: TractRemoteShareSubscriber, localizationServices: LocalizationServices, fontService: FontService, viewsService: ViewsService, analytics: AnalyticsContainer, toolOpenedAnalytics: ToolOpenedAnalytics, liveShareStream: String?, trainingTipsEnabled: Bool, page: Int?) {
         
         self.flowDelegate = flowDelegate
         self.resource = resource
@@ -60,7 +60,7 @@ class ToolViewModel: MobileContentPagesViewModel, ToolViewModelType {
         setupBinding()
     }
     
-    required init(flowDelegate: FlowDelegate, renderers: [MobileContentRenderer], primaryLanguage: LanguageModel, page: Int?) {
+    required init(flowDelegate: FlowDelegate, renderers: [MobileContentRendererType], primaryLanguage: LanguageModel, page: Int?) {
         fatalError("init(flowDelegate:renderers:primaryLanguage:page:) has not been implemented")
     }
     
@@ -99,7 +99,7 @@ class ToolViewModel: MobileContentPagesViewModel, ToolViewModelType {
         return nil
     }
     
-    private func getRenderer(language: LanguageModel) -> MobileContentRenderer? {
+    private func getRenderer(language: LanguageModel) -> MobileContentRendererType? {
         for renderer in renderers {
             if renderer.language.code.lowercased() == language.code.lowercased() {
                 return renderer

--- a/godtools/App/Flows/ToolsFlow.swift
+++ b/godtools/App/Flows/ToolsFlow.swift
@@ -575,7 +575,7 @@ class ToolsFlow: Flow {
             fontService: fontService
         )
         
-        var renderers: [MobileContentRenderer] = Array()
+        var renderers: [MobileContentRendererType] = Array()
         
         renderers.append(primaryRenderer)
         

--- a/godtools/App/Services/Renderer/Lessons/Views/Page/LessonPageView.swift
+++ b/godtools/App/Services/Renderer/Lessons/Views/Page/LessonPageView.swift
@@ -86,6 +86,8 @@ class LessonPageView: MobileContentPageView {
     
     override func didReceiveEvents(events: [String]) {
         
+        super.didReceiveEvents(events: events)
+        
         for event in events {
             if viewModel.manifestDismissListeners.contains(event) {
                 delegate?.lessonPageCloseLessonTapped(lessonPage: self)

--- a/godtools/App/Services/Renderer/MobileContent/Renderer/MobileContentRendererPageModel.swift
+++ b/godtools/App/Services/Renderer/MobileContent/Renderer/MobileContentRendererPageModel.swift
@@ -12,7 +12,7 @@ class MobileContentRendererPageModel {
     
     let pageNode: PageNode
     let page: Int
-    let numberOfPages: Int
+    let isLastPage: Bool
     let pageColors: MobileContentPageColors
     let safeArea: UIEdgeInsets
     let manifest: MobileContentXmlManifest
@@ -24,11 +24,11 @@ class MobileContentRendererPageModel {
     
     private weak var weakWindow: UIViewController?
     
-    required init(pageNode: PageNode, page: Int, numberOfPages: Int, window: UIViewController, safeArea: UIEdgeInsets, manifest: MobileContentXmlManifest, resourcesCache: ManifestResourcesCache, resource: ResourceModel, language: LanguageModel, pageViewFactories: [MobileContentPageViewFactoryType], primaryRendererLanguage: LanguageModel) {
+    required init(pageNode: PageNode, page: Int, isLastPage: Bool, window: UIViewController, safeArea: UIEdgeInsets, manifest: MobileContentXmlManifest, resourcesCache: ManifestResourcesCache, resource: ResourceModel, language: LanguageModel, pageViewFactories: [MobileContentPageViewFactoryType], primaryRendererLanguage: LanguageModel) {
         
         self.pageNode = pageNode
         self.page = page
-        self.numberOfPages = numberOfPages
+        self.isLastPage = isLastPage
         self.pageColors = MobileContentPageColors(pageNode: pageNode, manifest: manifest)
         self.weakWindow = window
         self.safeArea = safeArea
@@ -48,9 +48,5 @@ class MobileContentRendererPageModel {
         }
         
         return window
-    }
-    
-    var isLastPage: Bool {
-        return page == numberOfPages - 1
     }
 }

--- a/godtools/App/Services/Renderer/MobileContent/Renderer/MobileContentRendererType.swift
+++ b/godtools/App/Services/Renderer/MobileContent/Renderer/MobileContentRendererType.swift
@@ -1,0 +1,22 @@
+//
+//  MobileContentRendererType.swift
+//  godtools
+//
+//  Created by Levi Eggert on 5/6/21.
+//  Copyright © 2021 Cru. All rights reserved.
+//
+
+import Foundation
+
+protocol MobileContentRendererType {
+    
+    var manifest: MobileContentXmlManifest { get }
+    var resource: ResourceModel { get }
+    var language: LanguageModel { get }
+    var pages: ObservableValue<[PageNode]> { get }
+    
+    func getPageForListenerEvents(events: [String]) -> Int?
+    func getPageNode(page: Int) -> PageNode?
+    func renderPageFromAllPageNodes(page: Int, window: UIViewController, safeArea: UIEdgeInsets, primaryRendererLanguage: LanguageModel) -> Result<MobileContentView, Error>
+    func renderPageFromPageNodes(pageNodes: [PageNode], page: Int, window: UIViewController, safeArea: UIEdgeInsets, primaryRendererLanguage: LanguageModel) -> Result<MobileContentView, Error>
+}

--- a/godtools/App/Services/Renderer/MobileContent/Views/Pages/MobileContentPagesView.swift
+++ b/godtools/App/Services/Renderer/MobileContent/Views/Pages/MobileContentPagesView.swift
@@ -90,6 +90,13 @@ class MobileContentPagesView: UIViewController {
                 self?.startNavigation(navigationModel: navigationModel)
             }
         }
+        
+        viewModel.pagesRemoved.addObserver(self) { [weak self] (indexPaths: [IndexPath]) in
+            guard !indexPaths.isEmpty else {
+                return
+            }
+            self?.pageNavigationView.deletePagesAt(indexPaths: indexPaths)
+        }
     }
     
     func setupLayout() {
@@ -301,6 +308,8 @@ extension MobileContentPagesView: PageNavigationCollectionViewDelegate {
         if let contentPageCell = pageCell as? MobileContentPageCell {
             contentPageCell.mobileContentView?.viewDidDisappear()
         }
+        
+        viewModel.pageDidDisappear(page: page)
     }
     
     func pageNavigationDidScrollPage(pageNavigation: PageNavigationCollectionView, page: Int) {
@@ -313,10 +322,7 @@ extension MobileContentPagesView: PageNavigationCollectionViewDelegate {
 extension MobileContentPagesView: MobileContentPageViewDelegate {
     
     func pageViewDidReceiveEvents(pageView: MobileContentPageView, events: [String]) {
-        
-        if let page = viewModel.getPageForListenerEvents(events: events) {
-            pageNavigationView.scrollToPage(page: page, animated: true)
-        }
+        viewModel.pageDidReceiveEvents(events: events)
     }
     
     func pageViewDidReceiveUrl(pageView: MobileContentPageView, url: String) {

--- a/godtools/App/Services/Renderer/MobileContent/Views/Pages/MobileContentPagesViewModelType.swift
+++ b/godtools/App/Services/Renderer/MobileContent/Views/Pages/MobileContentPagesViewModelType.swift
@@ -14,10 +14,12 @@ protocol MobileContentPagesViewModelType {
     var pageNavigationSemanticContentAttribute: UISemanticContentAttribute { get }
     var rendererWillChangeSignal: Signal { get }
     var pageNavigation: ObservableValue<MobileContentPagesNavigationModel?> { get }
+    var pagesRemoved: ObservableValue<[IndexPath]> { get }
     
     func viewDidFinishLayout(window: UIViewController, safeArea: UIEdgeInsets)
-    func getPageForListenerEvents(events: [String]) -> Int?
     func pageWillAppear(page: Int) -> MobileContentView?
+    func pageDidDisappear(page: Int)
+    func pageDidReceiveEvents(events: [String])
     func buttonWithUrlTapped(url: String)
     func trainingTipTapped(event: TrainingTipEvent)
     func errorOccurred(error: MobileContentErrorViewModel)

--- a/godtools/App/Services/Renderer/MobileContent/XmlNodeParser/Nodes/PageNode.swift
+++ b/godtools/App/Services/Renderer/MobileContent/XmlNodeParser/Nodes/PageNode.swift
@@ -22,6 +22,7 @@ class PageNode: MobileContentXmlNode, BackgroundImageNodeType {
     let backgroundImageAlign: [String]
     let backgroundImageScaleType: String
     let cardTextColor: String?
+    let hidden: String?
     let listeners: [String]
     let primaryColor: String?
     let primaryTextColor: String?
@@ -43,6 +44,7 @@ class PageNode: MobileContentXmlNode, BackgroundImageNodeType {
         }
         backgroundImageScaleType = attributes["background-image-scale-type"]?.text ?? MobileContentBackgroundImageScaleType.fillHorizontally.rawValue
         cardTextColor = attributes["card-text-color"]?.text
+        hidden = attributes["hidden"]?.text
         listeners = attributes["listeners"]?.text.components(separatedBy: " ") ?? []
         primaryColor = attributes["primary-color"]?.text
         primaryTextColor = attributes["primary-text-color"]?.text
@@ -70,6 +72,10 @@ class PageNode: MobileContentXmlNode, BackgroundImageNodeType {
         else if let modalsNode = childNode as? ModalsNode {
             self.modalsNode = modalsNode
         }
+    }
+    
+    var isHidden: Bool {
+        return hidden == "true"
     }
     
     func getBackgroundColor() -> MobileContentRGBAColor? {

--- a/godtools/App/Share/Views/PageNavigationCollectionView/PageNavigationCollectionView.swift
+++ b/godtools/App/Share/Views/PageNavigationCollectionView/PageNavigationCollectionView.swift
@@ -211,6 +211,30 @@ class PageNavigationCollectionView: UIView, NibBased {
         collectionView.contentInsetAdjustmentBehavior = contentInsetAdjustmentBehavior
     }
     
+    func deletePagesAt(indexPaths: [IndexPath]) {
+                
+        guard collectionView.numberOfItems(inSection: 0) > 0 else {
+            return
+        }
+        
+        let currentPage: Int = self.currentPage
+        var pageNumberForDeletedPages: Int = currentPage
+        
+        for indexPath in indexPaths {
+            if indexPath.item < currentPage {
+                pageNumberForDeletedPages -= 1
+            }
+        }
+        
+        UIView.performWithoutAnimation {
+            collectionView.performBatchUpdates({
+                collectionView.deleteItems(at: indexPaths)
+            }, completion: nil)
+        }
+        
+        collectionView.scrollToItem(at: IndexPath(item: pageNumberForDeletedPages, section: 0), at: .centeredHorizontally, animated: false)
+    }
+    
     func getIndexPathForPageCell(pageCell: UICollectionViewCell) -> IndexPath? {
         return collectionView.indexPath(for: pageCell)
     }


### PR DESCRIPTION
The MobileContentPagesViewModel will now display visible page nodes, or page nodes that do not have the hidden=true attribute.
I also began adding support for triggering a hidden page listener which shows the page, however, this will be fully implemented in a separate task.
The main thing for this task is that page nodes with hidden=true do not show up in a Lesson.