### PR TITLE
GT-1375 fix auto layout constraints not getting applied in extension

### DIFF
--- a/godtools/App/Features/Account/Views/AccountItemCell.swift
+++ b/godtools/App/Features/Account/Views/AccountItemCell.swift
@@ -41,10 +41,13 @@ class AccountItemCell: UICollectionViewCell {
         
         clearItemParentView()
         
-        itemParentView.addSubview(viewModel.itemView)
-        viewModel.itemView.frame = itemParentView.bounds
-        viewModel.itemView.constrainEdgesToSuperview()
-        viewModel.itemView.delegate = self
+        let itemView: AccountItemViewType = viewModel.itemView
+        
+        itemParentView.addSubview(itemView)
+        itemView.frame = itemParentView.bounds
+        itemView.translatesAutoresizingMaskIntoConstraints = false
+        itemView.constrainEdgesToView(view: itemParentView)
+        itemView.delegate = self
     }
 }
 

--- a/godtools/App/Features/Articles/ArticleWebView.swift
+++ b/godtools/App/Features/Articles/ArticleWebView.swift
@@ -62,7 +62,8 @@ class ArticleWebView: UIViewController {
         
         // webView
         view.addSubview(webView)
-        webView.constrainEdgesToSuperview()
+        webView.translatesAutoresizingMaskIntoConstraints = false
+        webView.constrainEdgesToView(view: view)
         webView.alpha = 0
         webView.scrollView.showsVerticalScrollIndicator = true
         webView.scrollView.showsHorizontalScrollIndicator = false

--- a/godtools/App/Features/ToolTraining/Transitioning/ToolTrainingAnimatedTransitioning.swift
+++ b/godtools/App/Features/ToolTraining/Transitioning/ToolTrainingAnimatedTransitioning.swift
@@ -51,8 +51,10 @@ class ToolTrainingAnimatedTransitioning: NSObject, UIViewControllerAnimatedTrans
             }
             
             if toolTrainingView.view.superview == nil {
-                transitionContext.containerView.addSubview(toolTrainingView.view)
-                toolTrainingView.view.constrainEdgesToSuperview()
+                let parentView: UIView = transitionContext.containerView
+                parentView.addSubview(toolTrainingView.view)
+                toolTrainingView.view.translatesAutoresizingMaskIntoConstraints = false
+                toolTrainingView.view.constrainEdgesToView(view: parentView)
             }
             
             toolTrainingView.setViewState(viewState: .visible, animationDuration: animationDuration) { (finished: Bool) in

--- a/godtools/App/Features/ToolTraining/Views/ToolTrainingTipView.swift
+++ b/godtools/App/Features/ToolTraining/Views/ToolTrainingTipView.swift
@@ -28,8 +28,10 @@ class ToolTrainingTipView: UICollectionViewCell {
     
     func configure(mobileContentView: MobileContentView) {
             
-        contentView.addSubview(mobileContentView)
-        mobileContentView.constrainEdgesToSuperview()
+        let parentView: UIView = contentView
+        parentView.addSubview(mobileContentView)
+        mobileContentView.translatesAutoresizingMaskIntoConstraints = false
+        mobileContentView.constrainEdgesToView(view: parentView)
         self.mobileContentView = mobileContentView
     }
 }

--- a/godtools/App/Features/WebContent/WebContentView.swift
+++ b/godtools/App/Features/WebContent/WebContentView.swift
@@ -54,7 +54,8 @@ class WebContentView: UIViewController {
         
         // webView
         view.addSubview(webView)
-        webView.constrainEdgesToSuperview()
+        webView.translatesAutoresizingMaskIntoConstraints = false
+        webView.constrainEdgesToView(view: view)
         webView.alpha = 0
         webView.scrollView.showsVerticalScrollIndicator = true
         webView.scrollView.showsHorizontalScrollIndicator = false

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentAccordionSection/MobileContentAccordionSectionView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentAccordionSection/MobileContentAccordionSectionView.swift
@@ -167,8 +167,10 @@ extension MobileContentAccordionSectionView {
             return
         }
         
-        headerContainerView.addSubview(headerView)
-        headerView.constrainEdgesToSuperview(edgeInsets: UIEdgeInsets(top: 20, left: 20, bottom: 20, right: textStateImageTrailing.constant + textStateImageView.frame.size.width + 10))
+        let parentView: UIView = headerContainerView
+        parentView.addSubview(headerView)
+        headerView.translatesAutoresizingMaskIntoConstraints = false
+        headerView.constrainEdgesToView(view: parentView, edgeInsets: UIEdgeInsets(top: 20, left: 20, bottom: 20, right: textStateImageTrailing.constant + textStateImageView.frame.size.width + 10))
         self.headerView = headerView
     }
 }
