### PR TITLE
GT Adding arm64 for simulator in excluded architecture

### DIFF
--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -7667,6 +7667,7 @@
 				CURRENT_PROJECT_VERSION = 927;
 				DEVELOPMENT_TEAM = DQ48D9BF2V;
 				DISPLAY_NAME = "GodTools-Stage";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				INFOPLIST_FILE = godtools/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -8027,6 +8028,7 @@
 				CURRENT_PROJECT_VERSION = 927;
 				DEVELOPMENT_TEAM = DQ48D9BF2V;
 				DISPLAY_NAME = GodTools;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				INFOPLIST_FILE = godtools/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (


### PR DESCRIPTION
New macs running Apple Silicon will need this flag in order to run builds in the Simulator.

https://medium.com/@johny.urgiles/wrestling-with-xcode-12-and-arm64-6c7977922abb