### PR TITLE
GT-1394: Fix Bottom Gradient in Tool Cards

### DIFF
--- a/godtools/App/Services/Renderer/Views/Tool/Views/Card/ToolPageCardView.swift
+++ b/godtools/App/Services/Renderer/Views/Tool/Views/Card/ToolPageCardView.swift
@@ -143,6 +143,7 @@ class ToolPageCardView: MobileContentView {
         let rootView: UIView? = subviews.first
         rootView?.layer.cornerRadius = cardCornerRadius
         
+        // bottom gradient
         bottomGradientView.isUserInteractionEnabled = false
         bottomGradientView.backgroundColor = .clear
         bottomGradientLayer.frame = bottomGradientView.bounds
@@ -185,7 +186,6 @@ class ToolPageCardView: MobileContentView {
     
     func setDelegate(delegate: ToolPageCardViewDelegate?) {
         self.delegate = delegate
-        
     }
     
     func onCardVisible() {

--- a/godtools/App/Services/Renderer/Views/Tool/Views/Card/ToolPageCardView.swift
+++ b/godtools/App/Services/Renderer/Views/Tool/Views/Card/ToolPageCardView.swift
@@ -93,6 +93,11 @@ class ToolPageCardView: MobileContentView {
         }
     }
     
+    override func layoutSubviews() {
+        
+        setupBottomGradientView()
+    }
+    
     private func initializeNib() {
         
         let nib: UINib = UINib(nibName: String(describing: ToolPageCardView.self), bundle: nil)
@@ -134,19 +139,6 @@ class ToolPageCardView: MobileContentView {
         // background corner radius
         let rootView: UIView? = subviews.first
         rootView?.layer.cornerRadius = cardCornerRadius
-        
-        // bottom gradient
-        bottomGradientView.isUserInteractionEnabled = false
-        bottomGradientView.backgroundColor = .clear
-        let bottomGradient = CAGradientLayer()
-        bottomGradient.frame = bottomGradientView.bounds
-        bottomGradient.colors = [
-            UIColor.white.withAlphaComponent(0).cgColor,
-            UIColor.white.withAlphaComponent(0.5).cgColor,
-            UIColor.white.withAlphaComponent(0.75).cgColor,
-            UIColor.white.cgColor
-        ]
-        bottomGradientView.layer.insertSublayer(bottomGradient, at: 0)
     }
     
     private func setupBinding() {
@@ -177,8 +169,29 @@ class ToolPageCardView: MobileContentView {
         nextButton.isHidden = viewModel.hidesNextButton
     }
     
+    private func setupBottomGradientView() {
+        
+        bottomGradientView.isUserInteractionEnabled = false
+        bottomGradientView.backgroundColor = .clear
+        let bottomGradient = CAGradientLayer()
+        bottomGradient.frame = bottomGradientView.bounds
+        bottomGradient.colors = [
+            UIColor.white.withAlphaComponent(0).cgColor,
+            UIColor.white.withAlphaComponent(0.5).cgColor,
+            UIColor.white.withAlphaComponent(0.75).cgColor,
+            UIColor.white.cgColor
+        ]
+        
+        if let existingBottomGradient = bottomGradientView.layer.sublayers?[0] {
+            bottomGradientView.layer.replaceSublayer(existingBottomGradient, with: bottomGradient)
+        } else {
+            bottomGradientView.layer.insertSublayer(bottomGradient, at: 0)
+        }
+    }
+    
     func setDelegate(delegate: ToolPageCardViewDelegate?) {
         self.delegate = delegate
+        
     }
     
     func onCardVisible() {

--- a/godtools/App/Services/Renderer/Views/Tool/Views/Card/ToolPageCardView.swift
+++ b/godtools/App/Services/Renderer/Views/Tool/Views/Card/ToolPageCardView.swift
@@ -22,6 +22,7 @@ class ToolPageCardView: MobileContentView {
     private let backgroundImageView: MobileContentBackgroundImageView = MobileContentBackgroundImageView()
     private let swipeUpGesture: UISwipeGestureRecognizer = UISwipeGestureRecognizer()
     private let swipeDownGesture: UISwipeGestureRecognizer = UISwipeGestureRecognizer()
+    private let bottomGradientLayer: CAGradientLayer = CAGradientLayer()
     private let contentStackView: MobileContentStackView = MobileContentStackView(contentInsets: UIEdgeInsets(top: 15, left: 15, bottom: 0, right: 15), itemSpacing: 20, scrollIsEnabled: true)
     
     private lazy var keyboardObserver: KeyboardObserverType = KeyboardNotificationObserver(loggingEnabled: false)
@@ -95,7 +96,9 @@ class ToolPageCardView: MobileContentView {
     
     override func layoutSubviews() {
         
-        setupBottomGradientView()
+        super.layoutSubviews()
+        
+        bottomGradientLayer.frame = bottomGradientView.bounds
     }
     
     private func initializeNib() {
@@ -139,6 +142,17 @@ class ToolPageCardView: MobileContentView {
         // background corner radius
         let rootView: UIView? = subviews.first
         rootView?.layer.cornerRadius = cardCornerRadius
+        
+        bottomGradientView.isUserInteractionEnabled = false
+        bottomGradientView.backgroundColor = .clear
+        bottomGradientLayer.frame = bottomGradientView.bounds
+        bottomGradientLayer.colors = [
+            UIColor.white.withAlphaComponent(0).cgColor,
+            UIColor.white.withAlphaComponent(0.5).cgColor,
+            UIColor.white.withAlphaComponent(0.75).cgColor,
+            UIColor.white.cgColor
+        ]
+        bottomGradientView.layer.insertSublayer(bottomGradientLayer, at: 0)
     }
     
     private func setupBinding() {
@@ -167,26 +181,6 @@ class ToolPageCardView: MobileContentView {
         nextButton.setTitle(viewModel.nextButtonTitle, for: .normal)
         nextButton.setTitleColor(viewModel.nextButtonTitleColor, for: .normal)
         nextButton.isHidden = viewModel.hidesNextButton
-    }
-    
-    private func setupBottomGradientView() {
-        
-        bottomGradientView.isUserInteractionEnabled = false
-        bottomGradientView.backgroundColor = .clear
-        let bottomGradient = CAGradientLayer()
-        bottomGradient.frame = bottomGradientView.bounds
-        bottomGradient.colors = [
-            UIColor.white.withAlphaComponent(0).cgColor,
-            UIColor.white.withAlphaComponent(0.5).cgColor,
-            UIColor.white.withAlphaComponent(0.75).cgColor,
-            UIColor.white.cgColor
-        ]
-        
-        if let existingBottomGradient = bottomGradientView.layer.sublayers?[0] {
-            bottomGradientView.layer.replaceSublayer(existingBottomGradient, with: bottomGradient)
-        } else {
-            bottomGradientView.layer.insertSublayer(bottomGradient, at: 0)
-        }
     }
     
     func setDelegate(delegate: ToolPageCardViewDelegate?) {

--- a/godtools/App/Services/Renderer/Views/Tool/Views/Card/ToolPageCardView.xib
+++ b/godtools/App/Services/Renderer/Views/Tool/Views/Card/ToolPageCardView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -98,11 +98,11 @@
                 <constraint firstItem="1mf-U2-uc8" firstAttribute="leading" secondItem="LKt-g0-yhC" secondAttribute="leading" id="3pQ-Cz-8IV"/>
                 <constraint firstItem="LKt-g0-yhC" firstAttribute="top" secondItem="rZm-W3-Lwr" secondAttribute="bottom" id="5cO-3T-Q9R"/>
                 <constraint firstItem="1mf-U2-uc8" firstAttribute="trailing" secondItem="LKt-g0-yhC" secondAttribute="trailing" id="8FN-mZ-bDX"/>
-                <constraint firstItem="65A-1Q-biF" firstAttribute="leading" secondItem="LKt-g0-yhC" secondAttribute="leading" id="8aN-qv-PjE"/>
+                <constraint firstItem="65A-1Q-biF" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="8aN-qv-PjE"/>
                 <constraint firstItem="rZm-W3-Lwr" firstAttribute="top" secondItem="1dD-4I-w1p" secondAttribute="bottom" id="9XW-us-f6P"/>
                 <constraint firstItem="rZm-W3-Lwr" firstAttribute="trailing" secondItem="lKs-as-Ac5" secondAttribute="trailing" id="AfZ-py-tyi"/>
                 <constraint firstItem="tof-tC-XrA" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="14" id="Fk3-3d-1qK"/>
-                <constraint firstItem="65A-1Q-biF" firstAttribute="trailing" secondItem="LKt-g0-yhC" secondAttribute="trailing" id="I25-F3-YNW"/>
+                <constraint firstItem="65A-1Q-biF" firstAttribute="trailing" secondItem="iN0-l3-epB" secondAttribute="trailing" id="I25-F3-YNW"/>
                 <constraint firstItem="LKt-g0-yhC" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="JjR-qo-B9G"/>
                 <constraint firstAttribute="trailing" secondItem="Vbs-dr-uHK" secondAttribute="trailing" constant="20" id="ThV-Dd-fSL"/>
                 <constraint firstItem="UHR-SS-PKM" firstAttribute="top" secondItem="65A-1Q-biF" secondAttribute="bottom" id="Ttk-iS-pMA"/>

--- a/godtools/App/Services/Renderer/Views/Tool/Views/Cards/ToolPageCardsView.swift
+++ b/godtools/App/Services/Renderer/Views/Tool/Views/Cards/ToolPageCardsView.swift
@@ -353,6 +353,8 @@ extension ToolPageCardsView {
             cardTopConstraints.append(top)
             
             cardView.setDelegate(delegate: self)
+            
+            cardView.layoutSubviews()
         }
         
         setCardsState(cardsState: .starting, animated: false)

--- a/godtools/App/Services/Renderer/Views/Tool/Views/Cards/ToolPageCardsView.swift
+++ b/godtools/App/Services/Renderer/Views/Tool/Views/Cards/ToolPageCardsView.swift
@@ -353,8 +353,6 @@ extension ToolPageCardsView {
             cardTopConstraints.append(top)
             
             cardView.setDelegate(delegate: self)
-            
-            cardView.layoutSubviews()
         }
         
         setCardsState(cardsState: .starting, animated: false)


### PR DESCRIPTION
There were two parts to the issue I found:
1. The gradient is initially being set before the content insets between the CardsView and the Card are set.  So the width of the gradient is the full with of the CardsView, not the new shrunken width of the Card.
2. Multiple gradient layers are getting layered on top of each other each time `setupLayout()` is getting stepped through.  So, even when the content insets are applied to the card and I call `layoutSubviews()`, the original gradient still exists.

My solution is to:
1. Make sure the gradient is getting set after the content insets are in place, and
2. If there is a gradient layer already in place, replace it instead of adding a new one.