### PR TITLE
GT-1308: Video on First Onboarding Screen

### DIFF
--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -1021,6 +1021,10 @@
 		D19D010325AF549B007C535B /* DeepLinkingServiceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D19D010225AF549B007C535B /* DeepLinkingServiceType.swift */; };
 		D19EB5DE259BB39300685156 /* training_tip_callout.json in Resources */ = {isa = PBXBuildFile; fileRef = D19EB5DD259BB39300685156 /* training_tip_callout.json */; };
 		D19EB5E0259BB75900685156 /* training_tip_tips.json in Resources */ = {isa = PBXBuildFile; fileRef = D19EB5DF259BB75900685156 /* training_tip_tips.json */; };
+		D1AF02ED2730763700BEC921 /* VideoPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1AF02EC2730763600BEC921 /* VideoPlayerView.swift */; };
+		D1AF02EF2730767D00BEC921 /* VideoPlayerViewModelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1AF02EE2730767D00BEC921 /* VideoPlayerViewModelType.swift */; };
+		D1AF02F1273076E700BEC921 /* VideoPlayerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1AF02F0273076E700BEC921 /* VideoPlayerViewModel.swift */; };
+		D1AF02F3273080CE00BEC921 /* VideoPlayerView.xib in Resources */ = {isa = PBXBuildFile; fileRef = D1AF02F2273080CE00BEC921 /* VideoPlayerView.xib */; };
 		D1B944E5259E58F5004641DB /* remote_share_active.json in Resources */ = {isa = PBXBuildFile; fileRef = D1B944E4259E58F5004641DB /* remote_share_active.json */; };
 		D1C8FEB92714E7010071BD07 /* TutorialCellViewModelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1C8FEB82714E7000071BD07 /* TutorialCellViewModelType.swift */; };
 		D1C8FEBD2714E9650071BD07 /* OnboardingTutorialItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1C8FEBC2714E9650071BD07 /* OnboardingTutorialItem.swift */; };
@@ -2129,6 +2133,10 @@
 		D19D010225AF549B007C535B /* DeepLinkingServiceType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkingServiceType.swift; sourceTree = "<group>"; };
 		D19EB5DD259BB39300685156 /* training_tip_callout.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = training_tip_callout.json; sourceTree = "<group>"; };
 		D19EB5DF259BB75900685156 /* training_tip_tips.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = training_tip_tips.json; sourceTree = "<group>"; };
+		D1AF02EC2730763600BEC921 /* VideoPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoPlayerView.swift; sourceTree = "<group>"; };
+		D1AF02EE2730767D00BEC921 /* VideoPlayerViewModelType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoPlayerViewModelType.swift; sourceTree = "<group>"; };
+		D1AF02F0273076E700BEC921 /* VideoPlayerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoPlayerViewModel.swift; sourceTree = "<group>"; };
+		D1AF02F2273080CE00BEC921 /* VideoPlayerView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = VideoPlayerView.xib; sourceTree = "<group>"; };
 		D1B944E4259E58F5004641DB /* remote_share_active.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = remote_share_active.json; sourceTree = "<group>"; };
 		D1C8FEB82714E7000071BD07 /* TutorialCellViewModelType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TutorialCellViewModelType.swift; sourceTree = "<group>"; };
 		D1C8FEBC2714E9650071BD07 /* OnboardingTutorialItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingTutorialItem.swift; sourceTree = "<group>"; };
@@ -3997,6 +4005,7 @@
 				45AD18C425938A4E00A096A0 /* PageNavigationCollectionView */,
 				45AD18D425938A4E00A096A0 /* ProgressView */,
 				45BF6EB827050A0E003596A4 /* TransparentModal */,
+				D1AF02EB2730760900BEC921 /* VideoPlayerView */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -5548,6 +5557,17 @@
 			path = AppsFlyer;
 			sourceTree = "<group>";
 		};
