### PR TITLE
GT-1406 Implement flow item state visibility

### DIFF
--- a/godtools/App/Services/Renderer/Views/MobileContent/ViewFactory/MobileContentPageViewFactory.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/ViewFactory/MobileContentPageViewFactory.swift
@@ -269,7 +269,8 @@ class MobileContentPageViewFactory: MobileContentPageViewFactoryType {
         else if let contentFlowItem = renderableModel as? GodToolsToolParser.Flow.Item {
             
             let viewModel = MobileContentFlowItemViewModel(
-                flowItem: contentFlowItem
+                flowItem: contentFlowItem,
+                renderedPageContext: renderedPageContext
             )
             
             let view = MobileContentFlowItemView(viewModel: viewModel)

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentFlow/MobileContentFlowView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentFlow/MobileContentFlowView.swift
@@ -79,6 +79,10 @@ extension MobileContentFlowView {
         
         flowItemViews.append(flowItemView)
         
+        guard flowItemView.visibilityState != .gone else {
+            return
+        }
+        
         let row: MobileContentFlowRow
         
         if let currentRow = flowItemRows.last, currentRow.renderFlowItem(flowItemView: flowItemView) {

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentFlow/MobileContentFlowView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentFlow/MobileContentFlowView.swift
@@ -53,6 +53,10 @@ class MobileContentFlowView: MobileContentStackView {
         for row in flowItemRows {
             row.finishedRenderingChildren()
         }
+        
+        for flowItem in flowItemViews {
+            flowItem.setDelegate(delegate: self)
+        }
     }
 
     private func relayoutFlowForBoundsChange() {
@@ -102,5 +106,23 @@ extension MobileContentFlowView {
             
             row.renderFlowItem(flowItemView: flowItemView)
         }
+    }
+}
+
+// MARK: - MobileContentFlowItemViewDelegate
+
+extension MobileContentFlowView: MobileContentFlowItemViewDelegate {
+    
+    func flowItemViewDidChangeVisibilityState(flowItemView: MobileContentFlowItemView, previousVisibilityState: MobileContentViewVisibilityState, visibilityState: MobileContentViewVisibilityState) {
+        
+        guard previousVisibilityState != visibilityState else {
+            return
+        }
+        
+        if previousVisibilityState == .gone || visibilityState == .gone {
+            relayoutFlowForBoundsChange()
+        }
+                
+        flowItemView.isHidden = visibilityState != .visible
     }
 }

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentFlowItem/MobileContentFlowItemView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentFlowItem/MobileContentFlowItemView.swift
@@ -8,9 +8,16 @@
 
 import UIKit
 
+protocol MobileContentFlowItemViewDelegate: AnyObject {
+    
+    func flowItemViewDidChangeVisibilityState(flowItemView: MobileContentFlowItemView, previousVisibilityState: MobileContentViewVisibilityState, visibilityState: MobileContentViewVisibilityState)
+}
+
 class MobileContentFlowItemView: MobileContentStackView, MobileContentFlowRowItem {
     
     private let viewModel: MobileContentFlowItemViewModelType
+    
+    private weak var delegate: MobileContentFlowItemViewDelegate?
     
     var itemWidth: MobileContentViewWidth {
         return viewModel.width
@@ -37,7 +44,21 @@ class MobileContentFlowItemView: MobileContentStackView, MobileContentFlowRowIte
     private func setupBinding() {
         
         viewModel.visibilityState.addObserver(self) { [weak self] (visibilityState: MobileContentViewVisibilityState) in            
-            self?.setVisibilityState(visibilityState: visibilityState)
+            
+            guard let weakSelf = self else {
+                return
+            }
+            
+            let previousVisibilityState: MobileContentViewVisibilityState = weakSelf.visibilityState
+            
+            weakSelf.setVisibilityState(visibilityState: visibilityState)
+            
+            weakSelf.delegate?.flowItemViewDidChangeVisibilityState(flowItemView: weakSelf, previousVisibilityState: previousVisibilityState, visibilityState: visibilityState)
         }
+    }
+    
+    func setDelegate(delegate: MobileContentFlowItemViewDelegate?) {
+        
+        self.delegate = delegate
     }
 }

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentFlowItem/MobileContentFlowItemView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentFlowItem/MobileContentFlowItemView.swift
@@ -22,6 +22,8 @@ class MobileContentFlowItemView: MobileContentStackView, MobileContentFlowRowIte
         self.viewModel = viewModel
         
         super.init(contentInsets: .zero, itemSpacing: 0, scrollIsEnabled: false)
+        
+        setupBinding()
     }
     
     required init?(coder: NSCoder) {
@@ -30,5 +32,12 @@ class MobileContentFlowItemView: MobileContentStackView, MobileContentFlowRowIte
     
     required init(contentInsets: UIEdgeInsets, itemSpacing: CGFloat, scrollIsEnabled: Bool) {
         fatalError("init(contentInsets:itemSpacing:scrollIsEnabled:) has not been implemented")
+    }
+    
+    private func setupBinding() {
+        
+        viewModel.visibilityState.addObserver(self) { [weak self] (visibilityState: MobileContentViewVisibilityState) in            
+            self?.setVisibilityState(visibilityState: visibilityState)
+        }
     }
 }

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentFlowItem/MobileContentFlowItemViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentFlowItem/MobileContentFlowItemViewModel.swift
@@ -16,12 +16,26 @@ class MobileContentFlowItemViewModel: NSObject, MobileContentFlowItemViewModelTy
     
     private var visibilityFlowWatcher: FlowWatcher?
     
-    let visibilityState: ObservableValue<MobileContentViewVisibilityState> = ObservableValue(value: .visible)
+    let visibilityState: ObservableValue<MobileContentViewVisibilityState>
     
     required init(flowItem: GodToolsToolParser.Flow.Item, renderedPageContext: MobileContentRenderedPageContext) {
         
         self.flowItem = flowItem
         self.renderedPageContext = renderedPageContext
+        
+        let visibility: MobileContentViewVisibilityState
+        
+        if flowItem.isGone(state: renderedPageContext.rendererState) {
+            visibility = .gone
+        }
+        else if flowItem.isInvisible(state: renderedPageContext.rendererState) {
+            visibility = .hidden
+        }
+        else {
+            visibility = .visible
+        }
+        
+        visibilityState = ObservableValue(value: visibility)
         
         super.init()
         

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentFlowItem/MobileContentFlowItemViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentFlowItem/MobileContentFlowItemViewModel.swift
@@ -9,13 +9,42 @@
 import UIKit
 import GodToolsToolParser
 
-class MobileContentFlowItemViewModel: MobileContentFlowItemViewModelType {
+class MobileContentFlowItemViewModel: NSObject, MobileContentFlowItemViewModelType {
     
     private let flowItem: GodToolsToolParser.Flow.Item
+    private let renderedPageContext: MobileContentRenderedPageContext
     
-    required init(flowItem: GodToolsToolParser.Flow.Item) {
+    private var visibilityFlowWatcher: FlowWatcher?
+    
+    let visibilityState: ObservableValue<MobileContentViewVisibilityState> = ObservableValue(value: .visible)
+    
+    required init(flowItem: GodToolsToolParser.Flow.Item, renderedPageContext: MobileContentRenderedPageContext) {
         
         self.flowItem = flowItem
+        self.renderedPageContext = renderedPageContext
+        
+        super.init()
+        
+        visibilityFlowWatcher = flowItem.watchVisibility(state: renderedPageContext.rendererState, block: { [weak self] (invisible: KotlinBoolean, gone: KotlinBoolean) in
+            
+            let visibilityStateValue: MobileContentViewVisibilityState
+            
+            if gone.boolValue {
+                visibilityStateValue = .gone
+            }
+            else if invisible.boolValue {
+                visibilityStateValue = .hidden
+            }
+            else {
+                visibilityStateValue = .visible
+            }
+            
+            self?.visibilityState.accept(value: visibilityStateValue)
+        })
+    }
+    
+    deinit {
+        visibilityFlowWatcher?.close()
     }
     
     var width: MobileContentViewWidth {

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentFlowItem/MobileContentFlowItemViewModelType.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentFlowItem/MobileContentFlowItemViewModelType.swift
@@ -11,5 +11,6 @@ import GodToolsToolParser
 
 protocol MobileContentFlowItemViewModelType {
     
+    var visibilityState: ObservableValue<MobileContentViewVisibilityState> { get }
     var width: MobileContentViewWidth { get }
 }


### PR DESCRIPTION
This PR includes work that will update flowItems visibility (gone, hidden, visible) within the content flow.  Whenever a flowItem's visibility changes and the previous visibility or new visibility is equal to gone, it will trigger a rebuilding of the entire content flow and flow items.