### PR TITLE
GT-1367 Fix: Use Text-Scaling on Button Text, not Button

### DIFF
--- a/godtools/App/Services/Renderer/Parser/Multiplatform/Models/MultiplatformContentButton.swift
+++ b/godtools/App/Services/Renderer/Parser/Multiplatform/Models/MultiplatformContentButton.swift
@@ -80,7 +80,7 @@ class MultiplatformContentButton: ContentButtonModelType {
     }
     
     var textScale: MobileContentTextScale {
-        return MobileContentTextScale(doubleValue: button.textScale)
+        return MobileContentTextScale(doubleValue: button.text?.textScale ?? button.textScale)
     }
     
     var buttonWidth: GodToolsToolParser.Dimension {


### PR DESCRIPTION
This applies the proper value of the `textScaling` property to button text.