+		D1AF02EB2730760900BEC921 /* VideoPlayerView */ = {
+			isa = PBXGroup;
+			children = (
+				D1AF02EC2730763600BEC921 /* VideoPlayerView.swift */,
+				D1AF02F2273080CE00BEC921 /* VideoPlayerView.xib */,
+				D1AF02EE2730767D00BEC921 /* VideoPlayerViewModelType.swift */,
+				D1AF02F0273076E700BEC921 /* VideoPlayerViewModel.swift */,
+			);
+			path = VideoPlayerView;
+			sourceTree = "<group>";
+		};
 		D1C8FEB72714E6580071BD07 /* TutorialCell */ = {
 			isa = PBXGroup;
 			children = (
@@ -5893,6 +5913,7 @@
 				451EBE3924AD968B00C4D6DD /* 9a8cfa08121f0f0e78dbed54652c2c3f1d51c001a0b81dfdd092d378fd43633c.jpg in Resources */,
 				45AD1B1025938A4E00A096A0 /* ArticlesErrorMessageView.xib in Resources */,
 				45AD1ACD25938A4E00A096A0 /* FavoritingToolMessageView.xib in Resources */,
+				D1AF02F3273080CE00BEC921 /* VideoPlayerView.xib in Resources */,
 				451EBE3824AD968B00C4D6DD /* 298732618f6a220d016b5493508c038a8c821780ea699627d03d4a6035d3f6bb.jpg in Resources */,
 				455582E7269F2C1000C3FF14 /* TrainingPageView.xib in Resources */,
 				455583D9269F2DA500C3FF14 /* MobileContentTabsView.xib in Resources */,
@@ -6327,6 +6348,7 @@
 				45AD201725938A9800A096A0 /* ToolShortcutItem.swift in Sources */,
 				45AD1B3B25938A4F00A096A0 /* MenuDataSource.swift in Sources */,
 				45AD201F25938A9800A096A0 /* NoResponseSuccessType.swift in Sources */,
+				D1AF02F1273076E700BEC921 /* VideoPlayerViewModel.swift in Sources */,
 				45AD1B1A25938A4E00A096A0 /* InMemoryLearnToShareToolItems.swift in Sources */,
 				45AD1F7925938A9800A096A0 /* DeviceLanguageType.swift in Sources */,
 				45CB9FFC261FB0BE0036BEB3 /* LessonListItemViewModelType.swift in Sources */,
@@ -6546,6 +6568,7 @@
 				45AD1B5825938A4F00A096A0 /* AccountViewModelType.swift in Sources */,
 				453AF08626A8787E002D4AB1 /* MultiplatformCallToAction.swift in Sources */,
 				458EFED326B19A2C009EEB03 /* ToolNavigationFlow.swift in Sources */,
+				D1AF02EF2730767D00BEC921 /* VideoPlayerViewModelType.swift in Sources */,
 				45558342269F2C7B00C3FF14 /* ToolPageHeaderViewModelType.swift in Sources */,
 				45AD21162593958E00A096A0 /* LanguageModel+Direction.swift in Sources */,
 				45AD1AF225938A4E00A096A0 /* HelpWebContent.swift in Sources */,
@@ -6664,6 +6687,7 @@
 				455583EE269F2DA500C3FF14 /* MobileContentNumberViewModel.swift in Sources */,
 				45AD1B3825938A4F00A096A0 /* ChooseLanguageCellViewModelType.swift in Sources */,
 				45558323269F2C7B00C3FF14 /* ToolPageViewModel.swift in Sources */,
+				D1AF02ED2730763700BEC921 /* VideoPlayerView.swift in Sources */,
 				455E799526A6204A00972EC0 /* MobileContentMultiplatformParserFactory.swift in Sources */,
 				45558321269F2C7B00C3FF14 /* ToolPagePositions.swift in Sources */,
 				45585BD32687BD7900A21D12 /* ToolQueryParameters.swift in Sources */,

--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -5562,8 +5562,8 @@
 			children = (
 				D1AF02EC2730763600BEC921 /* VideoPlayerView.swift */,
 				D1AF02F2273080CE00BEC921 /* VideoPlayerView.xib */,
-				D1AF02EE2730767D00BEC921 /* VideoPlayerViewModelType.swift */,
 				D1AF02F0273076E700BEC921 /* VideoPlayerViewModel.swift */,
+				D1AF02EE2730767D00BEC921 /* VideoPlayerViewModelType.swift */,
 			);
 			path = VideoPlayerView;
 			sourceTree = "<group>";

--- a/godtools/App/AppDiContainer.swift
+++ b/godtools/App/AppDiContainer.swift
@@ -285,8 +285,8 @@ class AppDiContainer {
         )
     }
     
-    func onboardingTutorialCustomViewBuilder() -> CustomViewBuilderType {
-        return OnboardingTutorialCustomViewBuilder(deviceLanguage: deviceLanguage, localizationServices: localizationServices, analyticsContainer: analytics, analyticsScreenName: "onboarding")
+    func onboardingTutorialCustomViewBuilder(flowDelegate: FlowDelegate?) -> CustomViewBuilderType {
+        return OnboardingTutorialCustomViewBuilder(flowDelegate: flowDelegate, deviceLanguage: deviceLanguage, localizationServices: localizationServices, analyticsContainer: analytics, analyticsScreenName: "onboarding")
     }
     
     var firebaseConfiguration: FirebaseConfiguration {

--- a/godtools/App/AppDiContainer.swift
+++ b/godtools/App/AppDiContainer.swift
@@ -286,7 +286,7 @@ class AppDiContainer {
     }
     
     func onboardingTutorialCustomViewBuilder() -> CustomViewBuilderType {
-        return OnboardingTutorialCustomViewBuilder(deviceLanguage: deviceLanguage, localizationServices: localizationServices)
+        return OnboardingTutorialCustomViewBuilder(deviceLanguage: deviceLanguage, localizationServices: localizationServices, analyticsContainer: analytics, analyticsScreenName: "onboarding")
     }
     
     var firebaseConfiguration: FirebaseConfiguration {

--- a/godtools/App/Features/Onboarding/Models/OnboardingTutorialCustomViewBuilder.swift
+++ b/godtools/App/Features/Onboarding/Models/OnboardingTutorialCustomViewBuilder.swift
@@ -12,17 +12,21 @@ class OnboardingTutorialCustomViewBuilder: CustomViewBuilderType {
 
     private let deviceLanguage: DeviceLanguageType
     private let localizationServices: LocalizationServices
-
-    required init(deviceLanguage: DeviceLanguageType, localizationServices: LocalizationServices) {
+    private let analyticsContainer: AnalyticsContainer
+    private let analyticsScreenName: String
+    
+    required init(deviceLanguage: DeviceLanguageType, localizationServices: LocalizationServices, analyticsContainer: AnalyticsContainer, analyticsScreenName: String) {
 
         self.deviceLanguage = deviceLanguage
         self.localizationServices = localizationServices
+        self.analyticsContainer = analyticsContainer
+        self.analyticsScreenName = analyticsScreenName
     }
 
     func buildCustomView(customViewId: String) -> UIView? {
 
         if customViewId == "onboarding-0" {
-            let viewModel = OnboardingTutorialIntroViewModel(localizationServices: localizationServices)
+            let viewModel = OnboardingTutorialIntroViewModel(localizationServices: localizationServices, analyticsContainer: analyticsContainer, analyticsScreenName: analyticsScreenName)
 
             let view = OnboardingTutorialIntroView()
 

--- a/godtools/App/Features/Onboarding/Models/OnboardingTutorialCustomViewBuilder.swift
+++ b/godtools/App/Features/Onboarding/Models/OnboardingTutorialCustomViewBuilder.swift
@@ -10,12 +10,17 @@ import UIKit
 
 class OnboardingTutorialCustomViewBuilder: CustomViewBuilderType {
 
+    
+    private weak var flowDelegate: FlowDelegate?
+    
     private let deviceLanguage: DeviceLanguageType
     private let localizationServices: LocalizationServices
     private let analyticsContainer: AnalyticsContainer
     private let analyticsScreenName: String
     
-    required init(deviceLanguage: DeviceLanguageType, localizationServices: LocalizationServices, analyticsContainer: AnalyticsContainer, analyticsScreenName: String) {
+    required init(flowDelegate: FlowDelegate?, deviceLanguage: DeviceLanguageType, localizationServices: LocalizationServices, analyticsContainer: AnalyticsContainer, analyticsScreenName: String) {
+        
+        self.flowDelegate = flowDelegate
 
         self.deviceLanguage = deviceLanguage
         self.localizationServices = localizationServices
@@ -26,7 +31,7 @@ class OnboardingTutorialCustomViewBuilder: CustomViewBuilderType {
     func buildCustomView(customViewId: String) -> UIView? {
 
         if customViewId == "onboarding-0" {
-            let viewModel = OnboardingTutorialIntroViewModel(localizationServices: localizationServices, analyticsContainer: analyticsContainer, analyticsScreenName: analyticsScreenName)
+            let viewModel = OnboardingTutorialIntroViewModel(flowDelegate: flowDelegate, localizationServices: localizationServices, analyticsContainer: analyticsContainer, analyticsScreenName: analyticsScreenName)
 
             let view = OnboardingTutorialIntroView()
 

--- a/godtools/App/Features/Onboarding/Views/OnboardingTutorialIntroView.swift
+++ b/godtools/App/Features/Onboarding/Views/OnboardingTutorialIntroView.swift
@@ -14,7 +14,6 @@ class OnboardingTutorialIntroView: UIView, NibBased {
     @IBOutlet weak private var logoImageView: UIImageView!
     @IBOutlet weak private var titleLabel: UILabel!
     @IBOutlet weak private var videoButton: UIButton!
-    @IBOutlet weak private var youTubeVideoPlayer: YTPlayerView!
     
     private var viewModel: OnboardingTutorialIntroViewModelType?
     
@@ -41,9 +40,7 @@ class OnboardingTutorialIntroView: UIView, NibBased {
         titleLabel.text = viewModel.title
 
         logoImageView.image = viewModel.logoImage
-        
-        loadYoutubePlayerVideo(videoId: viewModel.youtubeVideoId)
-        
+                
         setupBinding()
     }
     
@@ -54,73 +51,6 @@ class OnboardingTutorialIntroView: UIView, NibBased {
     
     @objc private func videoLinkTapped (button: UIButton) {
         
-        youTubeVideoPlayer.playVideo()
-        
         viewModel?.videoLinkTapped()
-    }
-    
-    private func loadYoutubePlayerVideo(videoId: String) {
-        
-        youTubeVideoPlayer.delegate = self
-        youTubeVideoPlayer.load(withVideoId: videoId, playerVars: youtubePlayerParameters)
-        youTubeVideoPlayer.isHidden = true
-    }
-    
-    private func recueVideo() {
-        
-        guard let youtubeVideoId = viewModel?.youtubeVideoId else { return }
-        
-        youTubeVideoPlayer.cueVideo(byId: youtubeVideoId, startSeconds: 0.0)
-    }
-}
-
-// MARK: - YTPlayerViewDelegate
-
-extension OnboardingTutorialIntroView: YTPlayerViewDelegate {
-    
-    func playerViewDidBecomeReady(_ playerView: YTPlayerView) {
-        
-        print("\n ToolDetailView player view did become ready")
-    }
-    
-    func playerView(_ playerView: YTPlayerView, didChangeTo state: YTPlayerState) {
-        
-        print("\n ToolDetailView playerView didChangeTo state")
-        switch state {
-            
-        case .unstarted:
-            print("unstarted")
-        case .ended:
-            print("ended")
-            recueVideo()
-        case .playing:
-            print("playing")
-        case .paused:
-            print("paused")
-        case .buffering:
-            print("buffering")
-        case .cued:
-            print("cued")
-        case .unknown:
-            print("unknown")
-        @unknown default:
-            print("default")
-        }
-        
-        if state == .ended, let youTubePlayerId = viewModel?.youtubeVideoId {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
-                self?.loadYoutubePlayerVideo(videoId: youTubePlayerId)
-            }
-        }
-    }
-    
-    func playerView(_ playerView: YTPlayerView, didChangeTo quality: YTPlaybackQuality) {
-    
-        print("\n ToolDetailView playerView didChangeTo quality")
-    }
-    
-    func playerView(_ playerView: YTPlayerError, receivedError error: YTPlayerError) {
-        print("\n TutorialCell: youTubeVideoPlayer receivedError")
-        print("  error: \(error)")
     }
 }

--- a/godtools/App/Features/Onboarding/Views/OnboardingTutorialIntroView.swift
+++ b/godtools/App/Features/Onboarding/Views/OnboardingTutorialIntroView.swift
@@ -7,31 +7,133 @@
 //
 
 import UIKit
+import youtube_ios_player_helper
 
 class OnboardingTutorialIntroView: UIView, NibBased {
-
+    
     @IBOutlet weak private var logoImageView: UIImageView!
     @IBOutlet weak private var titleLabel: UILabel!
     @IBOutlet weak private var videoButton: UIButton!
-
+    @IBOutlet weak private var youTubeVideoPlayer: YTPlayerView!
+    @IBOutlet weak private var youTubeVideoPlayerLoadingView: UIView!
+    @IBOutlet weak private var youTubeVideoPlayerActivityIndicator: UIActivityIndicatorView!
+    
+    private var viewModel: OnboardingTutorialIntroViewModelType?
+    
     required init() {
         super.init(frame: UIScreen.main.bounds)
         loadNib()
     }
-
+    
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         loadNib()
     }
-
+    
+    var youtubePlayerParameters: [String : Any]? {
+        let playsInFullScreen = 0
+        
+        return [
+            "playsinline": playsInFullScreen
+        ]
+    }
+    
     func configure(viewModel: OnboardingTutorialIntroViewModelType) {
 
+        self.viewModel = viewModel
+        
         titleLabel.text = viewModel.title
 
         logoImageView.image = viewModel.logoImage
+        
+        loadYoutubePlayerVideo(videoId: viewModel.youtubeVideoId)
+    }
+    
+    private func setupBinding() {
+        
+        videoButton.addTarget(self, action: #selector(videoLinkTapped(button:)), for: .touchUpInside)
     }
 
-    @objc private func handleWatchVideo (button: UIButton) {
-        //TODO: Launch Video
+    @objc private func videoLinkTapped (button: UIButton) {
+        
+        viewModel?.videoLinkTapped()
+    }
+    
+    private func loadYoutubePlayerVideo(videoId: String) {
+        
+        youTubeVideoPlayerActivityIndicator.startAnimating()
+        youTubeVideoPlayer.delegate = self
+        youTubeVideoPlayer.load(withVideoId: videoId, playerVars: youtubePlayerParameters)
+    }
+    
+    private func stopVideo() {
+        
+        youTubeVideoPlayer.stopVideo()
+    }
+    
+    private func recueVideo() {
+        
+        guard let youtubeVideoId = viewModel?.youtubeVideoId else { return }
+        
+        youTubeVideoPlayer.cueVideo(byId: youtubeVideoId, startSeconds: 0.0)
+    }
+}
+
+// MARK: - YTPlayerViewDelegate
+
+extension OnboardingTutorialIntroView: YTPlayerViewDelegate {
+    
+    func playerViewDidBecomeReady(_ playerView: YTPlayerView) {
+        
+        print("\n ToolDetailView player view did become ready")
+        
+        UIView.animate(withDuration: 0.3, delay: 0, options: .curveEaseOut, animations: { [weak self] in
+            self?.youTubeVideoPlayerLoadingView.alpha = 0
+        }) { [weak self] (finished: Bool) in
+            self?.youTubeVideoPlayerLoadingView.isHidden = true
+            self?.youTubeVideoPlayerLoadingView.alpha = 1
+            self?.youTubeVideoPlayerActivityIndicator.stopAnimating()
+        }
+    }
+    
+    func playerView(_ playerView: YTPlayerView, didChangeTo state: YTPlayerState) {
+        
+        print("\n ToolDetailView playerView didChangeTo state")
+        switch state {
+            
+        case .unstarted:
+            print("unstarted")
+        case .ended:
+            print("ended")
+            recueVideo()
+        case .playing:
+            print("playing")
+        case .paused:
+            print("paused")
+        case .buffering:
+            print("buffering")
+        case .cued:
+            print("cued")
+        case .unknown:
+            print("unknown")
+        @unknown default:
+            print("default")
+        }
+        
+        if state == .ended, let youTubePlayerId = viewModel?.youtubeVideoId {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+                self?.loadYoutubePlayerVideo(videoId: youTubePlayerId)
+            }
+        }
+    }
+    
+    func playerView(_ playerView: YTPlayerView, didChangeTo quality: YTPlaybackQuality) {
+    
+        print("\n ToolDetailView playerView didChangeTo quality")
+    }
+    
+    func playerView(_ playerView: YTPlayerError, receivedError error: YTPlayerError) {
+        print("\n TutorialCell: youTubeVideoPlayer receivedError")
+        print("  error: \(error)")
     }
 }

--- a/godtools/App/Features/Onboarding/Views/OnboardingTutorialIntroView.swift
+++ b/godtools/App/Features/Onboarding/Views/OnboardingTutorialIntroView.swift
@@ -15,8 +15,6 @@ class OnboardingTutorialIntroView: UIView, NibBased {
     @IBOutlet weak private var titleLabel: UILabel!
     @IBOutlet weak private var videoButton: UIButton!
     @IBOutlet weak private var youTubeVideoPlayer: YTPlayerView!
-    @IBOutlet weak private var youTubeVideoPlayerLoadingView: UIView!
-    @IBOutlet weak private var youTubeVideoPlayerActivityIndicator: UIActivityIndicatorView!
     
     private var viewModel: OnboardingTutorialIntroViewModelType?
     
@@ -33,9 +31,7 @@ class OnboardingTutorialIntroView: UIView, NibBased {
     var youtubePlayerParameters: [String : Any]? {
         let playsInFullScreen = 0
         
-        return [
-            "playsinline": playsInFullScreen
-        ]
+        return ["playsinline": playsInFullScreen]
     }
     
     func configure(viewModel: OnboardingTutorialIntroViewModelType) {
@@ -47,28 +43,27 @@ class OnboardingTutorialIntroView: UIView, NibBased {
         logoImageView.image = viewModel.logoImage
         
         loadYoutubePlayerVideo(videoId: viewModel.youtubeVideoId)
+        
+        setupBinding()
     }
     
     private func setupBinding() {
         
         videoButton.addTarget(self, action: #selector(videoLinkTapped(button:)), for: .touchUpInside)
     }
-
+    
     @objc private func videoLinkTapped (button: UIButton) {
+        
+        youTubeVideoPlayer.playVideo()
         
         viewModel?.videoLinkTapped()
     }
     
     private func loadYoutubePlayerVideo(videoId: String) {
         
-        youTubeVideoPlayerActivityIndicator.startAnimating()
         youTubeVideoPlayer.delegate = self
         youTubeVideoPlayer.load(withVideoId: videoId, playerVars: youtubePlayerParameters)
-    }
-    
-    private func stopVideo() {
-        
-        youTubeVideoPlayer.stopVideo()
+        youTubeVideoPlayer.isHidden = true
     }
     
     private func recueVideo() {
@@ -86,14 +81,6 @@ extension OnboardingTutorialIntroView: YTPlayerViewDelegate {
     func playerViewDidBecomeReady(_ playerView: YTPlayerView) {
         
         print("\n ToolDetailView player view did become ready")
-        
-        UIView.animate(withDuration: 0.3, delay: 0, options: .curveEaseOut, animations: { [weak self] in
-            self?.youTubeVideoPlayerLoadingView.alpha = 0
-        }) { [weak self] (finished: Bool) in
-            self?.youTubeVideoPlayerLoadingView.isHidden = true
-            self?.youTubeVideoPlayerLoadingView.alpha = 1
-            self?.youTubeVideoPlayerActivityIndicator.stopAnimating()
-        }
     }
     
     func playerView(_ playerView: YTPlayerView, didChangeTo state: YTPlayerState) {

--- a/godtools/App/Features/Onboarding/Views/OnboardingTutorialIntroView.xib
+++ b/godtools/App/Features/Onboarding/Views/OnboardingTutorialIntroView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina5_5" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <customFonts key="customFonts">
@@ -20,6 +20,9 @@
                 <outlet property="logoImageView" destination="7RE-rj-898" id="zNc-zT-EJQ"/>
                 <outlet property="titleLabel" destination="g2I-2Q-yE9" id="B3d-mC-Yu0"/>
                 <outlet property="videoButton" destination="pwO-eC-2Xm" id="hNb-QS-DBC"/>
+                <outlet property="youTubeVideoPlayer" destination="7X7-m2-y7n" id="cCH-1o-7pi"/>
+                <outlet property="youTubeVideoPlayerActivityIndicator" destination="oQX-vd-hhI" id="Twy-ZM-oDm"/>
+                <outlet property="youTubeVideoPlayerLoadingView" destination="LQH-vk-7NK" id="NA2-vi-o0W"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
@@ -49,16 +52,46 @@
                         <color key="titleColor" red="0.23137254901960785" green="0.64313725490196072" blue="0.85882352941176465" alpha="1" colorSpace="calibratedRGB"/>
                     </state>
                 </button>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7X7-m2-y7n" userLabel="youTubeVideoPlayer" customClass="YTPlayerView">
+                    <rect key="frame" x="20.666666666666657" y="407" width="372.66666666666674" height="209.66666666666663"/>
+                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <constraints>
+                        <constraint firstAttribute="width" secondItem="7X7-m2-y7n" secondAttribute="height" multiplier="16:9" id="9w6-L4-zLz"/>
+                    </constraints>
+                </view>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LQH-vk-7NK" userLabel="youTubeVideoPlayerLoadingView">
+                    <rect key="frame" x="20.666666666666657" y="407" width="372.66666666666674" height="209.66666666666663"/>
+                    <subviews>
+                        <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="medium" translatesAutoresizingMaskIntoConstraints="NO" id="oQX-vd-hhI" userLabel="youTubeVideoPlayerActivityIndicator">
+                            <rect key="frame" x="176.33333333333334" y="95" width="20" height="20"/>
+                            <color key="color" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        </activityIndicatorView>
+                    </subviews>
+                    <color key="backgroundColor" red="0.90196078430000004" green="0.90196078430000004" blue="0.90196078430000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    <constraints>
+                        <constraint firstItem="oQX-vd-hhI" firstAttribute="centerY" secondItem="LQH-vk-7NK" secondAttribute="centerY" id="BkA-Os-Qdn"/>
+                        <constraint firstItem="oQX-vd-hhI" firstAttribute="centerX" secondItem="LQH-vk-7NK" secondAttribute="centerX" id="cF9-1g-WBG"/>
+                    </constraints>
+                </view>
             </subviews>
             <constraints>
+                <constraint firstItem="LQH-vk-7NK" firstAttribute="width" secondItem="2Ud-wT-1r3" secondAttribute="width" multiplier="0.9" id="1wb-cC-cEa"/>
+                <constraint firstItem="7X7-m2-y7n" firstAttribute="top" secondItem="pwO-eC-2Xm" secondAttribute="bottom" constant="20" id="7KH-G5-rJc"/>
+                <constraint firstItem="LQH-vk-7NK" firstAttribute="centerX" secondItem="2Ud-wT-1r3" secondAttribute="centerX" id="ALi-Yd-yjL"/>
                 <constraint firstItem="7RE-rj-898" firstAttribute="centerY" secondItem="2Ud-wT-1r3" secondAttribute="centerY" multiplier="0.4" id="ETq-yn-rFJ"/>
                 <constraint firstItem="g2I-2Q-yE9" firstAttribute="top" secondItem="7RE-rj-898" secondAttribute="bottom" constant="48" id="Kw4-qQ-Kqr"/>
                 <constraint firstItem="g2I-2Q-yE9" firstAttribute="leading" secondItem="2Ud-wT-1r3" secondAttribute="leading" constant="30" id="MZ5-uE-q9s"/>
                 <constraint firstAttribute="trailing" secondItem="pwO-eC-2Xm" secondAttribute="trailing" constant="30" id="Qzs-9g-wt9"/>
                 <constraint firstAttribute="trailing" secondItem="g2I-2Q-yE9" secondAttribute="trailing" constant="30" id="SGC-6s-wom"/>
+                <constraint firstItem="7X7-m2-y7n" firstAttribute="width" secondItem="7X7-m2-y7n" secondAttribute="height" multiplier="16:9" id="Sa1-cd-Poq"/>
                 <constraint firstItem="pwO-eC-2Xm" firstAttribute="leading" secondItem="2Ud-wT-1r3" secondAttribute="leading" constant="30" id="WAH-XY-zL0"/>
                 <constraint firstItem="7RE-rj-898" firstAttribute="width" secondItem="2Ud-wT-1r3" secondAttribute="width" multiplier="0.7" priority="900" id="ZCi-RI-WQ7"/>
+                <constraint firstItem="LQH-vk-7NK" firstAttribute="leading" secondItem="7X7-m2-y7n" secondAttribute="leading" id="eCp-3Q-r7B"/>
+                <constraint firstItem="LQH-vk-7NK" firstAttribute="trailing" secondItem="7X7-m2-y7n" secondAttribute="trailing" id="fhs-Co-kg7"/>
+                <constraint firstItem="LQH-vk-7NK" firstAttribute="bottom" secondItem="7X7-m2-y7n" secondAttribute="bottom" id="rj6-cc-OOL"/>
+                <constraint firstItem="7X7-m2-y7n" firstAttribute="centerX" secondItem="2Ud-wT-1r3" secondAttribute="centerX" id="tuy-JS-7TT"/>
                 <constraint firstItem="pwO-eC-2Xm" firstAttribute="top" secondItem="g2I-2Q-yE9" secondAttribute="bottom" constant="20" id="udr-9g-Sie"/>
+                <constraint firstItem="LQH-vk-7NK" firstAttribute="top" secondItem="7X7-m2-y7n" secondAttribute="top" id="xaQ-Zz-LCl"/>
                 <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="pwO-eC-2Xm" secondAttribute="bottom" constant="20" id="xeP-fh-mx3"/>
                 <constraint firstItem="7RE-rj-898" firstAttribute="centerX" secondItem="2Ud-wT-1r3" secondAttribute="centerX" id="zOm-P5-32s"/>
             </constraints>

--- a/godtools/App/Features/Onboarding/Views/OnboardingTutorialIntroView.xib
+++ b/godtools/App/Features/Onboarding/Views/OnboardingTutorialIntroView.xib
@@ -20,7 +20,6 @@
                 <outlet property="logoImageView" destination="7RE-rj-898" id="zNc-zT-EJQ"/>
                 <outlet property="titleLabel" destination="g2I-2Q-yE9" id="B3d-mC-Yu0"/>
                 <outlet property="videoButton" destination="pwO-eC-2Xm" id="hNb-QS-DBC"/>
-                <outlet property="youTubeVideoPlayer" destination="7X7-m2-y7n" id="cCH-1o-7pi"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
@@ -50,26 +49,15 @@
                         <color key="titleColor" red="0.23137254901960785" green="0.64313725490196072" blue="0.85882352941176465" alpha="1" colorSpace="calibratedRGB"/>
                     </state>
                 </button>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7X7-m2-y7n" userLabel="youTubeVideoPlayer" customClass="YTPlayerView">
-                    <rect key="frame" x="103.66666666666669" y="407" width="207" height="116.66666666666663"/>
-                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                    <constraints>
-                        <constraint firstAttribute="width" secondItem="7X7-m2-y7n" secondAttribute="height" multiplier="16:9" id="9w6-L4-zLz"/>
-                    </constraints>
-                </view>
             </subviews>
             <constraints>
-                <constraint firstItem="7X7-m2-y7n" firstAttribute="width" secondItem="2Ud-wT-1r3" secondAttribute="width" multiplier="0.5" id="0KP-ee-Z3L"/>
-                <constraint firstItem="7X7-m2-y7n" firstAttribute="top" secondItem="pwO-eC-2Xm" secondAttribute="bottom" constant="20" id="7KH-G5-rJc"/>
                 <constraint firstItem="7RE-rj-898" firstAttribute="centerY" secondItem="2Ud-wT-1r3" secondAttribute="centerY" multiplier="0.4" id="ETq-yn-rFJ"/>
                 <constraint firstItem="g2I-2Q-yE9" firstAttribute="top" secondItem="7RE-rj-898" secondAttribute="bottom" constant="48" id="Kw4-qQ-Kqr"/>
                 <constraint firstItem="g2I-2Q-yE9" firstAttribute="leading" secondItem="2Ud-wT-1r3" secondAttribute="leading" constant="30" id="MZ5-uE-q9s"/>
                 <constraint firstAttribute="trailing" secondItem="pwO-eC-2Xm" secondAttribute="trailing" constant="30" id="Qzs-9g-wt9"/>
                 <constraint firstAttribute="trailing" secondItem="g2I-2Q-yE9" secondAttribute="trailing" constant="30" id="SGC-6s-wom"/>
-                <constraint firstItem="7X7-m2-y7n" firstAttribute="width" secondItem="7X7-m2-y7n" secondAttribute="height" multiplier="16:9" id="Sa1-cd-Poq"/>
                 <constraint firstItem="pwO-eC-2Xm" firstAttribute="leading" secondItem="2Ud-wT-1r3" secondAttribute="leading" constant="30" id="WAH-XY-zL0"/>
                 <constraint firstItem="7RE-rj-898" firstAttribute="width" secondItem="2Ud-wT-1r3" secondAttribute="width" multiplier="0.7" priority="900" id="ZCi-RI-WQ7"/>
-                <constraint firstItem="7X7-m2-y7n" firstAttribute="centerX" secondItem="2Ud-wT-1r3" secondAttribute="centerX" id="tuy-JS-7TT"/>
                 <constraint firstItem="pwO-eC-2Xm" firstAttribute="top" secondItem="g2I-2Q-yE9" secondAttribute="bottom" constant="20" id="udr-9g-Sie"/>
                 <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="pwO-eC-2Xm" secondAttribute="bottom" constant="20" id="xeP-fh-mx3"/>
                 <constraint firstItem="7RE-rj-898" firstAttribute="centerX" secondItem="2Ud-wT-1r3" secondAttribute="centerX" id="zOm-P5-32s"/>

--- a/godtools/App/Features/Onboarding/Views/OnboardingTutorialIntroView.xib
+++ b/godtools/App/Features/Onboarding/Views/OnboardingTutorialIntroView.xib
@@ -21,8 +21,6 @@
                 <outlet property="titleLabel" destination="g2I-2Q-yE9" id="B3d-mC-Yu0"/>
                 <outlet property="videoButton" destination="pwO-eC-2Xm" id="hNb-QS-DBC"/>
                 <outlet property="youTubeVideoPlayer" destination="7X7-m2-y7n" id="cCH-1o-7pi"/>
-                <outlet property="youTubeVideoPlayerActivityIndicator" destination="oQX-vd-hhI" id="Twy-ZM-oDm"/>
-                <outlet property="youTubeVideoPlayerLoadingView" destination="LQH-vk-7NK" id="NA2-vi-o0W"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
@@ -53,31 +51,16 @@
                     </state>
                 </button>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7X7-m2-y7n" userLabel="youTubeVideoPlayer" customClass="YTPlayerView">
-                    <rect key="frame" x="20.666666666666657" y="407" width="372.66666666666674" height="209.66666666666663"/>
+                    <rect key="frame" x="103.66666666666669" y="407" width="207" height="116.66666666666663"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>
                         <constraint firstAttribute="width" secondItem="7X7-m2-y7n" secondAttribute="height" multiplier="16:9" id="9w6-L4-zLz"/>
                     </constraints>
                 </view>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LQH-vk-7NK" userLabel="youTubeVideoPlayerLoadingView">
-                    <rect key="frame" x="20.666666666666657" y="407" width="372.66666666666674" height="209.66666666666663"/>
-                    <subviews>
-                        <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="medium" translatesAutoresizingMaskIntoConstraints="NO" id="oQX-vd-hhI" userLabel="youTubeVideoPlayerActivityIndicator">
-                            <rect key="frame" x="176.33333333333334" y="95" width="20" height="20"/>
-                            <color key="color" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        </activityIndicatorView>
-                    </subviews>
-                    <color key="backgroundColor" red="0.90196078430000004" green="0.90196078430000004" blue="0.90196078430000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                    <constraints>
-                        <constraint firstItem="oQX-vd-hhI" firstAttribute="centerY" secondItem="LQH-vk-7NK" secondAttribute="centerY" id="BkA-Os-Qdn"/>
-                        <constraint firstItem="oQX-vd-hhI" firstAttribute="centerX" secondItem="LQH-vk-7NK" secondAttribute="centerX" id="cF9-1g-WBG"/>
-                    </constraints>
-                </view>
             </subviews>
             <constraints>
-                <constraint firstItem="LQH-vk-7NK" firstAttribute="width" secondItem="2Ud-wT-1r3" secondAttribute="width" multiplier="0.9" id="1wb-cC-cEa"/>
+                <constraint firstItem="7X7-m2-y7n" firstAttribute="width" secondItem="2Ud-wT-1r3" secondAttribute="width" multiplier="0.5" id="0KP-ee-Z3L"/>
                 <constraint firstItem="7X7-m2-y7n" firstAttribute="top" secondItem="pwO-eC-2Xm" secondAttribute="bottom" constant="20" id="7KH-G5-rJc"/>
-                <constraint firstItem="LQH-vk-7NK" firstAttribute="centerX" secondItem="2Ud-wT-1r3" secondAttribute="centerX" id="ALi-Yd-yjL"/>
                 <constraint firstItem="7RE-rj-898" firstAttribute="centerY" secondItem="2Ud-wT-1r3" secondAttribute="centerY" multiplier="0.4" id="ETq-yn-rFJ"/>
                 <constraint firstItem="g2I-2Q-yE9" firstAttribute="top" secondItem="7RE-rj-898" secondAttribute="bottom" constant="48" id="Kw4-qQ-Kqr"/>
                 <constraint firstItem="g2I-2Q-yE9" firstAttribute="leading" secondItem="2Ud-wT-1r3" secondAttribute="leading" constant="30" id="MZ5-uE-q9s"/>
@@ -86,12 +69,8 @@
                 <constraint firstItem="7X7-m2-y7n" firstAttribute="width" secondItem="7X7-m2-y7n" secondAttribute="height" multiplier="16:9" id="Sa1-cd-Poq"/>
                 <constraint firstItem="pwO-eC-2Xm" firstAttribute="leading" secondItem="2Ud-wT-1r3" secondAttribute="leading" constant="30" id="WAH-XY-zL0"/>
                 <constraint firstItem="7RE-rj-898" firstAttribute="width" secondItem="2Ud-wT-1r3" secondAttribute="width" multiplier="0.7" priority="900" id="ZCi-RI-WQ7"/>
-                <constraint firstItem="LQH-vk-7NK" firstAttribute="leading" secondItem="7X7-m2-y7n" secondAttribute="leading" id="eCp-3Q-r7B"/>
-                <constraint firstItem="LQH-vk-7NK" firstAttribute="trailing" secondItem="7X7-m2-y7n" secondAttribute="trailing" id="fhs-Co-kg7"/>
-                <constraint firstItem="LQH-vk-7NK" firstAttribute="bottom" secondItem="7X7-m2-y7n" secondAttribute="bottom" id="rj6-cc-OOL"/>
                 <constraint firstItem="7X7-m2-y7n" firstAttribute="centerX" secondItem="2Ud-wT-1r3" secondAttribute="centerX" id="tuy-JS-7TT"/>
                 <constraint firstItem="pwO-eC-2Xm" firstAttribute="top" secondItem="g2I-2Q-yE9" secondAttribute="bottom" constant="20" id="udr-9g-Sie"/>
-                <constraint firstItem="LQH-vk-7NK" firstAttribute="top" secondItem="7X7-m2-y7n" secondAttribute="top" id="xaQ-Zz-LCl"/>
                 <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="pwO-eC-2Xm" secondAttribute="bottom" constant="20" id="xeP-fh-mx3"/>
                 <constraint firstItem="7RE-rj-898" firstAttribute="centerX" secondItem="2Ud-wT-1r3" secondAttribute="centerX" id="zOm-P5-32s"/>
             </constraints>

--- a/godtools/App/Features/Onboarding/Views/OnboardingTutorialIntroViewModel.swift
+++ b/godtools/App/Features/Onboarding/Views/OnboardingTutorialIntroViewModel.swift
@@ -10,32 +10,38 @@ import UIKit
 
 class OnboardingTutorialIntroViewModel: OnboardingTutorialIntroViewModelType {
 
-    let logoImage: UIImage?
-    let title: String
-    let videoLinkLabel: String
-    let youtubeVideoId: String
+    private weak var flowDelegate: FlowDelegate?
     
     private let analyticsContainer: AnalyticsContainer
     private let analyticsScreenName: String
     
     private var youTubeVideoTracked: Bool
-
-    required init(localizationServices: LocalizationServices, analyticsContainer: AnalyticsContainer, analyticsScreenName: String) {
+    
+    let logoImage: UIImage?
+    let title: String
+    let videoLinkLabel: String
+    let youtubeVideoId: String
+    
+    required init(flowDelegate: FlowDelegate?, localizationServices: LocalizationServices, analyticsContainer: AnalyticsContainer, analyticsScreenName: String) {
         
-        logoImage = UIImage(named: "onboarding_welcome_logo")
-        title = localizationServices.stringForMainBundle(key: "onboardingTutorial.0.title")
-        videoLinkLabel = localizationServices.stringForMainBundle(key: "onboardingTutorial.0.videoLink.title")
-        youtubeVideoId = "RvhZ_wuxAgE"
+        self.flowDelegate = flowDelegate
         
         self.analyticsContainer = analyticsContainer
         self.analyticsScreenName = analyticsScreenName
         
         youTubeVideoTracked = false
+        
+        logoImage = UIImage(named: "onboarding_welcome_logo")
+        title = localizationServices.stringForMainBundle(key: "onboardingTutorial.0.title")
+        videoLinkLabel = localizationServices.stringForMainBundle(key: "onboardingTutorial.0.videoLink.title")
+        youtubeVideoId = "RvhZ_wuxAgE"
     }
     
     func videoLinkTapped() {
         
-        if !youTubeVideoTracked {
+        flowDelegate?.navigate(step: .videoButtonTappedFromOnboardingTutorial(youtubeVideoId: youtubeVideoId))
+        
+        /*if !youTubeVideoTracked {
             
             youTubeVideoTracked = true
             
@@ -49,6 +55,6 @@ class OnboardingTutorialIntroViewModel: OnboardingTutorialIntroViewModelType {
                     data: ["cru.tutorial_video": 1, "video_id": youtubeVideoId]
                 )
             )
-        }
+        }*/
     }
 }

--- a/godtools/App/Features/Onboarding/Views/OnboardingTutorialIntroViewModel.swift
+++ b/godtools/App/Features/Onboarding/Views/OnboardingTutorialIntroViewModel.swift
@@ -13,11 +13,42 @@ class OnboardingTutorialIntroViewModel: OnboardingTutorialIntroViewModelType {
     let logoImage: UIImage?
     let title: String
     let videoLinkLabel: String
+    let youtubeVideoId: String
+    
+    private let analyticsContainer: AnalyticsContainer
+    private let analyticsScreenName: String
+    
+    private var youTubeVideoTracked: Bool
 
-    required init(localizationServices: LocalizationServices) {
+    required init(localizationServices: LocalizationServices, analyticsContainer: AnalyticsContainer, analyticsScreenName: String) {
         
         logoImage = UIImage(named: "onboarding_welcome_logo")
         title = localizationServices.stringForMainBundle(key: "onboardingTutorial.0.title")
         videoLinkLabel = localizationServices.stringForMainBundle(key: "onboardingTutorial.0.videoLink.title")
+        youtubeVideoId = "RvhZ_wuxAgE"
+        
+        self.analyticsContainer = analyticsContainer
+        self.analyticsScreenName = analyticsScreenName
+        
+        youTubeVideoTracked = false
+    }
+    
+    func videoLinkTapped() {
+        
+        if !youTubeVideoTracked {
+            
+            youTubeVideoTracked = true
+            
+            analyticsContainer.trackActionAnalytics.trackAction(
+                trackAction: TrackActionModel(
+                    screenName: analyticsScreenName,
+                    actionName: "Tutorial Video",
+                    siteSection: "",
+                    siteSubSection: "",
+                    url: nil,
+                    data: ["cru.tutorial_video": 1, "video_id": youtubeVideoId]
+                )
+            )
+        }
     }
 }

--- a/godtools/App/Features/Onboarding/Views/OnboardingTutorialIntroViewModel.swift
+++ b/godtools/App/Features/Onboarding/Views/OnboardingTutorialIntroViewModel.swift
@@ -41,7 +41,7 @@ class OnboardingTutorialIntroViewModel: OnboardingTutorialIntroViewModelType {
         
         flowDelegate?.navigate(step: .videoButtonTappedFromOnboardingTutorial(youtubeVideoId: youtubeVideoId))
         
-        /*if !youTubeVideoTracked {
+        if !youTubeVideoTracked {
             
             youTubeVideoTracked = true
             
@@ -55,6 +55,6 @@ class OnboardingTutorialIntroViewModel: OnboardingTutorialIntroViewModelType {
                     data: ["cru.tutorial_video": 1, "video_id": youtubeVideoId]
                 )
             )
-        }*/
+        }
     }
 }

--- a/godtools/App/Features/Onboarding/Views/OnboardingTutorialIntroViewModelType.swift
+++ b/godtools/App/Features/Onboarding/Views/OnboardingTutorialIntroViewModelType.swift
@@ -14,4 +14,7 @@ protocol OnboardingTutorialIntroViewModelType {
     var logoImage: UIImage? { get }
     var title: String { get }
     var videoLinkLabel: String { get }
+    var youtubeVideoId: String { get }
+    
+    func videoLinkTapped()
 }

--- a/godtools/App/Features/Tutorial/TutorialView.swift
+++ b/godtools/App/Features/Tutorial/TutorialView.swift
@@ -22,7 +22,9 @@ class TutorialView: UIViewController {
     @IBOutlet weak private var pageControl: UIPageControl!
     
     required init(viewModel: TutorialViewModelType) {
+        
         self.viewModel = viewModel
+        
         super.init(nibName: String(describing: TutorialView.self), bundle: nil)
     }
     

--- a/godtools/App/Flows/FlowStep.swift
+++ b/godtools/App/Flows/FlowStep.swift
@@ -27,6 +27,9 @@ enum FlowStep {
     case openTutorialTapped
     
     // onboarding
+    case videoButtonTappedFromOnboardingTutorial(youtubeVideoId: String)
+    case closeVideoPlayerTappedFromOnboardingTutorial
+    case videoEndedOnOnboardingTutorial
     case skipTappedFromOnboardingTutorial
     case endTutorialFromOnboardingTutorial
     

--- a/godtools/App/Flows/OnboardingFlow.swift
+++ b/godtools/App/Flows/OnboardingFlow.swift
@@ -12,6 +12,8 @@ class OnboardingFlow: Flow {
     
     private weak var flowDelegate: FlowDelegate?
     
+    private var videoPlayerView: VideoPlayerView?
+    
     let appDiContainer: AppDiContainer
     let navigationController: UINavigationController
     
@@ -53,6 +55,25 @@ class OnboardingFlow: Flow {
         
         navigationController.setViewControllers([view], animated: false)
     }
+    
+    private func launchVideoPlayerView(youtubeVideoId: String) {
+        
+        let viewModel = VideoPlayerViewModel(FlowDelegate: self, youtubeVideoId: youtubeVideoId)
+        let view = VideoPlayerView(viewModel: viewModel)
+        
+        navigationController.present(view, animated: true, completion: nil)
+    }
+    
+    private func dismissVideoPlayerView() {
+        
+        navigationController.dismiss(animated: true, completion: nil)
+        videoPlayerView = nil
+    }
+    
+    private func dismissOnboardingFlow() {
+        
+        flowDelegate?.navigate(step: .dismissOnboardingTutorial)
+    }
 }
 
 extension OnboardingFlow: FlowDelegate {
@@ -61,11 +82,20 @@ extension OnboardingFlow: FlowDelegate {
         
         switch step {
             
+        case .videoButtonTappedFromOnboardingTutorial(let youtubeVideoId):
+            launchVideoPlayerView(youtubeVideoId: youtubeVideoId)
+        
+        case .closeVideoPlayerTappedFromOnboardingTutorial:
+            dismissVideoPlayerView()
+            
+        case .videoEndedOnOnboardingTutorial:
+            dismissVideoPlayerView()
+            
         case .skipTappedFromOnboardingTutorial:
-            flowDelegate?.navigate(step: .dismissOnboardingTutorial)
+            dismissOnboardingFlow()
             
         case .endTutorialFromOnboardingTutorial:
-            flowDelegate?.navigate(step: .dismissOnboardingTutorial)
+            dismissOnboardingFlow()
         
         default:
             break

--- a/godtools/App/Flows/OnboardingFlow.swift
+++ b/godtools/App/Flows/OnboardingFlow.swift
@@ -48,7 +48,7 @@ class OnboardingFlow: Flow {
             onboardingTutorialItemsRepository: onboardingTutorialItemsRepository,
             onboardingTutorialAvailability: appDiContainer.onboardingTutorialAvailability,
             openTutorialCalloutCache: appDiContainer.openTutorialCalloutCache,
-            customViewBuilder: appDiContainer.onboardingTutorialCustomViewBuilder(),
+            customViewBuilder: appDiContainer.onboardingTutorialCustomViewBuilder(flowDelegate: self),
             localizationServices: appDiContainer.localizationServices
         )
         let view = OnboardingTutorialView(viewModel: viewModel)
@@ -58,7 +58,7 @@ class OnboardingFlow: Flow {
     
     private func launchVideoPlayerView(youtubeVideoId: String) {
         
-        let viewModel = VideoPlayerViewModel(FlowDelegate: self, youtubeVideoId: youtubeVideoId)
+        let viewModel = VideoPlayerViewModel(flowDelegate: self, youtubeVideoId: youtubeVideoId)
         let view = VideoPlayerView(viewModel: viewModel)
         
         navigationController.present(view, animated: true, completion: nil)

--- a/godtools/App/Share/Views/TutorialPagerView/TutorialPagerView.xib
+++ b/godtools/App/Share/Views/TutorialPagerView/TutorialPagerView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>

--- a/godtools/App/Share/Views/VideoPlayerView/VideoPlayerView.swift
+++ b/godtools/App/Share/Views/VideoPlayerView/VideoPlayerView.swift
@@ -1,0 +1,128 @@
+//
+//  VideoPlayerView.swift
+//  godtools
+//
+//  Created by Robert Eldredge on 11/1/21.
+//  Copyright © 2021 Cru. All rights reserved.
+//
+
+import UIKit
+import youtube_ios_player_helper
+
+class VideoPlayerView: UIViewController {
+    
+    @IBOutlet weak private var youTubeVideoPlayer: YTPlayerView!
+    @IBOutlet weak private var youTubeVideoPlayerLoadingView: UIView!
+    @IBOutlet weak private var youTubeVideoPlayerActivityIndicator: UIActivityIndicatorView!
+    
+    private var viewModel: VideoPlayerViewModelType
+    
+    required init(viewModel: VideoPlayerViewModelType) {
+        
+        self.viewModel = viewModel
+        
+        super.init(nibName: String(describing: VideoPlayerView.self), bundle: nil)
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    deinit {
+        print("x deinit: \(type(of: self))")
+    }
+    
+    var youtubePlayerParameters: [String : Any]? {
+        let playsInFullScreen = 0
+        
+        return ["playsinline": playsInFullScreen]
+    }
+    
+    override func viewDidLoad() {
+        
+        super.viewDidLoad()
+        
+        loadYoutubePlayerVideo(videoId: viewModel.youtubeVideoId)
+    }
+    
+    private func loadYoutubePlayerVideo(videoId: String) {
+        
+        let hidesYouTubeVideoPlayer: Bool
+        
+        if !viewModel.youtubeVideoId.isEmpty {
+            hidesYouTubeVideoPlayer = false
+            youTubeVideoPlayerActivityIndicator.startAnimating()
+            youTubeVideoPlayer.delegate = self
+            youTubeVideoPlayer.load(withVideoId: viewModel.youtubeVideoId, playerVars: youtubePlayerParameters)
+        }
+        else {
+            hidesYouTubeVideoPlayer = true
+            youTubeVideoPlayer.stopVideo()
+            youTubeVideoPlayer.delegate = nil
+            youTubeVideoPlayerActivityIndicator.stopAnimating()
+        }
+
+        youTubeVideoPlayer.isHidden = hidesYouTubeVideoPlayer
+        youTubeVideoPlayerLoadingView.isHidden = hidesYouTubeVideoPlayer
+        
+        playVideo()
+    }
+    
+    private func playVideo() {
+        youTubeVideoPlayer.playVideo()
+    }
+    
+    private func stopVideo() {
+        youTubeVideoPlayer.stopVideo()
+    }
+}
+
+// MARK: - YTPlayerViewDelegate
+
+extension VideoPlayerView: YTPlayerViewDelegate {
+    
+    func playerViewDidBecomeReady(_ playerView: YTPlayerView) {
+        
+        UIView.animate(withDuration: 0.3, delay: 0, options: .curveEaseOut, animations: { [weak self] in
+            self?.youTubeVideoPlayerLoadingView.alpha = 0
+        }) { [weak self] (finished: Bool) in
+            self?.youTubeVideoPlayerLoadingView.isHidden = true
+            self?.youTubeVideoPlayerLoadingView.alpha = 1
+            self?.youTubeVideoPlayerActivityIndicator.stopAnimating()
+        }
+    }
+    
+    func playerView(_ playerView: YTPlayerView, didChangeTo state: YTPlayerState) {
+        
+        print("\n ToolDetailView playerView didChangeTo state")
+        switch state {
+            
+        case .unstarted:
+            print("unstarted")
+        case .ended:
+            print("ended")
+            viewModel.videoEnded()
+        case .playing:
+            print("playing")
+        case .paused:
+            print("paused")
+        case .buffering:
+            print("buffering")
+        case .cued:
+            print("cued")
+        case .unknown:
+            print("unknown")
+        @unknown default:
+            print("default")
+        }
+    }
+    
+    func playerView(_ playerView: YTPlayerView, didChangeTo quality: YTPlaybackQuality) {
+        print("\n ToolDetailView playerView didChangeTo quality")
+    }
+    
+    func playerView(_ playerView: YTPlayerError, receivedError error: YTPlayerError) {
+        print("\n TutorialCell: youTubeVideoPlayer receivedError")
+        print("  error: \(error)")
+    }
+}

--- a/godtools/App/Share/Views/VideoPlayerView/VideoPlayerView.swift
+++ b/godtools/App/Share/Views/VideoPlayerView/VideoPlayerView.swift
@@ -47,33 +47,22 @@ class VideoPlayerView: UIViewController {
     
     private func loadYoutubePlayerVideo(videoId: String) {
         
-        let hidesYouTubeVideoPlayer: Bool
-        
-        if !viewModel.youtubeVideoId.isEmpty {
-            hidesYouTubeVideoPlayer = false
-            youTubeVideoPlayerActivityIndicator.startAnimating()
-            youTubeVideoPlayer.delegate = self
-            youTubeVideoPlayer.load(withVideoId: viewModel.youtubeVideoId, playerVars: youtubePlayerParameters)
-        }
-        else {
-            hidesYouTubeVideoPlayer = true
+        if viewModel.youtubeVideoId.isEmpty {
             youTubeVideoPlayer.stopVideo()
             youTubeVideoPlayer.delegate = nil
             youTubeVideoPlayerActivityIndicator.stopAnimating()
+            youTubeVideoPlayer.isHidden = true
+            youTubeVideoPlayerLoadingView.isHidden = true
+            
+            return
         }
-
-        youTubeVideoPlayer.isHidden = hidesYouTubeVideoPlayer
-        youTubeVideoPlayerLoadingView.isHidden = hidesYouTubeVideoPlayer
         
-        playVideo()
-    }
-    
-    private func playVideo() {
+        youTubeVideoPlayer.delegate = self
+        youTubeVideoPlayerActivityIndicator.startAnimating()
+        youTubeVideoPlayer.load(withVideoId: viewModel.youtubeVideoId, playerVars: youtubePlayerParameters)
+        youTubeVideoPlayer.isHidden = false
+        youTubeVideoPlayerLoadingView.isHidden = false
         youTubeVideoPlayer.playVideo()
-    }
-    
-    private func stopVideo() {
-        youTubeVideoPlayer.stopVideo()
     }
 }
 

--- a/godtools/App/Share/Views/VideoPlayerView/VideoPlayerView.swift
+++ b/godtools/App/Share/Views/VideoPlayerView/VideoPlayerView.swift
@@ -33,9 +33,9 @@ class VideoPlayerView: UIViewController {
     }
     
     var youtubePlayerParameters: [String : Any]? {
-        let playsInFullScreen = 0
+        let disablesFullScreen = 1
         
-        return ["playsinline": playsInFullScreen]
+        return ["playsinline": disablesFullScreen]
     }
     
     override func viewDidLoad() {

--- a/godtools/App/Share/Views/VideoPlayerView/VideoPlayerView.swift
+++ b/godtools/App/Share/Views/VideoPlayerView/VideoPlayerView.swift
@@ -62,7 +62,6 @@ class VideoPlayerView: UIViewController {
         youTubeVideoPlayer.load(withVideoId: viewModel.youtubeVideoId, playerVars: youtubePlayerParameters)
         youTubeVideoPlayer.isHidden = false
         youTubeVideoPlayerLoadingView.isHidden = false
-        youTubeVideoPlayer.playVideo()
     }
 }
 
@@ -78,6 +77,8 @@ extension VideoPlayerView: YTPlayerViewDelegate {
             self?.youTubeVideoPlayerLoadingView.isHidden = true
             self?.youTubeVideoPlayerLoadingView.alpha = 1
             self?.youTubeVideoPlayerActivityIndicator.stopAnimating()
+            
+            self?.youTubeVideoPlayer.playVideo()
         }
     }
     

--- a/godtools/App/Share/Views/VideoPlayerView/VideoPlayerView.xib
+++ b/godtools/App/Share/Views/VideoPlayerView/VideoPlayerView.xib
@@ -4,7 +4,6 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
-        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -23,7 +22,6 @@
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0J7-7X-WaF" userLabel="youTubeVideoPlayer" customClass="YTPlayerView">
                     <rect key="frame" x="0.0" y="331.5" width="414" height="233"/>
-                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>
                         <constraint firstAttribute="width" secondItem="0J7-7X-WaF" secondAttribute="height" multiplier="16:9" id="aOP-Xa-DQh"/>
                     </constraints>
@@ -36,14 +34,12 @@
                             <color key="color" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         </activityIndicatorView>
                     </subviews>
-                    <color key="backgroundColor" red="0.90196078430000004" green="0.90196078430000004" blue="0.90196078430000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <constraints>
                         <constraint firstItem="yZl-3K-629" firstAttribute="centerY" secondItem="G6d-IV-qBu" secondAttribute="centerY" id="Yph-oQ-f8g"/>
                         <constraint firstItem="yZl-3K-629" firstAttribute="centerX" secondItem="G6d-IV-qBu" secondAttribute="centerX" id="pyY-fu-0cJ"/>
                     </constraints>
                 </view>
             </subviews>
-            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <constraints>
                 <constraint firstItem="G6d-IV-qBu" firstAttribute="bottom" secondItem="0J7-7X-WaF" secondAttribute="bottom" id="aAN-ty-9Ja"/>

--- a/godtools/App/Share/Views/VideoPlayerView/VideoPlayerView.xib
+++ b/godtools/App/Share/Views/VideoPlayerView/VideoPlayerView.xib
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="VideoPlayerView" customModule="godtools" customModuleProvider="target">
+            <connections>
+                <outlet property="youTubeVideoPlayer" destination="0J7-7X-WaF" id="Ssy-8P-W8P"/>
+                <outlet property="youTubeVideoPlayerActivityIndicator" destination="yZl-3K-629" id="EHr-ss-sKN"/>
+                <outlet property="youTubeVideoPlayerLoadingView" destination="G6d-IV-qBu" id="4Tz-om-ZGS"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB" userLabel="VideoPlayerView">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0J7-7X-WaF" userLabel="youTubeVideoPlayer" customClass="YTPlayerView">
+                    <rect key="frame" x="0.0" y="331.5" width="414" height="233"/>
+                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <constraints>
+                        <constraint firstAttribute="width" secondItem="0J7-7X-WaF" secondAttribute="height" multiplier="16:9" id="aOP-Xa-DQh"/>
+                    </constraints>
+                </view>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="G6d-IV-qBu" userLabel="youTubeVideoPlayerLoadingView">
+                    <rect key="frame" x="0.0" y="331.5" width="414" height="233"/>
+                    <subviews>
+                        <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="medium" translatesAutoresizingMaskIntoConstraints="NO" id="yZl-3K-629" userLabel="youTubeVideoPlayerActivityIndicator">
+                            <rect key="frame" x="197" y="106.5" width="20" height="20"/>
+                            <color key="color" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        </activityIndicatorView>
+                    </subviews>
+                    <color key="backgroundColor" red="0.90196078430000004" green="0.90196078430000004" blue="0.90196078430000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    <constraints>
+                        <constraint firstItem="yZl-3K-629" firstAttribute="centerY" secondItem="G6d-IV-qBu" secondAttribute="centerY" id="Yph-oQ-f8g"/>
+                        <constraint firstItem="yZl-3K-629" firstAttribute="centerX" secondItem="G6d-IV-qBu" secondAttribute="centerX" id="pyY-fu-0cJ"/>
+                    </constraints>
+                </view>
+            </subviews>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+            <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+            <constraints>
+                <constraint firstItem="G6d-IV-qBu" firstAttribute="bottom" secondItem="0J7-7X-WaF" secondAttribute="bottom" id="aAN-ty-9Ja"/>
+                <constraint firstItem="0J7-7X-WaF" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="bBk-VN-saX"/>
+                <constraint firstItem="0J7-7X-WaF" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="centerY" id="f0f-Da-7l8"/>
+                <constraint firstItem="G6d-IV-qBu" firstAttribute="top" secondItem="0J7-7X-WaF" secondAttribute="top" id="job-IR-hVR"/>
+                <constraint firstItem="0J7-7X-WaF" firstAttribute="width" secondItem="iN0-l3-epB" secondAttribute="width" id="lq7-c9-no7"/>
+                <constraint firstItem="0J7-7X-WaF" firstAttribute="width" secondItem="0J7-7X-WaF" secondAttribute="height" multiplier="16:9" id="qat-Yb-uR2"/>
+                <constraint firstItem="G6d-IV-qBu" firstAttribute="trailing" secondItem="0J7-7X-WaF" secondAttribute="trailing" id="tdP-4c-0f3"/>
+                <constraint firstItem="G6d-IV-qBu" firstAttribute="leading" secondItem="0J7-7X-WaF" secondAttribute="leading" id="uTB-qd-9Of"/>
+            </constraints>
+            <point key="canvasLocation" x="139" y="154"/>
+        </view>
+    </objects>
+</document>

--- a/godtools/App/Share/Views/VideoPlayerView/VideoPlayerView.xib
+++ b/godtools/App/Share/Views/VideoPlayerView/VideoPlayerView.xib
@@ -10,6 +10,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="VideoPlayerView" customModule="godtools" customModuleProvider="target">
             <connections>
+                <outlet property="view" destination="iN0-l3-epB" id="TiM-hf-IhD"/>
                 <outlet property="youTubeVideoPlayer" destination="0J7-7X-WaF" id="Ssy-8P-W8P"/>
                 <outlet property="youTubeVideoPlayerActivityIndicator" destination="yZl-3K-629" id="EHr-ss-sKN"/>
                 <outlet property="youTubeVideoPlayerLoadingView" destination="G6d-IV-qBu" id="4Tz-om-ZGS"/>

--- a/godtools/App/Share/Views/VideoPlayerView/VideoPlayerViewModel.swift
+++ b/godtools/App/Share/Views/VideoPlayerView/VideoPlayerViewModel.swift
@@ -1,0 +1,31 @@
+//
+//  VideoPlayerViewModel.swift
+//  godtools
+//
+//  Created by Robert Eldredge on 11/1/21.
+//  Copyright © 2021 Cru. All rights reserved.
+//
+
+import Foundation
+
+class VideoPlayerViewModel: VideoPlayerViewModelType {
+    
+    let youtubeVideoId: String
+    
+    required init (FlowDelegate: FlowDelegate?, youtubeVideoId: String) {
+        
+        self.youtubeVideoId = youtubeVideoId
+    }
+    
+    func closeButtonTapped() {
+        closeVideoPlayerView()
+    }
+    
+    func videoEnded() {
+        closeVideoPlayerView()
+    }
+    
+    private func closeVideoPlayerView() {
+        //TODO: Navigate Back to Onboarding-1
+    }
+}

--- a/godtools/App/Share/Views/VideoPlayerView/VideoPlayerViewModel.swift
+++ b/godtools/App/Share/Views/VideoPlayerView/VideoPlayerViewModel.swift
@@ -10,22 +10,24 @@ import Foundation
 
 class VideoPlayerViewModel: VideoPlayerViewModelType {
     
+    private weak var flowDelegate: FlowDelegate?
+    
     let youtubeVideoId: String
     
-    required init (FlowDelegate: FlowDelegate?, youtubeVideoId: String) {
+    required init (flowDelegate: FlowDelegate?, youtubeVideoId: String) {
+        
+        self.flowDelegate = flowDelegate
         
         self.youtubeVideoId = youtubeVideoId
     }
     
     func closeButtonTapped() {
-        closeVideoPlayerView()
+        
+        flowDelegate?.navigate(step: .closeVideoPlayerTappedFromOnboardingTutorial)
     }
     
     func videoEnded() {
-        closeVideoPlayerView()
-    }
-    
-    private func closeVideoPlayerView() {
-        //TODO: Navigate Back to Onboarding-1
+        
+        flowDelegate?.navigate(step: .videoEndedOnOnboardingTutorial)
     }
 }

--- a/godtools/App/Share/Views/VideoPlayerView/VideoPlayerViewModelType.swift
+++ b/godtools/App/Share/Views/VideoPlayerView/VideoPlayerViewModelType.swift
@@ -1,0 +1,17 @@
+//
+//  VideoPlayerViewModelType.swift
+//  godtools
+//
+//  Created by Robert Eldredge on 11/1/21.
+//  Copyright © 2021 Cru. All rights reserved.
+//
+
+import Foundation
+
+protocol VideoPlayerViewModelType {
+    
+    var youtubeVideoId: String { get }
+    
+    func closeButtonTapped()
+    func videoEnded()
+}


### PR DESCRIPTION
Added YouTube video player to the first screen of onboarding.  It's not perfect right now, there are some limitations that I ran into that's hard to resolve:

- I had to create a new screen to hold the UIView for the YouTube video player.
- The new screen appears on top of the TutorialPagerView like a drawer, with a bit of space at the top.  You can close the screen by swiping it down, and I believe that will stop the video and clean up the player.
- Preferably, I would like to have the video play in full screen, and use the "X" icon in YouTube's player view to close both the player and the drawer screen that contains it together.  So just pressing the "X" once should bring you right back to TutorialPagerView.  However, I can't find a good way to attach a callback to the "X" button that closes full screen, so I don't know how to make that work.  My temporary solution is to disable the full-screen for the video player, and have the user just swipe to close the drawer.  This is not ideal, but it should work.
- The video player and the drawer should both close once the video reaches the end, which is the desired behavior.