### PR TITLE
GT-1472 Fix AppsFlyer deferred deep linking into lessons list and all tools list

### DIFF
--- a/godtools/App/Features/Tools/ToolsMenuView.swift
+++ b/godtools/App/Features/Tools/ToolsMenuView.swift
@@ -11,8 +11,8 @@ import UIKit
 class ToolsMenuView: UIViewController {
     
     private let viewModel: ToolsMenuViewModelType
-    private let startingToolbarItem: ToolsMenuToolbarView.ToolbarItemView
     
+    private var startingToolbarItem: ToolsMenuToolbarView.ToolbarItemView = .favoritedTools
     private var lessonsView: LessonsListView?
     private var favoritedToolsView: FavoritedToolsView?
     private var allToolsView: AllToolsView?
@@ -109,6 +109,11 @@ class ToolsMenuView: UIViewController {
     }
     
     func reset(toolbarItem: ToolsMenuToolbarView.ToolbarItemView, animated: Bool) {
+        
+        guard didLayoutSubviews else {
+            startingToolbarItem = toolbarItem
+            return
+        }
         
         guard self.view != nil else {
             return


### PR DESCRIPTION
The issue here was the ToolsMenuView startingToolbarItem is overriding the reset methods toolbarItem when the view finishes layout.  This will happen anytime reset is called before the view finishes laying out.  This fix addresses that by updating the startingToolbarItem whenever reset is called and the view hasn't finished its layout. 