### PR TITLE
GT-1508 remove duplicated load nib logic

### DIFF
--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/CardCollectionPageCard/MobileContentCardCollectionPageCardView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/CardCollectionPageCard/MobileContentCardCollectionPageCardView.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class MobileContentCardCollectionPageCardView: MobileContentView {
+class MobileContentCardCollectionPageCardView: MobileContentView, NibBased {
     
     private let viewModel: MobileContentCardCollectionPageCardViewModelType
     
@@ -23,7 +23,7 @@ class MobileContentCardCollectionPageCardView: MobileContentView {
         
         super.init(frame: UIScreen.main.bounds)
         
-        initializeNib()
+        loadNib()
         setupLayout()
         setupBinding()
     }
@@ -32,22 +32,9 @@ class MobileContentCardCollectionPageCardView: MobileContentView {
         fatalError("init(coder:) has not been implemented")
     }
     
-    private func initializeNib() {
-        
-        let nib: UINib = UINib(nibName: String(describing: MobileContentCardCollectionPageCardView.self), bundle: nil)
-        let contents: [Any]? = nib.instantiate(withOwner: self, options: nil)
-        if let rootNibView = (contents as? [UIView])?.first {
-            addSubview(rootNibView)
-            rootNibView.frame = bounds
-            rootNibView.translatesAutoresizingMaskIntoConstraints = false
-            rootNibView.constrainEdgesToView(view: self)
-            rootNibView.backgroundColor = .clear
-            backgroundColor = .clear
-        }
-    }
-    
     private func setupLayout() {
-                
+               
+        backgroundColor = .clear
     }
     
     private func setupBinding() {

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentAccordionSection/MobileContentAccordionSectionView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentAccordionSection/MobileContentAccordionSectionView.swift
@@ -13,7 +13,7 @@ protocol MobileContentAccordionSectionViewDelegate: AnyObject {
     func sectionViewDidChangeTextHiddenState(sectionView: MobileContentAccordionSectionView, textIsHidden: Bool, textHeight: CGFloat)
 }
 
-class MobileContentAccordionSectionView: MobileContentView {
+class MobileContentAccordionSectionView: MobileContentView, NibBased {
  
     private let viewModel: MobileContentAccordionSectionViewModelType
     private let viewCornerRadius: CGFloat = 10
@@ -41,7 +41,7 @@ class MobileContentAccordionSectionView: MobileContentView {
         
         super.init(frame: UIScreen.main.bounds)
         
-        initializeNib()
+        loadNib()
         setupLayout()
         
         revealTextButton.addTarget(self, action: #selector(revealTextButtonTapped), for: .touchUpInside)
@@ -51,21 +51,9 @@ class MobileContentAccordionSectionView: MobileContentView {
         fatalError("init(coder:) has not been implemented")
     }
     
-    private func initializeNib() {
-        
-        let nib: UINib = UINib(nibName: String(describing: MobileContentAccordionSectionView.self), bundle: nil)
-        let contents: [Any]? = nib.instantiate(withOwner: self, options: nil)
-        if let rootNibView = (contents as? [UIView])?.first {
-            addSubview(rootNibView)
-            rootNibView.frame = bounds
-            rootNibView.translatesAutoresizingMaskIntoConstraints = false
-            rootNibView.constrainEdgesToSuperview()
-            rootNibView.backgroundColor = .clear
-            backgroundColor = .clear
-        }
-    }
-    
     private func setupLayout() {
+        
+        backgroundColor = .clear
         
         // shadowView
         shadowView.layer.cornerRadius = viewCornerRadius

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentInput/MobileContentInputView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentInput/MobileContentInputView.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class MobileContentInputView: MobileContentView {
+class MobileContentInputView: MobileContentView, NibBased {
     
     let viewModel: MobileContentInputViewModelType
         
@@ -21,7 +21,7 @@ class MobileContentInputView: MobileContentView {
         
         super.init(frame: UIScreen.main.bounds)
         
-        initializeNib()
+        loadNib()
         setupLayout()
         setupBinding()
         
@@ -30,18 +30,6 @@ class MobileContentInputView: MobileContentView {
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-    
-    private func initializeNib() {
-        
-        let nib: UINib = UINib(nibName: String(describing: MobileContentInputView.self), bundle: nil)
-        let contents: [Any]? = nib.instantiate(withOwner: self, options: nil)
-        if let rootNibView = (contents as? [UIView])?.first {
-            addSubview(rootNibView)
-            rootNibView.frame = bounds
-            rootNibView.translatesAutoresizingMaskIntoConstraints = false
-            rootNibView.constrainEdgesToSuperview()
-        }
     }
     
     private func setupLayout() {

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentTabs/MobileContentTabsView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentTabs/MobileContentTabsView.swift
@@ -9,7 +9,7 @@
 import UIKit
 import GodToolsToolParser
 
-class MobileContentTabsView: MobileContentView {
+class MobileContentTabsView: MobileContentView, NibBased {
     
     private let viewModel: MobileContentTabsViewModelType
     
@@ -24,7 +24,7 @@ class MobileContentTabsView: MobileContentView {
         
         super.init(frame: UIScreen.main.bounds)
         
-        initializeNib()
+        loadNib()
         setupLayout()
         setupBinding()
         
@@ -33,18 +33,6 @@ class MobileContentTabsView: MobileContentView {
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-    
-    private func initializeNib() {
-        
-        let nib: UINib = UINib(nibName: String(describing: MobileContentTabsView.self), bundle: nil)
-        let contents: [Any]? = nib.instantiate(withOwner: self, options: nil)
-        if let rootNibView = (contents as? [UIView])?.first {
-            addSubview(rootNibView)
-            rootNibView.frame = bounds
-            rootNibView.translatesAutoresizingMaskIntoConstraints = false
-            rootNibView.constrainEdgesToSuperview()
-        }
     }
     
     private func setupLayout() {

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentText/MobileContentTextView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentText/MobileContentTextView.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class MobileContentTextView: MobileContentView {
+class MobileContentTextView: MobileContentView, NibBased {
     
     enum ViewType {
         case labelOnly(label: UILabel, shouldAddLabelAsSubview: Bool)
@@ -66,7 +66,7 @@ class MobileContentTextView: MobileContentView {
             }
             self.textLabel = label
         case .loadFromNib:
-            initializeNib()
+            loadNib()
         }
         
         setupBinding()
@@ -74,19 +74,6 @@ class MobileContentTextView: MobileContentView {
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-    
-    private func initializeNib() {
-        
-        let nib: UINib = UINib(nibName: String(describing: MobileContentTextView.self), bundle: nil)
-        let contents: [Any]? = nib.instantiate(withOwner: self, options: nil)
-        if let rootNibView = (contents as? [UIView])?.first {
-            addSubview(rootNibView)
-            rootNibView.frame = bounds
-            rootNibView.translatesAutoresizingMaskIntoConstraints = false
-            rootNibView.constrainEdgesToSuperview()
-            rootNibView.backgroundColor = .clear
-        }
     }
     
     private func setupBinding() {

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/Page/MobileContentPageView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/Page/MobileContentPageView.swift
@@ -14,7 +14,7 @@ protocol MobileContentPageViewDelegate: AnyObject {
     func pageViewDidReceiveEvents(pageView: MobileContentPageView, eventIds: [EventId])
 }
 
-class MobileContentPageView: MobileContentView {
+class MobileContentPageView: MobileContentView, NibBased {
     
     private let viewModel: MobileContentPageViewModelType
     
@@ -30,7 +30,7 @@ class MobileContentPageView: MobileContentView {
         super.init(frame: UIScreen.main.bounds)
         
         if let nibName = nibName {
-            initializeNib(nibName: nibName)
+            loadNib(nibName: nibName)
         }
         setupLayout()
         setupBinding()
@@ -44,18 +44,6 @@ class MobileContentPageView: MobileContentView {
         
         if let backgroundImageParent = self.backgroundImageParent {
             backgroundImageView?.removeParentBoundsChangeObserver(parentView: backgroundImageParent)
-        }
-    }
-    
-    private func initializeNib(nibName: String) {
-        
-        let nib: UINib = UINib(nibName: nibName, bundle: nil)
-        let contents: [Any]? = nib.instantiate(withOwner: self, options: nil)
-        if let rootNibView = (contents as? [UIView])?.first {
-            addSubview(rootNibView)
-            rootNibView.backgroundColor = .clear
-            rootNibView.frame = bounds
-            rootNibView.constrainEdgesToSuperview()
         }
     }
     

--- a/godtools/App/Services/Renderer/Views/Tool/Views/CallToAction/ToolPageCallToActionView.swift
+++ b/godtools/App/Services/Renderer/Views/Tool/Views/CallToAction/ToolPageCallToActionView.swift
@@ -13,7 +13,7 @@ protocol ToolPageCallToActionViewDelegate: AnyObject {
     func toolPageCallToActionNextButtonTapped(callToActionView: ToolPageCallToActionView)
 }
 
-class ToolPageCallToActionView: MobileContentView {
+class ToolPageCallToActionView: MobileContentView, NibBased {
         
     let viewModel: ToolPageCallToActionViewModelType
         
@@ -28,7 +28,8 @@ class ToolPageCallToActionView: MobileContentView {
         
         super.init(frame: UIScreen.main.bounds)
         
-        initializeNib()
+        let rootNibView: UIView? = loadNib()
+        rootNibView?.semanticContentAttribute = viewModel.languageDirectionSemanticContentAttribute
         setupLayout()
         setupBinding()
         
@@ -39,19 +40,6 @@ class ToolPageCallToActionView: MobileContentView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    private func initializeNib() {
-        
-        let nib: UINib = UINib(nibName: String(describing: ToolPageCallToActionView.self), bundle: nil)
-        let contents: [Any]? = nib.instantiate(withOwner: self, options: nil)
-        if let rootNibView = (contents as? [UIView])?.first {
-            rootNibView.semanticContentAttribute = viewModel.languageDirectionSemanticContentAttribute
-            addSubview(rootNibView)
-            rootNibView.backgroundColor = .clear
-            rootNibView.frame = bounds
-            rootNibView.constrainEdgesToSuperview()
-        }
-    }
-    
     private func setupLayout() {
         
     }

--- a/godtools/App/Services/Renderer/Views/Tool/Views/Card/ToolPageCardView.swift
+++ b/godtools/App/Services/Renderer/Views/Tool/Views/Card/ToolPageCardView.swift
@@ -17,7 +17,7 @@ protocol ToolPageCardViewDelegate: AnyObject {
     func toolPageCardDidSwipeCardDown(cardView: ToolPageCardView)
 }
 
-class ToolPageCardView: MobileContentView {
+class ToolPageCardView: MobileContentView, NibBased {
         
     private let backgroundImageView: MobileContentBackgroundImageView = MobileContentBackgroundImageView()
     private let swipeUpGesture: UISwipeGestureRecognizer = UISwipeGestureRecognizer()
@@ -39,7 +39,7 @@ class ToolPageCardView: MobileContentView {
     private weak var delegate: ToolPageCardViewDelegate?
         
     let viewModel: ToolPageCardViewModelType
-            
+           
     @IBOutlet weak private var titleLabel: UILabel!
     @IBOutlet weak private var headerTrainingTipImageView: UIImageView!
     @IBOutlet weak private var titleSeparatorLine: UIView!
@@ -59,7 +59,8 @@ class ToolPageCardView: MobileContentView {
         
         super.init(frame: UIScreen.main.bounds)
                 
-        initializeNib()
+        let rootNibView: UIView? = loadNib()
+        rootNibView?.semanticContentAttribute = viewModel.languageDirectionSemanticContentAttribute
         setupLayout()
         setupBinding()
         
@@ -101,19 +102,9 @@ class ToolPageCardView: MobileContentView {
         relayoutBottomGradient()
     }
     
-    private func initializeNib() {
-        
-        let nib: UINib = UINib(nibName: String(describing: ToolPageCardView.self), bundle: nil)
-        let contents: [Any]? = nib.instantiate(withOwner: self, options: nil)
-        if let rootNibView = (contents as? [UIView])?.first {
-            rootNibView.semanticContentAttribute = viewModel.languageDirectionSemanticContentAttribute
-            addSubview(rootNibView)
-            rootNibView.frame = bounds
-            rootNibView.constrainEdgesToSuperview()
-        }
-    }
-    
     private func setupLayout() {
+        
+        backgroundColor = .white
         
         let cardCornerRadius: CGFloat = 8
         

--- a/godtools/App/Services/Renderer/Views/Tool/Views/Header/ToolPageHeaderView.swift
+++ b/godtools/App/Services/Renderer/Views/Tool/Views/Header/ToolPageHeaderView.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class ToolPageHeaderView: MobileContentView {
+class ToolPageHeaderView: MobileContentView, NibBased {
     
     private let numberLabelWidthForHiddenState: CGFloat = 50
     private let trainingTipLeadingToTitleForNumberHiddenState: CGFloat = 5
@@ -37,7 +37,7 @@ class ToolPageHeaderView: MobileContentView {
         
         super.init(frame: UIScreen.main.bounds)
         
-        initializeNib()
+        loadNib()
         
         numberLabelStartingLeadingToHeaderView = numberLabelLeadingToHeaderView.constant
         trainingTipStartingLeadingToTitle = trainingTipLeadingToTitle.constant
@@ -48,18 +48,6 @@ class ToolPageHeaderView: MobileContentView {
     
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-    
-    private func initializeNib() {
-        
-        let nib: UINib = UINib(nibName: String(describing: ToolPageHeaderView.self), bundle: nil)
-        let contents: [Any]? = nib.instantiate(withOwner: self, options: nil)
-        if let rootNibView = (contents as? [UIView])?.first {
-            addSubview(rootNibView)
-            rootNibView.translatesAutoresizingMaskIntoConstraints = false
-            rootNibView.constrainEdgesToView(view: self, edgeInsets: .zero)
-            rootNibView.backgroundColor = .clear
-        }
     }
     
     private func setupLayout() {

--- a/godtools/App/Services/Renderer/Views/Tool/Views/Modal/ToolPageModalView.swift
+++ b/godtools/App/Services/Renderer/Views/Tool/Views/Modal/ToolPageModalView.swift
@@ -15,7 +15,7 @@ protocol ToolPageModalViewDelegate: AnyObject {
     func toolPageModalDismissListenerActivated(modalView: ToolPageModalView)
 }
 
-class ToolPageModalView: MobileContentView {
+class ToolPageModalView: MobileContentView, NibBased {
     
     private let viewModel: ToolPageModalViewModelType
     
@@ -31,7 +31,7 @@ class ToolPageModalView: MobileContentView {
         
         super.init(frame: UIScreen.main.bounds)
         
-        initializeNib()
+        loadNib()
         setupLayout()
         setupBinding()        
     }
@@ -43,19 +43,6 @@ class ToolPageModalView: MobileContentView {
     required init(itemSpacing: CGFloat, scrollIsEnabled: Bool) {
         fatalError("init(itemSpacing:scrollIsEnabled:) has not been implemented")
     }
-    
-    private func initializeNib() {
-            
-            let nib: UINib = UINib(nibName: String(describing: ToolPageModalView.self), bundle: nil)
-            let contents: [Any]? = nib.instantiate(withOwner: self, options: nil)
-            if let rootNibView = (contents as? [UIView])?.first {
-                addSubview(rootNibView)
-                rootNibView.backgroundColor = .clear
-                rootNibView.frame = bounds
-                rootNibView.translatesAutoresizingMaskIntoConstraints = false
-                rootNibView.constrainEdgesToSuperview()
-            }
-        }
     
     private func setupLayout() {
         

--- a/godtools/App/Services/Renderer/Views/Training/Views/Page/TrainingPageView.swift
+++ b/godtools/App/Services/Renderer/Views/Training/Views/Page/TrainingPageView.swift
@@ -13,7 +13,7 @@ protocol TrainingPageViewDelegate: AnyObject {
     func trainingPageButtonWithUrlTapped(trainingPage: TrainingPageView, url: String)
 }
 
-class TrainingPageView: MobileContentView {
+class TrainingPageView: MobileContentView, NibBased {
     
     private let viewModel: TrainingPageViewModelType
     private let contentStackView: MobileContentStackView = MobileContentStackView(contentInsets: .zero, itemSpacing: 15, scrollIsEnabled: true)
@@ -29,22 +29,9 @@ class TrainingPageView: MobileContentView {
         
         super.init(frame: UIScreen.main.bounds)
         
-        initializeNib(nibName: String(describing: TrainingPageView.self))
+        loadNib(nibName: String(describing: TrainingPageView.self))
         setupLayout()
         setupBinding()
-    }
-    
-    private func initializeNib(nibName: String) {
-        
-        let nib: UINib = UINib(nibName: nibName, bundle: nil)
-        let contents: [Any]? = nib.instantiate(withOwner: self, options: nil)
-        if let rootNibView = (contents as? [UIView])?.first {
-            addSubview(rootNibView)
-            rootNibView.backgroundColor = .clear
-            rootNibView.frame = bounds
-            rootNibView.translatesAutoresizingMaskIntoConstraints = false
-            rootNibView.constrainEdgesToView(view: self)
-        }
     }
     
     required init?(coder: NSCoder) {

--- a/godtools/App/Services/Renderer/Views/Training/Views/TrainingTip/TrainingTipView.swift
+++ b/godtools/App/Services/Renderer/Views/Training/Views/TrainingTip/TrainingTipView.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class TrainingTipView: MobileContentView {
+class TrainingTipView: MobileContentView, NibBased {
     
     private let viewModel: TrainingTipViewModelType
     
@@ -21,7 +21,7 @@ class TrainingTipView: MobileContentView {
         
         super.init(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
         
-        initializeNib()
+        loadNib()
         setupLayout()
         setupBinding()
         
@@ -30,19 +30,6 @@ class TrainingTipView: MobileContentView {
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-    
-    private func initializeNib() {
-        
-        let nib: UINib = UINib(nibName: String(describing: TrainingTipView.self), bundle: nil)
-        let contents: [Any]? = nib.instantiate(withOwner: self, options: nil)
-        if let rootNibView = (contents as? [UIView])?.first {
-            addSubview(rootNibView)
-            rootNibView.frame = bounds
-            rootNibView.translatesAutoresizingMaskIntoConstraints = false
-            rootNibView.constrainEdgesToSuperview()
-            rootNibView.backgroundColor = .clear
-        }
     }
     
     private func setupLayout() {

--- a/godtools/App/Share/Protocols/NibBased.swift
+++ b/godtools/App/Share/Protocols/NibBased.swift
@@ -9,31 +9,42 @@
 import UIKit
 
 protocol NibBased: AnyObject {
-    static var nib: UINib { get }
+    static var nibName: String { get }
 }
 
 extension NibBased {
-    static var nib: UINib {
-        return UINib(nibName: String(describing: self), bundle: Bundle(for: self))
+    
+    static var nibName: String {
+        return String(describing: self)
     }
 }
 
 extension NibBased where Self: UIView {
     
-    func loadNib() {
+    @discardableResult func loadNib(nibName: String = Self.nibName) -> UIView? {
         
-        let contents: [Any]? = Self.nib.instantiate(withOwner: self, options: nil)
+        let nib: UINib = UINib(nibName: nibName, bundle: nil)
         
-        if let views = contents as? [UIView] {
-            
-            if let rootView = views.first {
-                                
-                addSubview(rootView)
-                rootView.frame = bounds
-                rootView.constrainEdgesToSuperview()
-                
-                constrainEdgesToSuperview()
-            }
+        guard let contents = nib.instantiate(withOwner: self, options: nil) as? [UIView] else {
+            assertionFailure("\n WARNING: Failed to load top level UIView objects from nib with nibName: \(nibName)")
+            return nil
         }
+        
+        guard let rootNibView = contents.first else {
+            
+            assertionFailure("\n WARNING: Top level object does not contain any child elements on nib with nibName: \(nibName)")
+            return nil
+        }
+        
+        addSubview(rootNibView)
+        rootNibView.frame = bounds
+        rootNibView.translatesAutoresizingMaskIntoConstraints = false
+        rootNibView.constrainEdgesToView(view: self)
+        rootNibView.backgroundColor = .clear
+        
+        // TODO: This method will need to be removed as it's not guaranteed this view is attached to a superview at this point.  Any view's that load a custom nib via loadNib() should be responsible for attaching those custom views to the superview and setting up any necessary constraints. ~Levi
+        constrainEdgesToSuperview()
+        
+        return rootNibView
     }
 }


### PR DESCRIPTION
This PR addresses code duplication when loading a UINib from a custom .xib.  Logic for loading a UINib exists in the NibBased extension loadNib method.  I updated the following UIView Subclasses to implement NibBased and utilize the loadNib method.