### PR TITLE
GT-1458 Fix navigate back to all tools from conversation starter tool

### DIFF
--- a/godtools/App/Flows/AppFlow.swift
+++ b/godtools/App/Flows/AppFlow.swift
@@ -270,6 +270,13 @@ class AppFlow: NSObject, ToolNavigationFlow, Flow {
             
             tractFlow = nil
             
+        case .chooseYourOwnAdventureFlowCompleted(let state):
+            switch state {
+            case .userClosedTool:
+                _ = navigationController.popViewController(animated: true)
+                chooseYourOwnAdventureFlow = nil
+            }
+            
         case .urlLinkTappedFromToolDetail(let url, let exitLink):
             navigateToURL(url: url, exitLink: exitLink)
             


### PR DESCRIPTION
Tapping back from the conversation starter tool should take you back to the tools menu.  I believe this broke in GT-1445 when I moved the ToolsFlow into AppFlow.