### PR TITLE
GT-1425 fix card collection page toggling

### DIFF
--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/CardCollectionPage/MobileContentCardCollectionPageView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/CardCollectionPage/MobileContentCardCollectionPageView.swift
@@ -134,9 +134,10 @@ class MobileContentCardCollectionPageView: MobileContentPageView {
     
     override func getPositionState() -> MobileContentViewPositionState {
         
-        let currentPage: Int = cardPageNavigationView.currentPage
+        let page: Int = cardPageNavigationView.currentPage
+        let currentCardId: String = viewModel.getCardId(card: page)
                 
-        return MobileContentCardCollectionPagePositionState(currentPage: currentPage)
+        return MobileContentCardCollectionPagePositionState(currentCardId: currentCardId)
     }
     
     override func setPositionState(positionState: MobileContentViewPositionState, animated: Bool) {
@@ -145,8 +146,10 @@ class MobileContentCardCollectionPageView: MobileContentPageView {
             return
         }
 
-        let currentPage: Int = cardCollectionPagePositionState.currentPage
-        
+        guard let currentPage = viewModel.getCardPosition(cardId: cardCollectionPagePositionState.currentCardId) else {
+            return
+        }
+                
         cardPageNavigationView.scrollToPage(page: currentPage, animated: animated)        
     }
 }

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/CardCollectionPage/MobileContentCardCollectionPageViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/CardCollectionPage/MobileContentCardCollectionPageViewModel.swift
@@ -41,6 +41,18 @@ class MobileContentCardCollectionPageViewModel: MobileContentPageViewModel, Mobi
     
     private func getCardAnalyticsScreenName(card: Int) -> String {
         
+        let resource: ResourceModel = rendererPageModel.resource
+        let pageId: String = rendererPageModel.pageModel.id
+        let cardId: String = getCardId(card: card)
+        let separator: String = ":"
+        
+        let screenName: String = resource.abbreviation + separator + pageId + separator + cardId
+        
+        return screenName
+    }
+    
+    func getCardId(card: Int) -> String {
+        
         let cards: [CardCollectionPage.Card] = cardCollectionPage.cards
         let cardId: String
         
@@ -52,13 +64,21 @@ class MobileContentCardCollectionPageViewModel: MobileContentPageViewModel, Mobi
             cardId = ""
         }
         
-        let resource: ResourceModel = rendererPageModel.resource
-        let pageId: String = rendererPageModel.pageModel.id
-        let separator: String = ":"
+        return cardId
+    }
+    
+    func getCardPosition(cardId: String) -> Int? {
         
-        let screenName: String = resource.abbreviation + separator + pageId + separator + cardId
+        let cards: [CardCollectionPage.Card] = cardCollectionPage.cards
         
-        return screenName
+        for index in 0 ..< cards.count {
+            let card: CardCollectionPage.Card = cards[index]
+            if card.id == cardId {
+                return index
+            }
+        }
+        
+        return nil
     }
     
     func pageDidAppear() {

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/CardCollectionPage/MobileContentCardCollectionPageViewModelType.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/CardCollectionPage/MobileContentCardCollectionPageViewModelType.swift
@@ -10,6 +10,8 @@ import Foundation
 
 protocol MobileContentCardCollectionPageViewModelType: MobileContentPageViewModelType {
     
+    func getCardId(card: Int) -> String
+    func getCardPosition(cardId: String) -> Int?
     func pageDidAppear()
     func cardDidAppear(card: Int)
 }

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/CardCollectionPage/Models/MobileContentCardCollectionPagePositionState.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/CardCollectionPage/Models/MobileContentCardCollectionPagePositionState.swift
@@ -10,10 +10,10 @@ import Foundation
 
 class MobileContentCardCollectionPagePositionState: MobileContentViewPositionState {
     
-    let currentPage: Int
+    let currentCardId: String
     
-    required init(currentPage: Int) {
+    required init(currentCardId: String) {
         
-        self.currentPage = currentPage
+        self.currentCardId = currentCardId
     }
 }

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/Pages/MobileContentPagesViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/Pages/MobileContentPagesViewModel.swift
@@ -61,6 +61,25 @@ class MobileContentPagesViewModel: NSObject, MobileContentPagesViewModelType {
         return currentRenderer
     }
     
+    private func getRendererPageModelsMatchingCurrentRenderedPageModels(renderer: MobileContentRendererType) -> [PageModelType] {
+        
+        var rendererPageModelsMatchingCurrentRenderedPageModels: [PageModelType] = Array()
+        
+        let currentRenderedPageModels: [PageModelType] = pageModels
+        let allPageModelsInNewRenderer: [PageModelType] = renderer.parser.pageModels
+        
+        for pageModel in currentRenderedPageModels {
+                        
+            guard let setRendererPageModel = allPageModelsInNewRenderer.filter({$0.id == pageModel.id}).first else {
+                continue
+            }
+            
+            rendererPageModelsMatchingCurrentRenderedPageModels.append(setRendererPageModel)
+        }
+        
+        return rendererPageModelsMatchingCurrentRenderedPageModels
+    }
+    
     private func getIndexForFirstPageModel(pageModel: PageModelType) -> Int? {
         for index in 0 ..< pageModels.count {
             let activePageModel: PageModelType = pageModels[index]
@@ -213,26 +232,9 @@ class MobileContentPagesViewModel: NSObject, MobileContentPagesViewModelType {
             
             var newPageModelsToRenderer: [PageModelType] = Array()
             
-            if let currentRenderer = self.currentRenderer, pagesShouldMatchRenderedPages {
+            if pagesShouldMatchRenderedPages {
                 
-                let renderedPageModelsUUIDs: [String] = pageModels.map({$0.uuid})
-                let allPageModelsInCurrentRenderer: [PageModelType] = currentRenderer.parser.pageModels
-                let allPageModelsInSetRenderer: [PageModelType] = renderer.parser.pageModels
-                
-                for page in allPageModelsInCurrentRenderer {
-                    
-                    guard let index = renderedPageModelsUUIDs.firstIndex(of: page.uuid) else {
-                        continue
-                    }
-                    
-                    let indexIsInRange: Bool = index >= 0 && index < allPageModelsInSetRenderer.count
-                    
-                    guard indexIsInRange else {
-                        continue
-                    }
-                    
-                    newPageModelsToRenderer.append(allPageModelsInSetRenderer[index])
-                }
+                newPageModelsToRenderer = getRendererPageModelsMatchingCurrentRenderedPageModels(renderer: renderer)
             }
             
             if newPageModelsToRenderer.isEmpty && renderer.parser.pageModels.count > 0 {


### PR DESCRIPTION
Fixed language toggling for the conversation starter tool.  The issue was when switching languages the current logic was fetching the incorrect page model.  Changed this to use the page id which guarantees the correct page model will be used when switching between language renderers.
 
@aaronlaib I also made a fix where the card index was being used to track which card should be navigated to when switching languages.  Updated to use card id instead.  