### PR TITLE
GT-1311 Remove underline showing on navigation bar when loading a tool or lesson

### DIFF
--- a/godtools/App/Share/Extensions/UINavigationBar+Appearance.swift
+++ b/godtools/App/Share/Extensions/UINavigationBar+Appearance.swift
@@ -66,9 +66,7 @@ extension UINavigationBar {
         if #available(iOS 13, *) {
             
             let appearance = UINavigationBarAppearance()
-            
-            appearance.configureWithOpaqueBackground()
-            
+                        
             if isTranslucent {
                 
                 appearance.configureWithTransparentBackground()

--- a/godtools/App/Share/NavControllers/ModalNavigationController.swift
+++ b/godtools/App/Share/NavControllers/ModalNavigationController.swift
@@ -30,13 +30,9 @@ class ModalNavigationController: UINavigationController {
         
         super.viewDidLoad()
             
-        navigationBar.setupNavigationBarAppearance(
-            backgroundColor: .white,
-            controlColor: nil,
-            titleFont: nil,
-            titleColor: nil,
-            isTranslucent: false
-        )
+        navigationBar.barTintColor = UIColor.white
+        navigationBar.isTranslucent = false
+        navigationBar.shadowImage = UIImage()
                                 
         setViewControllers([rootView], animated: false)
     }


### PR DESCRIPTION
The navigation bar underline was showing when a tool or lesson would load.  This removes the line that was showing.

![Simulator Screen Shot - iPhone 11 - 2021-10-13 at 15 41 29](https://user-images.githubusercontent.com/59846460/137205853-aa2acac5-953a-4baf-811d-804c6306741c.png)

