### PR TITLE
GT-1388 - Change startup initialization to prevent iOS 15 bug

### DIFF
--- a/godtools/App/AppDelegate.swift
+++ b/godtools/App/AppDelegate.swift
@@ -13,24 +13,22 @@ import FBSDKCoreKit
 class AppDelegate: UIResponder, UIApplicationDelegate {
     
     private let appWindow: UIWindow = UIWindow(frame: UIScreen.main.bounds)
-    private let appDeepLinkingService: DeepLinkingServiceType = AppDiContainer.getNewDeepLinkingService(loggingEnabled: false)
-    private let appDiContainer: AppDiContainer
-    private let appFlow: AppFlow
+        
+    private lazy var appDeepLinkingService: DeepLinkingServiceType = AppDiContainer.getNewDeepLinkingService(loggingEnabled: false)
+    private lazy var appDiContainer: AppDiContainer = {
+        AppDiContainer(appDeepLinkingService: appDeepLinkingService)
+    }()
+    
+    private lazy var appFlow: AppFlow = {
+        AppFlow(appDiContainer: appDiContainer, window: appWindow, appDeepLinkingService: appDeepLinkingService)
+    }()
     
     var window: UIWindow?
     
     static func setWindowBackgroundColorForStatusBarColor(color: UIColor) {
         (UIApplication.shared.delegate as? AppDelegate)?.window?.backgroundColor = color
     }
-    
-    override init() {
-        
-        appDiContainer = AppDiContainer(appDeepLinkingService: appDeepLinkingService)
-        appFlow = AppFlow(appDiContainer: appDiContainer, window: appWindow, appDeepLinkingService: appDeepLinkingService)
-        
-        super.init()
-    }
-    
+
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
                 
         appDiContainer.config.logConfiguration()


### PR DESCRIPTION
There's been some bugs reported in iOS 15 with Keychain data disappearing.  This would occur if initialization of the Keychain data access occurred during AppDelegate init() and the fix was to move this logic to AppDelegate didFinishLaunching().  I noticed in MPDX this was causing problems.  With GodTools I don't think there is any issue, however, I decided to move AppDiContainer and AppFlow initialization from AppDelegate init() to AppDelegate didFinishLaunching() by making those lazy variables so they're initialized upon first access.