### PR TITLE
GT-1477: Add Analytics Tracking for Pressing Quick Start Links

### DIFF
--- a/godtools/App/Features/Onboarding/Models/OnboardingQuickStartItem.swift
+++ b/godtools/App/Features/Onboarding/Models/OnboardingQuickStartItem.swift
@@ -10,8 +10,8 @@ import Foundation
 
 struct OnboardingQuickStartItem {
     
-    var title: String
-    var linkButtonTitle: String
-    var linkButtonFlowStep: FlowStep
-    var linkButtonAnalyticsAction: String
+    let title: String
+    let linkButtonTitle: String
+    let linkButtonFlowStep: FlowStep
+    let linkButtonAnalyticsAction: String
 }

--- a/godtools/App/Features/Onboarding/Models/OnboardingQuickStartItem.swift
+++ b/godtools/App/Features/Onboarding/Models/OnboardingQuickStartItem.swift
@@ -13,4 +13,5 @@ struct OnboardingQuickStartItem {
     var title: String
     var linkButtonTitle: String
     var linkButtonFlowStep: FlowStep
+    var linkButtonAnalyticsAction: String
 }

--- a/godtools/App/Features/Onboarding/OnboardingQuickStartViewModel.swift
+++ b/godtools/App/Features/Onboarding/OnboardingQuickStartViewModel.swift
@@ -78,7 +78,6 @@ class OnboardingQuickStartViewModel: OnboardingQuickStartViewModelType {
     }
     
     func endTutorialButtonTapped() {
-        trackActionAnalytics.trackAction(trackAction: TrackActionModel(screenName: analyticsScreenName, actionName: AnalyticsConstants.Values.onboardingStart, siteSection: "", siteSubSection: "", url: nil, data: nil))
         
         flowDelegate?.navigate(step: .endTutorialFromOnboardingQuickStart)
     }

