### PR TITLE
GT-1206 Fix pageDidAppear not getting called when animate scroll is set to false

### DIFF
--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/Pages/MobileContentPagesView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/Pages/MobileContentPagesView.swift
@@ -227,14 +227,10 @@ class MobileContentPagesView: UIViewController {
             currentNavigation = nil
         }
         else {
-            
-            // TODO: For now the animated argument will need to remain true. When scrolling to a page with animated set to false,
-            //  I noticed pageDidAppear is never called. I will need to investigate this more on the pageNavigationView
-            //  and ensure that the page life cycle methods are correctly called when scrolling to a page with animated set to false. ~Levi
-            
+                        
             pageNavigationView.scrollToPage(
                 page: navigationModel.page,
-                animated: true/*navigationModel.animated*/
+                animated: navigationModel.animated
             )
         }
     }
@@ -309,12 +305,8 @@ extension MobileContentPagesView: PageNavigationCollectionViewDelegate {
         viewModel.pageDidAppear(page: page)
     }
     
-    func pageNavigationPageWillDisappear(pageNavigation: PageNavigationCollectionView, pageCell: UICollectionViewCell, page: Int) {
-        
-    }
-    
     func pageNavigationPageDidDisappear(pageNavigation: PageNavigationCollectionView, pageCell: UICollectionViewCell, page: Int) {
-                
+                        
         if let contentPageCell = pageCell as? MobileContentPageCell {
             contentPageCell.mobileContentView?.notifyViewAndAllChildrenViewDidDisappear()
         }

--- a/godtools/App/Share/Views/PageNavigationCollectionView/PageNavigationCollectionView.swift
+++ b/godtools/App/Share/Views/PageNavigationCollectionView/PageNavigationCollectionView.swift
@@ -17,7 +17,6 @@ import UIKit
     @objc optional func pageNavigationDidChangeMostVisiblePage(pageNavigation: PageNavigationCollectionView, pageCell: UICollectionViewCell, page: Int)
     @objc optional func pageNavigationPageWillAppear(pageNavigation: PageNavigationCollectionView, pageCell: UICollectionViewCell, page: Int)
     @objc optional func pageNavigationPageDidAppear(pageNavigation: PageNavigationCollectionView, pageCell: UICollectionViewCell, page: Int)
-    @objc optional func pageNavigationPageWillDisappear(pageNavigation: PageNavigationCollectionView, pageCell: UICollectionViewCell, page: Int)
     @objc optional func pageNavigationPageDidDisappear(pageNavigation: PageNavigationCollectionView, pageCell: UICollectionViewCell, page: Int)
     @objc optional func pageNavigationDidEndScrollingAnimation(pageNavigation: PageNavigationCollectionView)
 }
@@ -112,6 +111,10 @@ class PageNavigationCollectionView: UIView, NibBased {
         
         if animated {
             isAnimatingScroll = true
+        }
+        else {
+            // Set this to true because when animated is false we don't get any of the scrollView delegate methods called.
+            shouldNotifyPageDidAppearForDataReload = true
         }
         
         collectionView.scrollToItem(
@@ -283,10 +286,6 @@ class PageNavigationCollectionView: UIView, NibBased {
         delegate?.pageNavigationPageDidAppear?(pageNavigation: self, pageCell: pageCell, page: page)
     }
     
-    private func pageWillDisappear(pageCell: UICollectionViewCell, page: Int) {
-        delegate?.pageNavigationPageWillDisappear?(pageNavigation: self, pageCell: pageCell, page: page)
-    }
-    
     private func pageDidDisappear(pageCell: UICollectionViewCell, page: Int) {
         delegate?.pageNavigationPageDidDisappear?(pageNavigation: self, pageCell: pageCell, page: page)
     }
@@ -317,7 +316,7 @@ extension PageNavigationCollectionView: UICollectionViewDelegateFlowLayout, UICo
     func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
         
         let page: Int = indexPath.row
-        
+                
         pageWillAppear(pageCell: cell, page: page)
         
         if shouldNotifyPageDidAppearForDataReload {


### PR DESCRIPTION
- Fixed pageDidAppear not getting called which occurs whenever scrollToPage animated flag is set to false.  This is because the ScrollView delegate methods will not get called when animated is set to false.  I was able to re-use similar functionality for calling pageDidAppear when table data is reloaded.  
- Removed the pageWillDisappear delegate method because it is not being used and UICollectionView doesn't provide any means of reporting when a cell will disappear.  There is also the pageDidDisappear which UICollectionView does provide and can be used if any cleanup is needed.