### PR TITLE
GT-1308 Fix positioning image to right of button title

### DIFF
--- a/godtools/App/Features/Onboarding/Views/OnboardingTutorialIntroView.swift
+++ b/godtools/App/Features/Onboarding/Views/OnboardingTutorialIntroView.swift
@@ -51,6 +51,8 @@ class OnboardingTutorialIntroView: UIView, NibBased {
     
     override func didMoveToSuperview() {
         
+        super.didMoveToSuperview()
+        
         guard superview != nil else {
             return
         }

--- a/godtools/App/Features/Onboarding/Views/OnboardingTutorialIntroView.swift
+++ b/godtools/App/Features/Onboarding/Views/OnboardingTutorialIntroView.swift
@@ -46,7 +46,16 @@ class OnboardingTutorialIntroView: UIView, NibBased {
         
         super.layoutSubviews()
         
-        videoButton.centerTitleAndSetImageRightOfTitleWithSpacing(spacing: 16)
+        layoutVideoButtonTitleAndImage()
+    }
+    
+    override func didMoveToSuperview() {
+        
+        guard superview != nil else {
+            return
+        }
+        
+        layoutVideoButtonTitleAndImage()
     }
     
     func configure(viewModel: OnboardingTutorialIntroViewModelType) {
@@ -54,16 +63,23 @@ class OnboardingTutorialIntroView: UIView, NibBased {
         self.viewModel = viewModel
         
         titleLabel.text = viewModel.title
-        videoButton.setTitle(viewModel.videoLinkLabel, for: .normal)
-        videoButton.setImage(UIImage(named: "play_icon"), for: .normal)
-        videoButton.setImageColor(color: UIColor(red: 0.23, green: 0.64, blue: 0.86, alpha: 1.0))
-        logoImageView.image = viewModel.logoImage
         
-        layoutIfNeeded()
+        videoButton.setTitle(viewModel.videoLinkLabel, for: .normal)
+        videoButton.setImage(ImageCatalog.playIcon.image, for: .normal)
+        videoButton.setImageColor(color: UIColor(red: 0.23, green: 0.64, blue: 0.86, alpha: 1.0))
+        layoutVideoButtonTitleAndImage()
+        
+        logoImageView.image = viewModel.logoImage
     }
     
     @objc private func videoLinkTapped (button: UIButton) {
         
         viewModel?.videoLinkTapped()
+    }
+    
+    private func layoutVideoButtonTitleAndImage() {
+        
+        videoButton.layoutIfNeeded()
+        videoButton.centerTitleAndSetImageRightOfTitleWithSpacing(spacing: 7)
     }
 }

--- a/godtools/App/Features/Tools/Views/OpenTutorialView/OpenTutorialView.swift
+++ b/godtools/App/Features/Tools/Views/OpenTutorialView/OpenTutorialView.swift
@@ -25,7 +25,7 @@ class OpenTutorialView: UIView, NibBased {
     
     override func layoutSubviews() {
         super.layoutSubviews()
-        openTutorialButton.centerTitleAndSetImageRightOfTitleWithSpacing(spacing: 16)
+        openTutorialButton.centerTitleAndSetImageRightOfTitleWithSpacing(spacing: 7)
     }
     
     func configure(viewModel: OpenTutorialViewModelType) {

--- a/godtools/App/Share/Extensions/UIKit+Extensions.swift
+++ b/godtools/App/Share/Extensions/UIKit+Extensions.swift
@@ -25,7 +25,7 @@ extension UIButton {
             let titleLeft: CGFloat = (buttonWidth / 2 - titleWidth / 2) - imageWidth
             
             titleEdgeInsets = UIEdgeInsets(top: 0, left: titleLeft, bottom: 0, right: 0)
-            imageEdgeInsets = UIEdgeInsets(top: 0, left: titleLeft + titleWidth + spacing, bottom: 0, right: 0)
+            imageEdgeInsets = UIEdgeInsets(top: 0, left: titleLeft + titleWidth + imageWidth + spacing, bottom: 0, right: 0)
         }
     }
     

--- a/godtools/App/Share/ImageCatalog.swift
+++ b/godtools/App/Share/ImageCatalog.swift
@@ -23,6 +23,7 @@ enum ImageCatalog: String {
     case navSettings = "nav_gear"
     case navShare = "share"
     case notFavorited = "not_favorited"
+    case playIcon = "play_icon"
     case toolsMenuLessons = "tools_menu_lessons"
     case toolsMenuFavorites = "tools_menu_favorites"
     case toolsMenuAllTools = "tools_menu_all_tools"


### PR DESCRIPTION
Hey @reldredge71 this should do it.  One I had to force the layout on the button by calling layoutIfNeeded, and also added an override for when the view is actually added to the superview and updating the button layout when that happens because when we configure that view it's not even part of the view hierarchy at that point.

Also fixed the shared extension by including the imageWidth when positioning the image to the right of the button title. Including that imageWidth places the image left edge right on the title right edge.