@@ -183,8 +185,10 @@ extension MobileContentAccordionSectionView {
             return
         }
         
-        textContainerView.addSubview(textView)
-        textView.constrainEdgesToSuperview(edgeInsets: UIEdgeInsets(top: 0, left: 20, bottom: 20, right: 20))
+        let parentView: UIView = textContainerView
+        parentView.addSubview(textView)
+        textView.translatesAutoresizingMaskIntoConstraints = false
+        textView.constrainEdgesToView(view: parentView, edgeInsets: UIEdgeInsets(top: 0, left: 20, bottom: 20, right: 20))
         self.textView = textView
     }
 }

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentEmbeddedVideo/MobileContentEmbeddedVideoView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentEmbeddedVideo/MobileContentEmbeddedVideoView.swift
@@ -36,8 +36,10 @@ class MobileContentEmbeddedVideoView: MobileContentView {
         
         // videoView
         videoView.backgroundColor = .clear
-        addSubview(videoView)
-        videoView.constrainEdgesToSuperview()
+        let parentView: UIView = self
+        parentView.addSubview(videoView)
+        videoView.translatesAutoresizingMaskIntoConstraints = false
+        videoView.constrainEdgesToView(view: parentView)
     }
     
     private func setupBinding() {

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentHeader/MobileContentHeaderView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentHeader/MobileContentHeaderView.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2021 Cru. All rights reserved.
 //
 
-import Foundation
+import UIKit
 
 class MobileContentHeaderView: MobileContentView {
     
@@ -61,8 +61,10 @@ extension MobileContentHeaderView {
             return
         }
         
-        addSubview(textView)
-        textView.constrainEdgesToSuperview()
+        let parentView: UIView = self
+        parentView.addSubview(textView)
+        textView.translatesAutoresizingMaskIntoConstraints = false
+        textView.constrainEdgesToView(view: parentView)
         self.textView = textView
         
         let scaledFont: UIFont = textView.viewModel.getScaledFont(

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentImage/MobileContentImageView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentImage/MobileContentImageView.swift
@@ -143,10 +143,12 @@ class MobileContentImageView: MobileContentView {
             return
         }
         
+        let parentView: UIView = self
         let emptyView = UIView()
         emptyView.backgroundColor = .clear
-        addSubview(emptyView)
-        emptyView.constrainEdgesToSuperview()
+        parentView.addSubview(emptyView)
+        emptyView.translatesAutoresizingMaskIntoConstraints = false
+        emptyView.constrainEdgesToView(view: parentView)
         
         let heightConstraint: NSLayoutConstraint = NSLayoutConstraint(
             item: emptyView,

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentLink/MobileContentLinkView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentLink/MobileContentLinkView.swift
@@ -32,8 +32,10 @@ class MobileContentLinkView: MobileContentView {
     private func setupLayout() {
         
         // linkButton
-        addSubview(linkButton)
-        linkButton.constrainEdgesToSuperview()
+        let parentView: UIView = self
+        parentView.addSubview(linkButton)
+        linkButton.translatesAutoresizingMaskIntoConstraints = false
+        linkButton.constrainEdgesToView(view: parentView)
         
         let heightConstraint: NSLayoutConstraint = NSLayoutConstraint(
             item: linkButton,

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentMultiSelectOption/MobileContentMultiSelectOptionView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentMultiSelectOption/MobileContentMultiSelectOptionView.swift
@@ -83,8 +83,10 @@ class MobileContentMultiSelectOptionView: MobileContentStackView {
         
         if !subviews.contains(overlayButton) {
             
-            addSubview(overlayButton)
-            overlayButton.constrainEdgesToSuperview()
+            let parentView: UIView = self
+            parentView.addSubview(overlayButton)
+            overlayButton.translatesAutoresizingMaskIntoConstraints = false
+            overlayButton.constrainEdgesToView(view: parentView)
             overlayButton.setTitle(nil, for: .normal)
             overlayButton.backgroundColor = .clear
         }

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentMultiSelectOption/MobileContentMultiSelectOptionView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentMultiSelectOption/MobileContentMultiSelectOptionView.swift
@@ -53,8 +53,10 @@ class MobileContentMultiSelectOptionView: MobileContentStackView {
             return
         }
         
-        insertSubview(shadowView, at: 0)
-        shadowView.constrainEdgesToSuperview(edgeInsets: shadowEdgeInsetsToSuperView)
+        let parentView: UIView = self
+        parentView.insertSubview(shadowView, at: 0)
+        shadowView.translatesAutoresizingMaskIntoConstraints = false
+        shadowView.constrainEdgesToView(view: parentView, edgeInsets: shadowEdgeInsetsToSuperView)
         shadowView.backgroundColor = .white
         shadowView.layer.cornerRadius = cornerRadius
         shadowView.layer.shadowOffset = CGSize(width: 1, height: 1)

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentTabs/MobileContentTabsView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentTabs/MobileContentTabsView.swift
@@ -120,9 +120,8 @@ extension MobileContentTabsView {
         }
                 
         tabContentContainerView.addSubview(tabView)
-        
         tabView.translatesAutoresizingMaskIntoConstraints = false
-        tabView.constrainEdgesToSuperview()
+        tabView.constrainEdgesToView(view: tabContentContainerView)
         
         layoutIfNeeded()
     }

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/Heading/MobileContentHeadingView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/Heading/MobileContentHeadingView.swift
@@ -61,8 +61,10 @@ extension MobileContentHeadingView {
             return
         }
         
-        addSubview(textView)
-        textView.constrainEdgesToSuperview()
+        let parentView: UIView = self
+        parentView.addSubview(textView)
+        textView.translatesAutoresizingMaskIntoConstraints = false
+        textView.constrainEdgesToView(view: parentView)
         self.textView = textView
         
         let scaledFont: UIFont = textView.viewModel.getScaledFont(

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/Pages/Views/Page/MobileContentPageCell.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/Pages/Views/Page/MobileContentPageCell.swift
@@ -34,7 +34,8 @@ class MobileContentPageCell: UICollectionViewCell {
     func configure(mobileContentView: MobileContentView) {
         
         contentView.addSubview(mobileContentView)
-        mobileContentView.constrainEdgesToSuperview()
+        mobileContentView.translatesAutoresizingMaskIntoConstraints = false
+        mobileContentView.constrainEdgesToView(view: contentView)
         
         self.mobileContentView = mobileContentView
     }

--- a/godtools/App/Services/Renderer/Views/Tool/Views/Card/ToolPageCardView.swift
+++ b/godtools/App/Services/Renderer/Views/Tool/Views/Card/ToolPageCardView.swift
@@ -112,7 +112,8 @@ class ToolPageCardView: MobileContentView, NibBased {
         
         // contentStackView
         contentStackContainer.addSubview(contentStackView)
-        contentStackView.constrainEdgesToSuperview()
+        contentStackView.translatesAutoresizingMaskIntoConstraints = false
+        contentStackView.constrainEdgesToView(view: contentStackContainer)
         layoutIfNeeded()
         contentStackView.setScrollViewContentInset(contentInset: UIEdgeInsets(
             top: 0,

--- a/godtools/App/Services/Renderer/Views/Tool/Views/Modal/ToolPageModalView.swift
+++ b/godtools/App/Services/Renderer/Views/Tool/Views/Modal/ToolPageModalView.swift
@@ -48,7 +48,8 @@ class ToolPageModalView: MobileContentView, NibBased {
         
         // contentStackView
         contentContainerView.addSubview(contentStackView)
-        contentStackView.constrainEdgesToSuperview()
+        contentStackView.translatesAutoresizingMaskIntoConstraints = false
+        contentStackView.constrainEdgesToView(view: contentContainerView)
         setParentAndAddChild(childView: contentStackView)
     }
     

--- a/godtools/App/Services/Renderer/Views/Tool/Views/Page/ToolPageView.swift
+++ b/godtools/App/Services/Renderer/Views/Tool/Views/Page/ToolPageView.swift
@@ -179,7 +179,8 @@ extension ToolPageView {
         
         headerContainerView.isHidden = false
         headerContainerView.addSubview(headerView)
-        headerView.constrainEdgesToSuperview()
+        headerView.translatesAutoresizingMaskIntoConstraints = false
+        headerView.constrainEdgesToView(view: headerContainerView)
         self.headerView = headerView
         
         setHeaderHidden(hidden: false, animated: false)
@@ -224,7 +225,8 @@ extension ToolPageView {
         
         heroContainerView.isHidden = false
         heroContainerView.addSubview(heroView)
-        heroView.constrainEdgesToSuperview()
+        heroView.translatesAutoresizingMaskIntoConstraints = false
+        heroView.constrainEdgesToView(view: heroContainerView)
         self.heroView = heroView
     }
     
@@ -276,7 +278,8 @@ extension ToolPageView: ToolPageCallToActionViewDelegate {
                 
         callToActionContainerView.isHidden = false
         callToActionContainerView.addSubview(callToActionView)
-        callToActionView.constrainEdgesToSuperview()
+        callToActionView.translatesAutoresizingMaskIntoConstraints = false
+        callToActionView.constrainEdgesToView(view: callToActionContainerView)
         self.callToActionView = callToActionView
         
         callToActionContainerView.layoutIfNeeded()

--- a/godtools/App/Services/Renderer/Views/Training/Views/Page/TrainingPageView.swift
+++ b/godtools/App/Services/Renderer/Views/Training/Views/Page/TrainingPageView.swift
@@ -42,7 +42,8 @@ class TrainingPageView: MobileContentView, NibBased {
         
         // contentStackView
         contentStackContainerView.addSubview(contentStackView)
-        contentStackView.constrainEdgesToSuperview()
+        contentStackView.translatesAutoresizingMaskIntoConstraints = false
+        contentStackView.constrainEdgesToView(view: contentStackContainerView)
         contentStackView.setScrollViewContentInset(contentInset: UIEdgeInsets(
             top: 0,
             left: 0,

--- a/godtools/App/Share/AnimationTransitions/FadeAnimationTransition.swift
+++ b/godtools/App/Share/AnimationTransitions/FadeAnimationTransition.swift
@@ -43,7 +43,8 @@ class FadeAnimationTransition: NSObject, UIViewControllerAnimatedTransitioning {
                 
                 if toView.superview == nil {
                     containerView.addSubview(toView)
-                    toView.constrainEdgesToSuperview()
+                    toView.translatesAutoresizingMaskIntoConstraints = false
+                    toView.constrainEdgesToView(view: containerView)
                 }
                 
                 toView.alpha = 0

--- a/godtools/App/Share/Extensions/UIView+Constraints.swift
+++ b/godtools/App/Share/Extensions/UIView+Constraints.swift
@@ -10,64 +10,6 @@ import UIKit
 
 extension UIView {
     
-    func constrainEdgesToSuperview(edgeInsets: UIEdgeInsets = .zero) {
-        
-        guard let superview = self.superview else {
-            // TODO: Instead of checking for superview, force view as argument. ~Levi
-            //assertionFailure("Failed to constrain view edges to superview because a superview does not exist.  Is view added to a view hierarchy?")
-            print("\n WARNING: Failed to constrain edges to superview because superview is null.")
-            return
-        }
-        
-        // TODO: Don't set this here, require caller to make this. ~Levi
-        translatesAutoresizingMaskIntoConstraints = false
-        
-        let leading: NSLayoutConstraint = NSLayoutConstraint(
-            item: self,
-            attribute: .leading,
-            relatedBy: .equal,
-            toItem: superview,
-            attribute: .leading,
-            multiplier: 1,
-            constant: edgeInsets.left
-        )
-        
-        let trailing: NSLayoutConstraint = NSLayoutConstraint(
-            item: self,
-            attribute: .trailing,
-            relatedBy: .equal,
-            toItem: superview,
-            attribute: .trailing,
-            multiplier: 1,
-            constant: edgeInsets.right * -1
-        )
-        
-        let top: NSLayoutConstraint = NSLayoutConstraint(
-            item: self,
-            attribute: .top,
-            relatedBy: .equal,
-            toItem: superview,
-            attribute: .top,
-            multiplier: 1,
-            constant: edgeInsets.top
-        )
-        
-        let bottom: NSLayoutConstraint = NSLayoutConstraint(
-            item: self,
-            attribute: .bottom,
-            relatedBy: .equal,
-            toItem: superview,
-            attribute: .bottom,
-            multiplier: 1,
-            constant: edgeInsets.bottom * -1
-        )
-        
-        superview.addConstraint(leading)
-        superview.addConstraint(trailing)
-        superview.addConstraint(top)
-        superview.addConstraint(bottom)
-    }
-    
     func constrainEdgesToView(view: UIView, edgeInsets: UIEdgeInsets = .zero) {
         
         constrainTopToView(view: view, constant: edgeInsets.top)

--- a/godtools/App/Share/Protocols/NibBased.swift
+++ b/godtools/App/Share/Protocols/NibBased.swift
@@ -41,10 +41,7 @@ extension NibBased where Self: UIView {
         rootNibView.translatesAutoresizingMaskIntoConstraints = false
         rootNibView.constrainEdgesToView(view: self)
         rootNibView.backgroundColor = .clear
-        
-        // TODO: This method will need to be removed as it's not guaranteed this view is attached to a superview at this point.  Any view's that load a custom nib via loadNib() should be responsible for attaching those custom views to the superview and setting up any necessary constraints. ~Levi
-        constrainEdgesToSuperview()
-        
+                
         return rootNibView
     }
 }

--- a/godtools/App/Share/Views/TransparentModal/TransparentModalView.swift
+++ b/godtools/App/Share/Views/TransparentModal/TransparentModalView.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import SwiftUI
 
 class TransparentModalView: UIViewController {
     
@@ -159,12 +160,14 @@ extension TransparentModalView {
         let scrollView = UIScrollView()
         scrollView.backgroundColor = .white
         view.addSubview(scrollView)
-        scrollView.constrainEdgesToSuperview()
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.constrainEdgesToView(view: view)
         
         let contentView = UIView()
         contentView.backgroundColor = .clear
         scrollView.addSubview(contentView)
-        contentView.constrainEdgesToSuperview()
+        contentView.translatesAutoresizingMaskIntoConstraints = false
+        contentView.constrainEdgesToView(view: scrollView)
         
         let equalWidths: NSLayoutConstraint = NSLayoutConstraint(
             item: scrollView,
@@ -179,7 +182,8 @@ extension TransparentModalView {
         scrollView.addConstraint(equalWidths)
         
         contentView.addSubview(modalView.modal)
-        modalView.modal.constrainEdgesToSuperview()
+        modalView.modal.translatesAutoresizingMaskIntoConstraints = false
+        modalView.modal.constrainEdgesToView(view: contentView)
     }
 }
 


### PR DESCRIPTION
This PR removes the method ```func constrainEdgesToSuperview(edgeInsets: UIEdgeInsets = .zero) ``` in ```UIView+Constraints.swift``` and is replaced by ```func constrainEdgesToView(view: UIView, edgeInsets: UIEdgeInsets = .zero)```.

The reason for this change is the original method had a guard that would fail if the view's superview was null.  By forcing a view argument we can ensure the caller's edge constraints will be attached to the supplied view.  And it doesn't have to be the caller's superview either. 

Also removed setting ```translatesAutoresizingMaskIntoConstraints``` from ```UIView+Constraints``` extension.  The purpose of this extension is to reduce boilerplate code for attaching constraints.  translatesAutoresizingMaskIntoConstraints should be left up to the caller.