### PR TITLE
GT-1197 Upgraded to Xcode 12.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: swift
 os: osx
-osx_image: xcode12.3
+osx_image: xcode12.5
 xcode_project: godtools.xcworkspace
 branches:
   only:

--- a/Podfile
+++ b/Podfile
@@ -23,7 +23,7 @@ target 'godtools' do
     pod 'FirebaseCrashlytics', '7.3.0'
     pod 'Fuzi', '~> 3.1.1'
     pod 'lottie-ios', '~> 3.1.8'
-    pod 'RealmSwift', '~> 10.5.0'
+    pod 'RealmSwift', '~> 10.7.4'
     pod 'SnowplowTracker', '~> 1.3'
     pod 'SSZipArchive', '~> 2.2.2'
     pod 'Starscream', '~> 4.0.0'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - AdobeMobileSDK (4.21.0):
-    - AdobeMobileSDK/iOS (= 4.21.0)
-  - AdobeMobileSDK/iOS (4.21.0)
+  - AdobeMobileSDK (4.21.2):
+    - AdobeMobileSDK/iOS (= 4.21.2)
+  - AdobeMobileSDK/iOS (4.21.2)
   - AppAuth (0.92.0)
   - AppsFlyerFramework (6.0.8)
   - FBSDKCoreKit (8.0.0):
@@ -10,7 +10,7 @@ PODS:
   - FBSDKCoreKit/Basics (8.0.0)
   - FBSDKCoreKit/Core (8.0.0):
     - FBSDKCoreKit/Basics
-  - FirebaseABTesting (7.3.0):
+  - FirebaseABTesting (7.11.0):
     - FirebaseCore (~> 7.0)
   - FirebaseAnalytics (7.3.0):
     - FirebaseCore (~> 7.0)
@@ -42,7 +42,7 @@ PODS:
     - FirebaseInstallations (~> 7.0)
     - GoogleUtilities/Environment (~> 7.0)
     - nanopb (~> 2.30906.0)
-  - FirebaseInstallations (7.3.0):
+  - FirebaseInstallations (7.11.0):
     - FirebaseCore (~> 7.0)
     - GoogleUtilities/Environment (~> 7.0)
     - GoogleUtilities/UserDefaults (~> 7.0)
@@ -66,24 +66,24 @@ PODS:
     - FirebaseAnalytics (~> 7.0)
     - GoogleAnalytics (~> 3.17)
     - GoogleUtilitiesLegacy (~> 1.3)
-  - GoogleUtilities/AppDelegateSwizzler (7.1.1):
+  - GoogleUtilities/AppDelegateSwizzler (7.4.1):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
-  - GoogleUtilities/Environment (7.1.1):
+  - GoogleUtilities/Environment (7.4.1):
     - PromisesObjC (~> 1.2)
-  - GoogleUtilities/Logger (7.1.1):
+  - GoogleUtilities/Logger (7.4.1):
     - GoogleUtilities/Environment
-  - GoogleUtilities/MethodSwizzler (7.1.1):
+  - GoogleUtilities/MethodSwizzler (7.4.1):
     - GoogleUtilities/Logger
-  - GoogleUtilities/Network (7.1.1):
+  - GoogleUtilities/Network (7.4.1):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
     - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (7.1.1)"
-  - GoogleUtilities/Reachability (7.1.1):
+  - "GoogleUtilities/NSData+zlib (7.4.1)"
+  - GoogleUtilities/Reachability (7.4.1):
     - GoogleUtilities/Logger
-  - GoogleUtilities/UserDefaults (7.1.1):
+  - GoogleUtilities/UserDefaults (7.4.1):
     - GoogleUtilities/Logger
   - GoogleUtilitiesLegacy (1.3.2):
     - GoogleSymbolUtilities (~> 1.1)
@@ -101,14 +101,14 @@ PODS:
     - nanopb/encode (= 2.30906.0)
   - nanopb/decode (2.30906.0)
   - nanopb/encode (2.30906.0)
-  - PromisesObjC (1.2.11)
-  - Realm (10.5.0):
-    - Realm/Headers (= 10.5.0)
-  - Realm/Headers (10.5.0)
-  - RealmSwift (10.5.0):
-    - Realm (= 10.5.0)
+  - PromisesObjC (1.2.12)
+  - Realm (10.7.6):
+    - Realm/Headers (= 10.7.6)
+  - Realm/Headers (10.7.6)
+  - RealmSwift (10.7.6):
+    - Realm (= 10.7.6)
   - Result (5.0.0)
-  - SnowplowTracker (1.6.1):
+  - SnowplowTracker (1.7.1):
     - FMDB (~> 2.6)
   - SSZipArchive (2.2.3)
   - Starscream (4.0.4)
@@ -117,7 +117,7 @@ PODS:
     - GTMAppAuth
     - Result
   - TTTAttributedLabel (2.0.0)
-  - YoutubePlayer-in-WKWebView (0.3.4)
+  - YoutubePlayer-in-WKWebView (0.3.5)
 
 DEPENDENCIES:
   - AdobeMobileSDK (~> 4.19)
@@ -132,7 +132,7 @@ DEPENDENCIES:
   - GoogleTagManager (~> 7.2.0)
   - GTMAppAuth (= 0.7.0)
   - lottie-ios (~> 3.1.8)
