### PR TITLE
GT add git push to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,3 +66,7 @@ jobs:
           MATCH_GIT_BASIC_AUTHORIZATION_PAT: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION_PAT }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
         run: bundle exec fastlane cru_shared_lane_build_and_deploy_for_testflight_release is_running_in_ci:true
+
+      - name: Push Commits To Git
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        run: git push

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,6 +67,6 @@ jobs:
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
         run: bundle exec fastlane cru_shared_lane_build_and_deploy_for_testflight_release is_running_in_ci:true
 
-      - name: Push Commits To Git
+      - name: Push Commits To Remote
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         run: git push


### PR DESCRIPTION
Hey @frett adding that ```git push``` step to push any commits during the workflow.  I'm not sure if I will need to use any GITHUB_TOKEN or personal access token?  