### PR TITLE
GT-1398 -- Fix for disappearing Screen Share Icon

### DIFF
--- a/godtools/App/Features/Tool/Views/ToolNavBar/ToolNavBarView.swift
+++ b/godtools/App/Features/Tool/Views/ToolNavBar/ToolNavBarView.swift
@@ -47,7 +47,6 @@ class ToolNavBarView: NSObject {
         self.delegate = delegate
         
         setupNavigationBar(parentViewController: parentViewController, viewModel: viewModel)
-        setupBinding(viewModel: viewModel)
     }
     
     func reloadAppearance() {
@@ -131,17 +130,10 @@ class ToolNavBarView: NSObject {
                 for: .valueChanged
             )
         }
-    }
-    
-    private func setupBinding(viewModel: ToolNavBarViewModelType) {
         
-        viewModel.remoteShareIsActive.addObserver(self) { [weak self] (isActive: Bool) in
-            self?.setRemoteShareActiveNavItem(hidden: !isActive)
-        }
+        setRemoteShareActiveNavItem(hidden: !viewModel.remoteShareIsActive.value)
         
-        viewModel.selectedLanguage.addObserver(self) { [weak self] (index: Int) in
-            self?.chooseLanguageControl.selectedSegmentIndex = index
-        }
+        chooseLanguageControl.selectedSegmentIndex = viewModel.selectedLanguage.value
     }
     
     @objc private func backButtonTapped() {

--- a/godtools/App/Features/Tool/Views/ToolNavBar/ToolNavBarView.swift
+++ b/godtools/App/Features/Tool/Views/ToolNavBar/ToolNavBarView.swift
@@ -67,6 +67,8 @@ class ToolNavBarView: NSObject {
         parentViewController.removeAllBarButtonItems()
         chooseLanguageControl.removeAllSegments()
         
+        remoteShareActiveNavItem = nil
+        
         parentViewController.title = viewModel.navTitle
         
         navigationController?.navigationBar.setupNavigationBarAppearance(


### PR DESCRIPTION
Screen Share Icon should remain visible at the top of the screen while screen sharing is happening.