### PR TITLE
GT1453 - Fix tool header number label clipping

### DIFF
--- a/godtools/App/Services/Renderer/Views/Tool/Views/Header/ToolPageHeaderView.xib
+++ b/godtools/App/Services/Renderer/Views/Tool/Views/Header/ToolPageHeaderView.xib
@@ -26,7 +26,7 @@
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GaW-Xr-cq8" userLabel="backgroundView">
                     <rect key="frame" x="0.0" y="0.0" width="414" height="100"/>
                     <subviews>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="251" text="5" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PU9-rf-kta" userLabel="numberLabel">
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="251" horizontalCompressionResistancePriority="999" text="5" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PU9-rf-kta" userLabel="numberLabel">
                             <rect key="frame" x="15" y="14" width="19" height="36"/>
                             <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="30"/>
                             <nil key="textColor"/>


### PR DESCRIPTION
For this fix I increased the compression resistance on the number UILabel.  A higher compression resistance won't allow the label to shrink smaller than the containing text.