### PR TITLE
GT-1359 Fix status bar for iOS 11

### DIFF
--- a/godtools/App/AppDelegate.swift
+++ b/godtools/App/AppDelegate.swift
@@ -19,6 +19,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     var window: UIWindow?
     
+    static func setWindowBackgroundColorForStatusBarColor(color: UIColor) {
+        (UIApplication.shared.delegate as? AppDelegate)?.window?.backgroundColor = color
+    }
+    
     override init() {
         
         appDiContainer = AppDiContainer(appDeepLinkingService: appDeepLinkingService)

--- a/godtools/App/Flows/AppFlow.swift
+++ b/godtools/App/Flows/AppFlow.swift
@@ -47,7 +47,7 @@ class AppFlow: NSObject, Flow {
         super.init()
         
         rootController.view.frame = UIScreen.main.bounds
-        rootController.view.backgroundColor = UIColor.white
+        rootController.view.backgroundColor = .clear
         
         navigationController.view.backgroundColor = .white
         navigationController.setNavigationBarHidden(true, animated: false)

--- a/godtools/App/Flows/MenuFlow.swift
+++ b/godtools/App/Flows/MenuFlow.swift
@@ -30,7 +30,7 @@ class MenuFlow: Flow {
         navigationController.setNavigationBarHidden(false, animated: false)
         
         navigationController.navigationBar.setupNavigationBarAppearance(
-            backgroundColor: ColorPalette.gtBlue.color,
+            backgroundColor: ColorPalette.primaryNavBar.color,
             controlColor: .white,
             titleFont: fontService.getFont(size: 17, weight: .semibold),
             titleColor: .white,

--- a/godtools/App/Flows/ToolsFlow.swift
+++ b/godtools/App/Flows/ToolsFlow.swift
@@ -58,12 +58,14 @@ class ToolsFlow: ToolNavigationFlow, Flow {
     
     private func configureNavigationBar(shouldAnimateNavigationBarHiddenState: Bool) {
         
+        AppDelegate.setWindowBackgroundColorForStatusBarColor(color: ColorPalette.primaryNavBar.color)
+        
         navigationController.setNavigationBarHidden(false, animated: shouldAnimateNavigationBarHiddenState)
         
         let fontService: FontService = appDiContainer.getFontService()
         
         navigationController.navigationBar.setupNavigationBarAppearance(
-            backgroundColor: ColorPalette.gtBlue.color,
+            backgroundColor: ColorPalette.primaryNavBar.color,
             controlColor: .white,
             titleFont: fontService.getFont(size: 17, weight: .semibold),
             titleColor: .white,

--- a/godtools/App/Share/ColorPalette.swift
+++ b/godtools/App/Share/ColorPalette.swift
@@ -7,16 +7,23 @@
 //
 
 import Foundation
+import UIKit
 
 enum ColorPalette {
     
     case gtBlue
+    case primaryNavBar
     
     var color: UIColor {
-        
         switch self {
         case .gtBlue:
-            return UIColor(red: 59.0/255.0, green: 164.0/255.0, blue: 219.0/255.0, alpha: 1.0)
+            return getGtBlueColor()
+        case .primaryNavBar:
+            return getGtBlueColor()
         }
+    }
+    
+    private func getGtBlueColor() -> UIColor {
+        return UIColor(red: 59.0/255.0, green: 164.0/255.0, blue: 219.0/255.0, alpha: 1.0)
     }
 }

--- a/godtools/Info.plist
+++ b/godtools/Info.plist
@@ -94,10 +94,6 @@
 	<array>
 		<string>armv7</string>
 	</array>
-	<key>UIStatusBarHidden</key>
-	<false/>
-	<key>UIStatusBarStyle</key>
-	<string>UIStatusBarStyleLightContent</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>


### PR DESCRIPTION
Fixed status bar for iOS 11 by setting window background color to match navigation bar background color.  Doesn't effect iOS 13 and up because status bar color will use the navigation bar color by default.