--- a/godtools/App/Features/Onboarding/OnboardingQuickStartViewModel.swift
+++ b/godtools/App/Features/Onboarding/OnboardingQuickStartViewModel.swift
@@ -17,9 +17,11 @@ class OnboardingQuickStartViewModel: OnboardingQuickStartViewModelType {
     
     private let quickStartItems: [OnboardingQuickStartItem]
     
+    private let trackActionAnalytics: TrackActionAnalytics
+    
     private weak var flowDelegate: FlowDelegate?
     
-    required init(flowDelegate: FlowDelegate, localizationServices: LocalizationServices) {
+    required init(flowDelegate: FlowDelegate, localizationServices: LocalizationServices, trackActionAnalytics: TrackActionAnalytics) {
         
         title = localizationServices.stringForMainBundle(key: "onboardingQuickStart.title")
         skipButtonTitle = localizationServices.stringForMainBundle(key: "navigationBar.navigationItem.skip")
@@ -27,25 +29,34 @@ class OnboardingQuickStartViewModel: OnboardingQuickStartViewModelType {
         
         self.flowDelegate = flowDelegate
         
+        self.trackActionAnalytics = trackActionAnalytics
+        
         quickStartItems = [
             OnboardingQuickStartItem(
                 title: localizationServices.stringForMainBundle(key: "onboardingQuickStart.0.title"),
                 linkButtonTitle: localizationServices.stringForMainBundle(key:  "onboardingQuickStart.0.button.title"),
-                linkButtonFlowStep: .readArticlesTappedFromOnboardingQuickStart
+                linkButtonFlowStep: .readArticlesTappedFromOnboardingQuickStart,
+                linkButtonAnalyticsAction: AnalyticsConstants.Values.onboardingQuickStartArticles
             ),
             OnboardingQuickStartItem(
                 title: localizationServices.stringForMainBundle(key: "onboardingQuickStart.1.title"),
                 linkButtonTitle: localizationServices.stringForMainBundle(key:  "onboardingQuickStart.1.button.title"),
-                linkButtonFlowStep: .tryLessonsTappedFromOnboardingQuickStart
+                linkButtonFlowStep: .tryLessonsTappedFromOnboardingQuickStart,
+                linkButtonAnalyticsAction: AnalyticsConstants.Values.onboardingQuickStartLessons
             ),
             OnboardingQuickStartItem(
                 title: localizationServices.stringForMainBundle(key: "onboardingQuickStart.2.title"),
                 linkButtonTitle: localizationServices.stringForMainBundle(key:  "onboardingQuickStart.2.button.title"),
-                linkButtonFlowStep: .chooseToolTappedFromOnboardingQuickStart
+                linkButtonFlowStep: .chooseToolTappedFromOnboardingQuickStart,
+                linkButtonAnalyticsAction: AnalyticsConstants.Values.onboardingQuickStartTools
             ),
         ]
         
         quickStartItemCount = quickStartItems.count
+    }
+    
+    private var analyticsScreenName: String {
+        return "onboarding-quick-start"
     }
     
     func quickStartCellWillAppear(index: Int) -> OnboardingQuickStartCellViewModelType {
@@ -54,9 +65,11 @@ class OnboardingQuickStartViewModel: OnboardingQuickStartViewModelType {
     }
     
     func quickStartCellTapped(index: Int) {
-        let flowStep = quickStartItems[index].linkButtonFlowStep
+        let item = quickStartItems[index]
         
-        flowDelegate?.navigate(step: flowStep)
+        trackActionAnalytics.trackAction(trackAction: TrackActionModel(screenName: analyticsScreenName, actionName: item.linkButtonAnalyticsAction, siteSection: "", siteSubSection: "", url: nil, data: nil))
+        
+        flowDelegate?.navigate(step: item.linkButtonFlowStep)
     }
     
     func skipButtonTapped() {
@@ -65,6 +78,7 @@ class OnboardingQuickStartViewModel: OnboardingQuickStartViewModelType {
     }
     
     func endTutorialButtonTapped() {
+        trackActionAnalytics.trackAction(trackAction: TrackActionModel(screenName: analyticsScreenName, actionName: AnalyticsConstants.Values.onboardingStart, siteSection: "", siteSubSection: "", url: nil, data: nil))
         
         flowDelegate?.navigate(step: .endTutorialFromOnboardingQuickStart)
     }

--- a/godtools/App/Features/Onboarding/OnboardingTutorialViewModel.swift
+++ b/godtools/App/Features/Onboarding/OnboardingTutorialViewModel.swift
@@ -20,7 +20,7 @@ class OnboardingTutorialViewModel: TutorialPagerViewModel {
         self.viewBuilder = customViewBuilder
         self.localizationServices = localizationServices
         
-        let tutorialPagerAnalyticsModel = TutorialPagerAnalytics(screenName: "onboarding", siteSection: "onboarding", siteSubsection: "", continueButtonTappedActionName: "On-Boarding Start", continueButtonTappedData: ["cru.onboarding_start": 1], screenTrackIndexOffset: 2)
+        let tutorialPagerAnalyticsModel = TutorialPagerAnalytics(screenName: "onboarding", siteSection: "onboarding", siteSubsection: "", continueButtonTappedActionName: "Onboarding Start", continueButtonTappedData: ["cru.onboarding_start": 1], screenTrackIndexOffset: 2)
         
         super.init(flowDelegate: flowDelegate, analyticsContainer: analyticsContainer, tutorialVideoAnalytics: tutorialVideoAnalytics,  tutorialItems: onboardingTutorialItemsRepository.tutorialItems, tutorialPagerAnalyticsModel: tutorialPagerAnalyticsModel, skipButtonTitle: localizationServices.stringForMainBundle(key: "navigationBar.navigationItem.skip"))
         

--- a/godtools/App/Flows/OnboardingFlow.swift
+++ b/godtools/App/Flows/OnboardingFlow.swift
@@ -73,7 +73,7 @@ class OnboardingFlow: Flow {
         
         if appDiContainer.deviceLanguage.isEnglish {
             
-            let viewModel = OnboardingQuickStartViewModel(flowDelegate: self, localizationServices: appDiContainer.localizationServices)
+            let viewModel = OnboardingQuickStartViewModel(flowDelegate: self, localizationServices: appDiContainer.localizationServices, trackActionAnalytics: appDiContainer.analytics.trackActionAnalytics)
             let view = OnboardingQuickStartView(viewModel: viewModel)
             
             navigationController.setViewControllers([view], animated: true)

--- a/godtools/App/Services/Analytics/AnalyticsConstants.swift
+++ b/godtools/App/Services/Analytics/AnalyticsConstants.swift
@@ -54,7 +54,6 @@ struct AnalyticsConstants {
         static let shareIconEngaged = "Share Icon Engaged"
         static let shareScreenEngaged = "Share Screen Engaged"
         static let shareScreenOpened = "Share Screen Opened"
-        static let onboardingStart = "onboarding_start"
         static let onboardingQuickStartArticles = "onboarding_link_articles"
         static let onboardingQuickStartLessons = "onboarding_link_lessons"
         static let onboardingQuickStartTools = "onboarding_link_tools"

--- a/godtools/App/Services/Analytics/AnalyticsConstants.swift
+++ b/godtools/App/Services/Analytics/AnalyticsConstants.swift
@@ -54,6 +54,10 @@ struct AnalyticsConstants {
         static let shareIconEngaged = "Share Icon Engaged"
         static let shareScreenEngaged = "Share Screen Engaged"
         static let shareScreenOpened = "Share Screen Opened"
+        static let onboardingStart = "onboarding_start"
+        static let onboardingQuickStartArticles = "onboarding_link_articles"
+        static let onboardingQuickStartLessons = "onboarding_link_lessons"
+        static let onboardingQuickStartTools = "onboarding_link_tools"
     }
     
     struct ActionNames {


### PR DESCRIPTION
Created a couple of new analytics events to be triggered when pressing the Quick Start links, or pressing the "Get Started" button.