### PR TITLE
GT-1366 allow buttons to have multiple lines of text

### DIFF
--- a/godtools/App/Services/Renderer/Parser/Protocol/Models/MobileContentButtonIcon.swift
+++ b/godtools/App/Services/Renderer/Parser/Protocol/Models/MobileContentButtonIcon.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2021 Cru. All rights reserved.
 //
 
-import Foundation
 import UIKit
 
 struct MobileContentButtonIcon {

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentButton/MobileContentButtonView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentButton/MobileContentButtonView.swift
@@ -17,6 +17,7 @@ class MobileContentButtonView: MobileContentView {
     private let buttonTitle: UILabel = UILabel()
     private let buttonImagePaddingToButtonTitle: CGFloat = 12
     
+    private var tapGesture: UITapGestureRecognizer?
     private var buttonImageView: UIImageView?
     
     required init(viewModel: MobileContentButtonViewModelType) {
@@ -28,7 +29,10 @@ class MobileContentButtonView: MobileContentView {
         setupLayout()
         setupBinding()
         
-        //button.addTarget(self, action: #selector(handleButtonTapped), for: .touchUpInside)
+        // tapGesture
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(buttonTapped))
+        addGestureRecognizer(tapGesture)
+        self.tapGesture = tapGesture
     }
     
     required init?(coder: NSCoder) {
@@ -42,6 +46,8 @@ class MobileContentButtonView: MobileContentView {
         // buttonTitle
         addButtonTitleAndConstraints(buttonTitle: buttonTitle, buttonIcon: viewModel.icon)
         
+        buttonTitle.isUserInteractionEnabled = false
+        buttonTitle.backgroundColor = .clear
         buttonTitle.numberOfLines = 0
         buttonTitle.lineBreakMode = .byWordWrapping
         buttonTitle.textAlignment = .center
@@ -50,6 +56,8 @@ class MobileContentButtonView: MobileContentView {
         if let buttonIcon = viewModel.icon {
             
             let buttonImageView: UIImageView = UIImageView(image: buttonIcon.image)
+            buttonImageView.isUserInteractionEnabled = false
+            buttonImageView.backgroundColor = .clear
             
             addButtonImageViewAndConstraints(buttonImageView: buttonImageView, buttonIcon: buttonIcon)
             
@@ -75,7 +83,7 @@ class MobileContentButtonView: MobileContentView {
         }
     }
     
-    @objc func handleButtonTapped() {
+    @objc private func buttonTapped() {
         
         switch viewModel.buttonType {
         

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentButton/MobileContentButtonView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentButton/MobileContentButtonView.swift
@@ -15,6 +15,7 @@ class MobileContentButtonView: MobileContentView {
     
     private let viewModel: MobileContentButtonViewModelType
     private let buttonTitle: UILabel = UILabel()
+    private let buttonImagePaddingToButtonTitle: CGFloat = 12
     
     private var buttonImageView: UIImageView?
     
@@ -72,10 +73,6 @@ class MobileContentButtonView: MobileContentView {
         viewModel.visibilityState.addObserver(self) { [weak self] (visibilityState: MobileContentViewVisibilityState) in
             self?.setVisibilityState(visibilityState: visibilityState)
         }
-        
-        drawBorder(color: .green)
-        buttonTitle.drawBorder(color: .blue)
-        buttonImageView?.drawBorder(color: .red)
     }
     
     @objc func handleButtonTapped() {
@@ -112,85 +109,26 @@ extension MobileContentButtonView {
         
         buttonTitle.translatesAutoresizingMaskIntoConstraints = false
         
-        // top
-        let top: NSLayoutConstraint = NSLayoutConstraint(
-            item: buttonTitle,
-            attribute: .top,
-            relatedBy: .equal,
-            toItem: self,
-            attribute: .top,
-            multiplier: 1,
-            constant: 0
-        )
+        buttonTitle.constrainTopToView(view: self)
         
-        addConstraint(top)
-        
-        // bottom
-        let bottom: NSLayoutConstraint = NSLayoutConstraint(
-            item: buttonTitle,
-            attribute: .bottom,
-            relatedBy: .equal,
-            toItem: self,
-            attribute: .bottom,
-            multiplier: 1,
-            constant: 0
-        )
-        
-        addConstraint(bottom)
+        buttonTitle.constrainBottomToView(view: self)
         
         if buttonIcon != nil {
             
-            let centerHorizontally: NSLayoutConstraint = NSLayoutConstraint(
-                item: buttonTitle,
-                attribute: .centerX,
-                relatedBy: .equal,
-                toItem: self,
-                attribute: .centerX,
-                multiplier: 1,
-                constant: 0
-            )
-            
-            addConstraint(centerHorizontally)
+            buttonTitle.constrainCenterHorizontallyInView(view: self)
         }
         else {
             
-            let leading: NSLayoutConstraint = NSLayoutConstraint(
-                item: buttonTitle,
-                attribute: .leading,
-                relatedBy: .equal,
-                toItem: self,
-                attribute: .leading,
-                multiplier: 1,
-                constant: 0
-            )
+            buttonTitle.constrainLeadingToView(view: self)
             
-            addConstraint(leading)
-            
-            let trailing: NSLayoutConstraint = NSLayoutConstraint(
-                item: buttonTitle,
-                attribute: .trailing,
-                relatedBy: .equal,
-                toItem: self,
-                attribute: .trailing,
-                multiplier: 1,
-                constant: 0
-            )
-            
-            addConstraint(trailing)
+            buttonTitle.constrainTrailingToView(view: self)
         }
         
-        // height
-        let heightConstraint: NSLayoutConstraint = NSLayoutConstraint(
-            item: buttonTitle,
-            attribute: .height,
+        buttonTitle.addHeightConstraint(
+            constant: CGFloat(MobileContentButtonView.buttonHeight),
             relatedBy: .greaterThanOrEqual,
-            toItem: nil,
-            attribute: .notAnAttribute,
-            multiplier: 1,
-            constant: CGFloat(MobileContentButtonView.buttonHeight)
+            priority: 1000
         )
-        heightConstraint.priority = UILayoutPriority(1000)
-        buttonTitle.addConstraint(heightConstraint)
     }
     
     private func addButtonImageViewAndConstraints(buttonImageView: UIImageView, buttonIcon: MobileContentButtonIcon) {
@@ -198,19 +136,9 @@ extension MobileContentButtonView {
         addSubview(buttonImageView)
         
         buttonImageView.translatesAutoresizingMaskIntoConstraints = false
-               
-        let centerVertically: NSLayoutConstraint = NSLayoutConstraint(
-            item: buttonImageView,
-            attribute: .centerY,
-            relatedBy: .equal,
-            toItem: self,
-            attribute: .centerY,
-            multiplier: 1,
-            constant: 0
-        )
         
-        addConstraint(centerVertically)
-                
+        buttonImageView.constrainCenterVerticallyInView(view: self)
+                        
         switch buttonIcon.gravity {
         
         case .start:
@@ -222,7 +150,7 @@ extension MobileContentButtonView {
                 toItem: buttonTitle,
                 attribute: .leading,
                 multiplier: 1,
-                constant: 0
+                constant: buttonImagePaddingToButtonTitle * -1
             )
             
             addConstraint(trailing)
@@ -236,13 +164,14 @@ extension MobileContentButtonView {
                 toItem: buttonTitle,
                 attribute: .trailing,
                 multiplier: 1,
-                constant: 0
+                constant: buttonImagePaddingToButtonTitle
             )
             
             addConstraint(leading)
         }
         
         buttonImageView.addWidthConstraint(constant: CGFloat(buttonIcon.size))
+        
         buttonImageView.addHeightConstraint(constant: CGFloat(buttonIcon.size))
     }
 }

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentButton/MobileContentButtonView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentButton/MobileContentButtonView.swift
@@ -11,10 +11,12 @@ import UIKit
 
 class MobileContentButtonView: MobileContentView {
     
-    static let buttonHeight = 50
+    private static let buttonHeight = 50
     
     private let viewModel: MobileContentButtonViewModelType
-    private let button: UIButton = UIButton(type: .custom)
+    private let buttonTitle: UILabel = UILabel()
+    
+    private var buttonImageView: UIImageView?
     
     required init(viewModel: MobileContentButtonViewModelType) {
         
@@ -25,7 +27,7 @@ class MobileContentButtonView: MobileContentView {
         setupLayout()
         setupBinding()
         
-        button.addTarget(self, action: #selector(handleButtonTapped), for: .touchUpInside)
+        //button.addTarget(self, action: #selector(handleButtonTapped), for: .touchUpInside)
     }
     
     required init?(coder: NSCoder) {
@@ -34,55 +36,46 @@ class MobileContentButtonView: MobileContentView {
     
     private func setupLayout() {
         
-        // button
-        addSubview(button)
-        button.constrainEdgesToSuperview()
+        layer.cornerRadius = 5
         
-        let heightConstraint: NSLayoutConstraint = NSLayoutConstraint(
-            item: button,
-            attribute: .height,
-            relatedBy: .equal,
-            toItem: nil,
-            attribute: .notAnAttribute,
-            multiplier: 1,
-            constant: CGFloat(MobileContentButtonView.buttonHeight)
-        )
-        heightConstraint.priority = UILayoutPriority(1000)
-        button.addConstraint(heightConstraint)
+        // buttonTitle
+        addButtonTitleAndConstraints(buttonTitle: buttonTitle, buttonIcon: viewModel.icon)
         
-        button.layer.cornerRadius = 5
+        buttonTitle.numberOfLines = 0
+        buttonTitle.lineBreakMode = .byWordWrapping
+        buttonTitle.textAlignment = .center
+        
+        // buttonImageView
+        if let buttonIcon = viewModel.icon {
+            
+            let buttonImageView: UIImageView = UIImageView(image: buttonIcon.image)
+            
+            addButtonImageViewAndConstraints(buttonImageView: buttonImageView, buttonIcon: buttonIcon)
+            
+            self.buttonImageView = buttonImageView
+        }
     }
     
     private func setupBinding() {
         
-        button.backgroundColor = viewModel.backgroundColor
-        button.titleLabel?.font = viewModel.font
-        button.setTitle(viewModel.title, for: .normal)
-        button.setTitleColor(viewModel.titleColor, for: .normal)
+        backgroundColor = viewModel.backgroundColor
         
         if let borderColor = viewModel.borderColor, let borderWidth = viewModel.borderWidth {
-            button.layer.borderColor = borderColor.cgColor
-            button.layer.borderWidth = borderWidth
+            layer.borderColor = borderColor.cgColor
+            layer.borderWidth = borderWidth
         }
         
-        if let icon = viewModel.icon {
-            
-            if icon.gravity == .end {
-                button.semanticContentAttribute = UIApplication.shared.userInterfaceLayoutDirection == .rightToLeft ? .forceLeftToRight : .forceRightToLeft
-            }
-            
-            button.setImage(icon.image, for: .normal)
-            
-            button.setInsets(forContentPadding:
-                UIEdgeInsets(top: 6, left: 6, bottom: 6, right: 6),
-                imageTitlePadding: 10,
-                iconGravity: icon.gravity
-            )
-        }
-        
+        buttonTitle.font = viewModel.font
+        buttonTitle.text = viewModel.title
+        buttonTitle.textColor = viewModel.titleColor
+    
         viewModel.visibilityState.addObserver(self) { [weak self] (visibilityState: MobileContentViewVisibilityState) in
             self?.setVisibilityState(visibilityState: visibilityState)
         }
+        
+        drawBorder(color: .green)
+        buttonTitle.drawBorder(color: .blue)
+        buttonImageView?.drawBorder(color: .red)
     }
     
     @objc func handleButtonTapped() {
@@ -106,5 +99,150 @@ class MobileContentButtonView: MobileContentView {
     
     override var heightConstraintType: MobileContentViewHeightConstraintType {
         return .constrainedToChildren
+    }
+}
+
+// MARK: - Constraints
+
+extension MobileContentButtonView {
+
+    private func addButtonTitleAndConstraints(buttonTitle: UILabel, buttonIcon: MobileContentButtonIcon?) {
+        
+        addSubview(buttonTitle)
+        
+        buttonTitle.translatesAutoresizingMaskIntoConstraints = false
+        
+        // top
+        let top: NSLayoutConstraint = NSLayoutConstraint(
+            item: buttonTitle,
+            attribute: .top,
+            relatedBy: .equal,
+            toItem: self,
+            attribute: .top,
+            multiplier: 1,
+            constant: 0
+        )
+        
+        addConstraint(top)
+        
+        // bottom
+        let bottom: NSLayoutConstraint = NSLayoutConstraint(
+            item: buttonTitle,
+            attribute: .bottom,
+            relatedBy: .equal,
+            toItem: self,
+            attribute: .bottom,
+            multiplier: 1,
+            constant: 0
+        )
+        
+        addConstraint(bottom)
+        
+        if buttonIcon != nil {
+            
+            let centerHorizontally: NSLayoutConstraint = NSLayoutConstraint(
+                item: buttonTitle,
+                attribute: .centerX,
+                relatedBy: .equal,
+                toItem: self,
+                attribute: .centerX,
+                multiplier: 1,
+                constant: 0
+            )
+            
+            addConstraint(centerHorizontally)
+        }
+        else {
+            
+            let leading: NSLayoutConstraint = NSLayoutConstraint(
+                item: buttonTitle,
+                attribute: .leading,
+                relatedBy: .equal,
+                toItem: self,
+                attribute: .leading,
+                multiplier: 1,
+                constant: 0
+            )
+            
+            addConstraint(leading)
+            
+            let trailing: NSLayoutConstraint = NSLayoutConstraint(
+                item: buttonTitle,
+                attribute: .trailing,
+                relatedBy: .equal,
+                toItem: self,
+                attribute: .trailing,
+                multiplier: 1,
+                constant: 0
+            )
+            
+            addConstraint(trailing)
+        }
+        
+        // height
+        let heightConstraint: NSLayoutConstraint = NSLayoutConstraint(
+            item: buttonTitle,
+            attribute: .height,
+            relatedBy: .greaterThanOrEqual,
+            toItem: nil,
+            attribute: .notAnAttribute,
+            multiplier: 1,
+            constant: CGFloat(MobileContentButtonView.buttonHeight)
+        )
+        heightConstraint.priority = UILayoutPriority(1000)
+        buttonTitle.addConstraint(heightConstraint)
+    }
+    
+    private func addButtonImageViewAndConstraints(buttonImageView: UIImageView, buttonIcon: MobileContentButtonIcon) {
+        
+        addSubview(buttonImageView)
+        
+        buttonImageView.translatesAutoresizingMaskIntoConstraints = false
+               
+        let centerVertically: NSLayoutConstraint = NSLayoutConstraint(
+            item: buttonImageView,
+            attribute: .centerY,
+            relatedBy: .equal,
+            toItem: self,
+            attribute: .centerY,
+            multiplier: 1,
+            constant: 0
+        )
+        
+        addConstraint(centerVertically)
+                
+        switch buttonIcon.gravity {
+        
+        case .start:
+            
+            let trailing: NSLayoutConstraint = NSLayoutConstraint(
+                item: buttonImageView,
+                attribute: .trailing,
+                relatedBy: .equal,
+                toItem: buttonTitle,
+                attribute: .leading,
+                multiplier: 1,
+                constant: 0
+            )
+            
+            addConstraint(trailing)
+            
+        case .end:
+            
+            let leading: NSLayoutConstraint = NSLayoutConstraint(
+                item: buttonImageView,
+                attribute: .leading,
+                relatedBy: .equal,
+                toItem: buttonTitle,
+                attribute: .trailing,
+                multiplier: 1,
+                constant: 0
+            )
+            
+            addConstraint(leading)
+        }
+        
+        buttonImageView.addWidthConstraint(constant: CGFloat(buttonIcon.size))
+        buttonImageView.addHeightConstraint(constant: CGFloat(buttonIcon.size))
     }
 }

--- a/godtools/App/Share/Extensions/UIView+Constraints.swift
+++ b/godtools/App/Share/Extensions/UIView+Constraints.swift
@@ -12,54 +12,126 @@ extension UIView {
     
     func constrainEdgesToSuperview(edgeInsets: UIEdgeInsets = .zero) {
         
-        if let superview = superview {
-            
-            translatesAutoresizingMaskIntoConstraints = false
-            
-            let leading: NSLayoutConstraint = NSLayoutConstraint(
-                item: self,
-                attribute: .leading,
-                relatedBy: .equal,
-                toItem: superview,
-                attribute: .leading,
-                multiplier: 1,
-                constant: edgeInsets.left
-            )
-            
-            let trailing: NSLayoutConstraint = NSLayoutConstraint(
-                item: self,
-                attribute: .trailing,
-                relatedBy: .equal,
-                toItem: superview,
-                attribute: .trailing,
-                multiplier: 1,
-                constant: edgeInsets.right * -1
-            )
-            
-            let top: NSLayoutConstraint = NSLayoutConstraint(
-                item: self,
-                attribute: .top,
-                relatedBy: .equal,
-                toItem: superview,
-                attribute: .top,
-                multiplier: 1,
-                constant: edgeInsets.top
-            )
-            
-            let bottom: NSLayoutConstraint = NSLayoutConstraint(
-                item: self,
-                attribute: .bottom,
-                relatedBy: .equal,
-                toItem: superview,
-                attribute: .bottom,
-                multiplier: 1,
-                constant: edgeInsets.bottom * -1
-            )
-            
-            superview.addConstraint(leading)
-            superview.addConstraint(trailing)
-            superview.addConstraint(top)
-            superview.addConstraint(bottom)
+        guard let superview = self.superview else {
+            assertionFailure("Failed to constrain view edges to superview because a superview does not exist.  Is view added to a view hierarchy?")
+            return
         }
+        
+        translatesAutoresizingMaskIntoConstraints = false
+        
+        let leading: NSLayoutConstraint = NSLayoutConstraint(
+            item: self,
+            attribute: .leading,
+            relatedBy: .equal,
+            toItem: superview,
+            attribute: .leading,
+            multiplier: 1,
+            constant: edgeInsets.left
+        )
+        
+        let trailing: NSLayoutConstraint = NSLayoutConstraint(
+            item: self,
+            attribute: .trailing,
+            relatedBy: .equal,
+            toItem: superview,
+            attribute: .trailing,
+            multiplier: 1,
+            constant: edgeInsets.right * -1
+        )
+        
+        let top: NSLayoutConstraint = NSLayoutConstraint(
+            item: self,
+            attribute: .top,
+            relatedBy: .equal,
+            toItem: superview,
+            attribute: .top,
+            multiplier: 1,
+            constant: edgeInsets.top
+        )
+        
+        let bottom: NSLayoutConstraint = NSLayoutConstraint(
+            item: self,
+            attribute: .bottom,
+            relatedBy: .equal,
+            toItem: superview,
+            attribute: .bottom,
+            multiplier: 1,
+            constant: edgeInsets.bottom * -1
+        )
+        
+        superview.addConstraint(leading)
+        superview.addConstraint(trailing)
+        superview.addConstraint(top)
+        superview.addConstraint(bottom)
+    }
+    
+    func centerHorizontallyToSuperview() {
+        
+        guard let superview = superview else {
+            assertionFailure("Failed to center view horizontally because a superview does not exist.  Is view added to a view hierarchy?")
+            return
+        }
+        
+        let centerHorizontally: NSLayoutConstraint = NSLayoutConstraint(
+            item: self,
+            attribute: .centerX,
+            relatedBy: .equal,
+            toItem: superview,
+            attribute: .centerX,
+            multiplier: 1,
+            constant: 0
+        )
+        
+        addConstraint(centerHorizontally)
+    }
+    
+    func centerVerticallyToSuperview() {
+        
+        guard let superview = superview else {
+            assertionFailure("Failed to center view vertically because a superview does not exist.  Is view added to a view hierarchy?")
+            return
+        }
+        
+        let centerVertically: NSLayoutConstraint = NSLayoutConstraint(
+            item: self,
+            attribute: .centerY,
+            relatedBy: .equal,
+            toItem: superview,
+            attribute: .centerY,
+            multiplier: 1,
+            constant: 0
+        )
+        
+        superview.addConstraint(centerVertically)
+    }
+    
+    func addWidthConstraint(constant: CGFloat, priority: CGFloat = 1000) {
+        
+        let widthConstraint: NSLayoutConstraint = NSLayoutConstraint(
+            item: self,
+            attribute: .width,
+            relatedBy: .equal,
+            toItem: nil,
+            attribute: .notAnAttribute,
+            multiplier: 1,
+            constant: constant
+        )
+        widthConstraint.priority = UILayoutPriority(Float(priority))
+        addConstraint(widthConstraint)
+    }
+    
+    func addHeightConstraint(constant: CGFloat, priority: CGFloat = 1000) {
+        
+        let heightConstraint: NSLayoutConstraint = NSLayoutConstraint(
+            item: self,
+            attribute: .height,
+            relatedBy: .equal,
+            toItem: nil,
+            attribute: .notAnAttribute,
+            multiplier: 1,
+            constant: constant
+        )
+        heightConstraint.priority = UILayoutPriority(Float(priority))
+        addConstraint(heightConstraint)
     }
 }

--- a/godtools/App/Share/Extensions/UIView+Constraints.swift
+++ b/godtools/App/Share/Extensions/UIView+Constraints.swift
@@ -13,10 +13,13 @@ extension UIView {
     func constrainEdgesToSuperview(edgeInsets: UIEdgeInsets = .zero) {
         
         guard let superview = self.superview else {
-            assertionFailure("Failed to constrain view edges to superview because a superview does not exist.  Is view added to a view hierarchy?")
+            // TODO: Instead of checking for superview, force view as argument. ~Levi
+            //assertionFailure("Failed to constrain view edges to superview because a superview does not exist.  Is view added to a view hierarchy?")
+            print("\n WARNING: Failed to constrain edges to superview because superview is null.")
             return
         }
         
+        // TODO: Don't set this here, require caller to make this. ~Levi
         translatesAutoresizingMaskIntoConstraints = false
         
         let leading: NSLayoutConstraint = NSLayoutConstraint(
@@ -65,44 +68,94 @@ extension UIView {
         superview.addConstraint(bottom)
     }
     
-    func centerHorizontallyToSuperview() {
+    func constrainTopToView(view: UIView) {
         
-        guard let superview = superview else {
-            assertionFailure("Failed to center view horizontally because a superview does not exist.  Is view added to a view hierarchy?")
-            return
-        }
+        let top: NSLayoutConstraint = NSLayoutConstraint(
+            item: self,
+            attribute: .top,
+            relatedBy: .equal,
+            toItem: view,
+            attribute: .top,
+            multiplier: 1,
+            constant: 0
+        )
+        
+        view.addConstraint(top)
+    }
+    
+    func constrainBottomToView(view: UIView) {
+        
+        let bottom: NSLayoutConstraint = NSLayoutConstraint(
+            item: self,
+            attribute: .bottom,
+            relatedBy: .equal,
+            toItem: view,
+            attribute: .bottom,
+            multiplier: 1,
+            constant: 0
+        )
+        
+        view.addConstraint(bottom)
+    }
+    
+    func constrainLeadingToView(view: UIView) {
+        
+        let leading: NSLayoutConstraint = NSLayoutConstraint(
+            item: self,
+            attribute: .leading,
+            relatedBy: .equal,
+            toItem: view,
+            attribute: .leading,
+            multiplier: 1,
+            constant: 0
+        )
+        
+        view.addConstraint(leading)
+    }
+    
+    func constrainTrailingToView(view: UIView) {
+        
+        let trailing: NSLayoutConstraint = NSLayoutConstraint(
+            item: self,
+            attribute: .trailing,
+            relatedBy: .equal,
+            toItem: view,
+            attribute: .trailing,
+            multiplier: 1,
+            constant: 0
+        )
+        
+        view.addConstraint(trailing)
+    }
+    
+    func constrainCenterHorizontallyInView(view: UIView) {
         
         let centerHorizontally: NSLayoutConstraint = NSLayoutConstraint(
             item: self,
             attribute: .centerX,
             relatedBy: .equal,
-            toItem: superview,
+            toItem: view,
             attribute: .centerX,
             multiplier: 1,
             constant: 0
         )
         
-        addConstraint(centerHorizontally)
+        view.addConstraint(centerHorizontally)
     }
     
-    func centerVerticallyToSuperview() {
-        
-        guard let superview = superview else {
-            assertionFailure("Failed to center view vertically because a superview does not exist.  Is view added to a view hierarchy?")
-            return
-        }
+    func constrainCenterVerticallyInView(view: UIView) {
         
         let centerVertically: NSLayoutConstraint = NSLayoutConstraint(
             item: self,
             attribute: .centerY,
             relatedBy: .equal,
-            toItem: superview,
+            toItem: view,
             attribute: .centerY,
             multiplier: 1,
             constant: 0
         )
         
-        superview.addConstraint(centerVertically)
+        view.addConstraint(centerVertically)
     }
     
     func addWidthConstraint(constant: CGFloat, priority: CGFloat = 1000) {
@@ -120,12 +173,12 @@ extension UIView {
         addConstraint(widthConstraint)
     }
     
-    func addHeightConstraint(constant: CGFloat, priority: CGFloat = 1000) {
+    func addHeightConstraint(constant: CGFloat, relatedBy: NSLayoutConstraint.Relation = .equal, priority: CGFloat = 1000) {
         
         let heightConstraint: NSLayoutConstraint = NSLayoutConstraint(
             item: self,
             attribute: .height,
-            relatedBy: .equal,
+            relatedBy: relatedBy,
             toItem: nil,
             attribute: .notAnAttribute,
             multiplier: 1,


### PR DESCRIPTION
- Changes to MobileContentButtonView to support multiline text.  Had to remove UIButton because it is very difficult to use the System UIButton with multiline text and image.  Instead using UILabel and UIImageView and manually adding constraints.

![lesson-test](https://user-images.githubusercontent.com/59846460/144911464-e0ed3d9e-f956-4e38-a3a1-d0c185642f84.png)

![button-styles](https://user-images.githubusercontent.com/59846460/144911492-a45aa5a0-ab3c-4c31-a962-0c6bec4d9168.png)


