### PR TITLE
set XCode version in GHA build job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,9 @@ jobs:
   
   build:
     runs-on: macos-11
-    
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_13.2.app/Contents/Developer
+
     steps:
       
       - name: Checkout code


### PR DESCRIPTION
Use environment variable to set GHA to use XCode 13.2.