### PR TITLE
GT-1298 Fix choose language visibility

### DIFF
--- a/godtools/App/Features/Tools/ToolsMenuView.swift
+++ b/godtools/App/Features/Tools/ToolsMenuView.swift
@@ -96,11 +96,7 @@ class ToolsMenuView: UIViewController {
         viewModel.languageTapped()
     }
     
-    private func navigateToToolsListForToolbarItem(toolbarItem: ToolsMenuToolbarView.ToolbarItemView, animated: Bool) {
-        
-        guard let page = toolbarView.toolbarItemViews.firstIndex(of: toolbarItem) else {
-            return
-        }
+    private func didChangeToolbarItem(toolbarItem: ToolsMenuToolbarView.ToolbarItemView) {
         
         let hidesChooseLanguageButton: Bool
         
@@ -115,6 +111,15 @@ class ToolsMenuView: UIViewController {
         
         setChooseLanguageButtonHidden(hidden: hidesChooseLanguageButton)
         
+        toolbarView.setSelectedToolbarItem(toolbarItem: toolbarItem)
+    }
+    
+    private func navigateToToolsListForToolbarItem(toolbarItem: ToolsMenuToolbarView.ToolbarItemView, animated: Bool) {
+        
+        guard let page = toolbarView.toolbarItemViews.firstIndex(of: toolbarItem) else {
+            return
+        }
+                
         if animated {
             isAnimatingNavigationToToolsList = true
         }
@@ -124,7 +129,7 @@ class ToolsMenuView: UIViewController {
             animated: animated
         )
         
-        toolbarView.setSelectedToolbarItem(toolbarItem: toolbarItem)
+        didChangeToolbarItem(toolbarItem: toolbarItem)
     }
     
     private func setChooseLanguageButtonHidden(hidden: Bool) {
@@ -206,7 +211,7 @@ extension ToolsMenuView: UIScrollViewDelegate {
            !isAnimatingNavigationToToolsList,
            let mostVisibleItem = getMostVisibleToolsList() {
             
-            toolbarView.setSelectedToolbarItem(toolbarItem: mostVisibleItem)
+            didChangeToolbarItem(toolbarItem: mostVisibleItem)
         }
     }
     


### PR DESCRIPTION
The choose language button at the top right of the navigation bar is supposed to be hidden when viewing the lessons list and visible when viewing favorites and all tools lists.  This works as long as you tap the Lessons, Favorites, and All Tools navigation buttons at the bottom of the screen, however, if you pan horizontally between lists the visibility will not update.  This fix addresses that.