### PR TITLE
GT-1463 Fix home screen panning of tools lists

### DIFF
--- a/godtools/App/Flows/AppFlow.swift
+++ b/godtools/App/Flows/AppFlow.swift
@@ -485,9 +485,7 @@ extension AppFlow {
         )
         
         navigationController.setViewControllers([toolsMenuView], animated: false)
-        
-        navigationController.view.layoutIfNeeded()
-                    
+                            
         self.toolsMenuView = toolsMenuView
     }
     


### PR DESCRIPTION
This was a strange one, the bug would only occur when dismissing a viewController that was presented on the navigationController and also calling layoutIfNeeded on the navigationController when setting the toolsMenu in the stack.  I initially had the layoutIfNeeded there to force the navigationController to layout when setting the toolsMenu in the stack.  I don't think it is necessary however, so will remove to address this bug.