### PR TITLE
GT-1127 Referencing receipt so it can get properly destroyed

### DIFF
--- a/godtools/App/Features/Tools/Views/Tool/ToolItemInitialDownloadProgress.swift
+++ b/godtools/App/Features/Tools/Views/Tool/ToolItemInitialDownloadProgress.swift
@@ -44,6 +44,8 @@ extension ToolItemInitialDownloadProgress {
         
         destroyDownloadAttachmentsReceipt()
         
+        downloadAttachmentsReceipt = receipt
+        
         receipt.progressObserver.addObserver(self) { [weak self] (progress: Double) in
             DispatchQueue.main.async { [weak self] in
                 self?.attachmentsDownloadProgress.accept(value: progress)
@@ -63,15 +65,29 @@ extension ToolItemInitialDownloadProgress {
                 }
             }
         }
+        
+        receipt.completedSignal.addObserver(self) { [weak self] in
+            DispatchQueue.main.async { [weak self] in
+                self?.destroyDownloadAttachmentsReceipt()
+            }
+        }
     }
     
     private func observeDownloadResourceTranslationsReceipt(receipt: DownloadTranslationsReceipt) {
         
         destroyDownloadResourceTranslationsReceipt()
         
+        downloadResourceTranslationsReceipt = receipt
+        
         receipt.progressObserver.addObserver(self) { [weak self] (progress: Double) in
             DispatchQueue.main.async { [weak self] in
                 self?.translationDownloadProgress.accept(value: progress)
+            }
+        }
+        
+        receipt.completedSignal.addObserver(self) { [weak self] in
+            DispatchQueue.main.async { [weak self] in
+                self?.destroyDownloadResourceTranslationsReceipt()
             }
         }
     }


### PR DESCRIPTION
Receipts weren't getting referenced so they were never getting cleaned up. I believe this should fix the crash that was occurring.