### PR TITLE
Remove pageModel.isLastPage from hidesNextButton logic

### DIFF
--- a/godtools/App/Services/Renderer/Tool/Views/Card/ToolPageCardViewModel.swift
+++ b/godtools/App/Services/Renderer/Tool/Views/Card/ToolPageCardViewModel.swift
@@ -51,7 +51,7 @@ class ToolPageCardViewModel: ToolPageCardViewModelType {
             let isLastCard: Bool = cardPosition >= numberOfCards - 1
             hidesCardPositionLabel = false
             hidesPreviousButton = false
-            hidesNextButton = (pageModel.isLastPage || isLastCard) ? true : false
+            hidesNextButton = isLastCard ? true : false
         }
         
         if let analyticsEventsNode = cardNode.analyticsEventsNode {


### PR DESCRIPTION
We should only hide the "Next" button on the last card on each page.  `isLastPage` doesn't factor into the logic here.