-  - RealmSwift (~> 10.5.0)
+  - RealmSwift (~> 10.7.4)
   - SnowplowTracker (~> 1.3)
   - SSZipArchive (~> 2.2.2)
   - Starscream (~> 4.0.0)
@@ -182,17 +182,17 @@ SPEC REPOS:
     - YoutubePlayer-in-WKWebView
 
 SPEC CHECKSUMS:
-  AdobeMobileSDK: d1ca0f19d381e977f8c2a8f277c5889df00b479b
+  AdobeMobileSDK: 0072f212876db078ffefdf42c5e5d6537dd434cb
   AppAuth: 3f4f1d6d85ad631d0bbf15ffcdc10c447face97a
   AppsFlyerFramework: 57fb1fc68a5b8103353ce94d6e57861cbc4a55c3
   FBSDKCoreKit: 9d27fe97a2fa2abe5eeefea8240e837623ab88e0
-  FirebaseABTesting: 303b5366c0c75be479424e8935e2f475cf24ce21
+  FirebaseABTesting: e66f1f80747792630d9b292966de206d5df9853b
   FirebaseAnalytics: 2580c2d62535ae7b644143d48941fcc239ea897a
   FirebaseCore: 4d3c72622ce0e2106aaa07bb4b2935ba2c370972
   FirebaseCoreDiagnostics: d50e11039e5984d92c8a512be2395f13df747350
   FirebaseCrashlytics: d31325312c92e2cb2f0386d589b9aa44e303d99b
   FirebaseInAppMessaging: 9436b16bbd1fd02bcb50c25ed485150b3269d611
-  FirebaseInstallations: 971df89b48ae5ee4cc2bf6935f3857a525d28550
+  FirebaseInstallations: a58d4f72ec5861840b84df489f2668d970df558a
   FMDB: 2ce00b547f966261cd18927a3ddb07cb6f3db82a
   Fuzi: 4c10d6449c0b49a85cd75b13844c559c0fc71220
   GoogleAnalytics: f42cc53a87a51fe94334821868d9c8481ff47a7b
@@ -201,24 +201,24 @@ SPEC CHECKSUMS:
   GoogleDataTransport: 116c84c4bdeb76be2a7a46de51244368f9794eab
   GoogleSymbolUtilities: 631ee17048aa5e9ab133470d768ea997a5ef9b96
   GoogleTagManager: 9d8981519a985e37d5d86e46b9a58d404094a814
-  GoogleUtilities: 3dc4ff0d5e4840e2fa8eef0889620e8c33d4218c
+  GoogleUtilities: f8a43108b38a68eebe8b3540e1f4f2d28843ce20
   GoogleUtilitiesLegacy: 5501bedec1646bd284286eb5fc9453f7e23a12f4
   GTMAppAuth: 8d724be29ab8f2f6d35b2bf929d76340c9d1f1b1
   GTMSessionFetcher: b3503b20a988c4e20cc189aa798fd18220133f52
   lottie-ios: 3a3758ef5a008e762faec9c9d50a39842f26d124
   nanopb: 1bf24dd71191072e120b83dd02d08f3da0d65e53
-  PromisesObjC: 8c196f5a328c2cba3e74624585467a557dcb482f
-  Realm: e1c22c3d83b229afb70ebc10e1771c91e9542d12
-  RealmSwift: 6fc078d9d3fd7e58c71bfdbb694e252462f112a5
+  PromisesObjC: 3113f7f76903778cf4a0586bd1ab89329a0b7b97
+  Realm: ed860452717c8db8f4bf832b6807f7f2ce708839
+  RealmSwift: e31c4ddbcc42ac879313d656b86f9ca539f6f4f4
   Result: ed341d2f236af425b803e690e9bd8fd0a0cb7c5a
-  SnowplowTracker: f274be1b224ddc0ec58ee1f23c232fa9738bbb75
+  SnowplowTracker: c393b26c456142ad5a78f4e4d771c71cb194f06c
   SSZipArchive: 62d4947b08730e4cda640473b0066d209ff033c9
   Starscream: 5178aed56b316f13fa3bc55694e583d35dd414d9
   SWXMLHash: 9cc0c2e4807926c74377724aa8722ee5707a0485
   TheKeyOAuthSwift: e5e9ba7c9e9a22b4ddfe586c6b30cb91463410c0
   TTTAttributedLabel: 8cffe8e127e4e82ff3af1e5386d4cd0ad000b656
-  YoutubePlayer-in-WKWebView: af2f5929fc78882d94bfdfeea999b661b78d9717
+  YoutubePlayer-in-WKWebView: cfbf46da51d7370662a695a8f351e5fa1d3e1008
 
-PODFILE CHECKSUM: 675d4c12c4c5f7ac5a287d84ec5f41afe322d905
+PODFILE CHECKSUM: 636027c8162f43876470883785dc5ee3b20faf9f
 
 COCOAPODS: 1.10.0


### PR DESCRIPTION
Hey @reldredge71  @gyasistory, upgrading Xcode to 12.5 so we can start working off of iOS 14.5.  Will be doing the same for MPDX.