### PR TITLE
GT-1506 add shadow support to base MobileContentView

### DIFF
--- a/godtools.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/godtools.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/AppsFlyerSDK/AppsFlyerFramework.git",
         "state": {
           "branch": null,
-          "revision": "0021c8848a3e1f022989a01763d3678a6b6b15e7",
-          "version": "6.4.2"
+          "revision": "dde1f5b04105fa9a27b3ac78b2af88d4164755dc",
+          "version": "6.4.4"
         }
       },
       {

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentAccordionSection/MobileContentAccordionSectionView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentAccordionSection/MobileContentAccordionSectionView.swift
@@ -24,7 +24,6 @@ class MobileContentAccordionSectionView: MobileContentView {
     
     private weak var delegate: MobileContentAccordionSectionViewDelegate?
     
-    @IBOutlet weak private var shadowView: UIView!
     @IBOutlet weak private var contentView: UIView!
     @IBOutlet weak private var textContainerView: UIView!
     @IBOutlet weak private var headerContainerView: UIView!

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentAccordionSection/MobileContentAccordionSectionView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentAccordionSection/MobileContentAccordionSectionView.swift
@@ -67,12 +67,9 @@ class MobileContentAccordionSectionView: MobileContentView {
     
     private func setupLayout() {
         
-        // shadowView
-        shadowView.layer.cornerRadius = viewCornerRadius
-        shadowView.layer.shadowOffset = CGSize(width: 1, height: 1)
-        shadowView.layer.shadowColor = UIColor.black.cgColor
-        shadowView.layer.shadowRadius = 3
-        shadowView.layer.shadowOpacity = 0.3
+        layer.cornerRadius = viewCornerRadius
+        
+        drawShadow()
         
         // contentView
         contentView.backgroundColor = .white

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentAccordionSection/MobileContentAccordionSectionView.xib
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentAccordionSection/MobileContentAccordionSectionView.xib
@@ -14,7 +14,6 @@
                 <outlet property="headerContainerBottomToView" destination="Eyg-3t-XVl" id="L9a-jL-9p9"/>
                 <outlet property="headerContainerView" destination="fT8-zZ-Ha7" id="Xry-6a-jsV"/>
                 <outlet property="revealTextButton" destination="rxU-wm-wOn" id="FfB-zU-UL5"/>
-                <outlet property="shadowView" destination="xvp-mb-V7d" id="bgU-5F-D0k"/>
                 <outlet property="textContainerBottomToView" destination="kS1-Gg-ibk" id="FhA-Zo-N56"/>
                 <outlet property="textContainerView" destination="Bho-ue-3qC" id="W6p-HW-sMq"/>
                 <outlet property="textStateImageTrailing" destination="0Jj-5G-sqx" id="hTZ-g2-Xm7"/>
@@ -26,10 +25,6 @@
             <rect key="frame" x="0.0" y="0.0" width="414" height="74"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xvp-mb-V7d" userLabel="shadowView">
-                    <rect key="frame" x="0.0" y="0.0" width="414" height="74"/>
-                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                </view>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="UiB-zw-0fl" userLabel="contentView">
                     <rect key="frame" x="0.0" y="0.0" width="414" height="74"/>
                     <subviews>
@@ -87,12 +82,8 @@
             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
                 <constraint firstAttribute="bottom" secondItem="UiB-zw-0fl" secondAttribute="bottom" id="0Qz-Bp-NEw"/>
-                <constraint firstItem="xvp-mb-V7d" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="6zi-Yh-VVK"/>
-                <constraint firstAttribute="trailing" secondItem="xvp-mb-V7d" secondAttribute="trailing" id="P1Y-xA-TlF"/>
                 <constraint firstItem="UiB-zw-0fl" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="PAX-wy-RAI"/>
-                <constraint firstItem="xvp-mb-V7d" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="ioI-Qi-YUI"/>
                 <constraint firstAttribute="trailing" secondItem="UiB-zw-0fl" secondAttribute="trailing" id="mgK-ek-XUg"/>
-                <constraint firstAttribute="bottom" secondItem="xvp-mb-V7d" secondAttribute="bottom" id="rVu-N0-BiV"/>
                 <constraint firstItem="UiB-zw-0fl" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="zng-66-hgN"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentCard/MobileContentCardView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentCard/MobileContentCardView.swift
@@ -11,6 +11,7 @@ import UIKit
 class MobileContentCardView: MobileContentStackView {
     
     private let viewModel: MobileContentCardViewModelType
+    private let viewCornerRadius: CGFloat = 10
     
     private var shadowView: UIView?
     private var buttonOverlay: UIButton?
@@ -20,6 +21,9 @@ class MobileContentCardView: MobileContentStackView {
         self.viewModel = viewModel
         
         super.init(contentInsets: UIEdgeInsets(top: 20, left: 15, bottom: 20, right: 15), itemSpacing: 0, scrollIsEnabled: false)
+        
+        setupLayout()
+        setupBinding()
     }
     
     required init?(coder: NSCoder) {
@@ -30,6 +34,18 @@ class MobileContentCardView: MobileContentStackView {
         fatalError("init(contentInsets:itemSpacing:scrollIsEnabled:) has not been implemented")
     }
     
+    private func setupLayout() {
+        
+        backgroundColor = .white
+        layer.cornerRadius = viewCornerRadius
+        
+        drawShadow()
+    }
+    
+    private func setupBinding() {
+        
+    }
+    
     override var paddingInsets: UIEdgeInsets {
         return UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 8)
     }
@@ -37,30 +53,7 @@ class MobileContentCardView: MobileContentStackView {
     override func finishedRenderingChildren() {
         super.finishedRenderingChildren()
         
-        drawShadow()
         addButtonOverlay()
-    }
-    
-    private func drawShadow() {
-        
-        if let shadowView = self.shadowView {
-            shadowView.removeFromSuperview()
-            self.shadowView = nil
-        }
-        
-        let shadowView: UIView = UIView()
-        
-        insertSubview(shadowView, at: 0)
-        shadowView.translatesAutoresizingMaskIntoConstraints = false
-        shadowView.constrainEdgesToView(view: self)
-        shadowView.backgroundColor = .white
-        shadowView.layer.cornerRadius = 10
-        shadowView.layer.shadowOffset = CGSize(width: 1, height: 1)
-        shadowView.layer.shadowColor = UIColor.black.cgColor
-        shadowView.layer.shadowRadius = 3
-        shadowView.layer.shadowOpacity = 0.3
-        
-        self.shadowView = shadowView
     }
     
     private func addButtonOverlay() {

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentMultiSelect/MobileContentMultiSelectView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentMultiSelect/MobileContentMultiSelectView.swift
@@ -12,36 +12,19 @@ class MobileContentMultiSelectView: MobileContentStackView {
         
     private let viewModel: MobileContentMultiSelectViewModelType
     private let itemSpacing: CGFloat
-    private let shadowEdgeInsets: UIEdgeInsets
     private let isSingleColumn: Bool
-    private let supportsShadowsOnOptionsViews: Bool
     
     private var multiSelectOptionRows: [MobileContentRowView] = Array()
     private var optionViewsAdded: Bool = false
             
     required init(viewModel: MobileContentMultiSelectViewModelType) {
         
-        let itemSpacing: CGFloat
-        let shadowEdgeInsets: UIEdgeInsets
         let isSingleColumn: Bool = viewModel.numberOfColumnsForOptions == 1
-        let supportsShadowsOnOptionsViews: Bool = true
-        
-        if isSingleColumn && supportsShadowsOnOptionsViews {
-            
-            itemSpacing = 35
-            shadowEdgeInsets = UIEdgeInsets(top: -10, left: -10, bottom: -10, right: -10)
-        }
-        else {
-            
-            itemSpacing = 15
-            shadowEdgeInsets = .zero
-        }
+        let itemSpacing: CGFloat = isSingleColumn ? 35 : 15
         
         self.viewModel = viewModel
         self.itemSpacing = itemSpacing
-        self.shadowEdgeInsets = shadowEdgeInsets
         self.isSingleColumn = isSingleColumn
-        self.supportsShadowsOnOptionsViews = supportsShadowsOnOptionsViews
         
         super.init(contentInsets: .zero, itemSpacing: itemSpacing, scrollIsEnabled: false)
         
@@ -106,10 +89,6 @@ extension MobileContentMultiSelectView {
         }
         
         multiSelectOptionRow.renderChild(childView: optionView)
-        
-        if supportsShadowsOnOptionsViews {
-            optionView.drawShadow(shadowEdgeInsetsToSuperView: shadowEdgeInsets, cornerRadius: 10)
-        }
     }
     
     private func getNewMultiSelectOptionRow() -> MobileContentRowView {

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentMultiSelectOption/MobileContentMultiSelectOptionView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentMultiSelectOption/MobileContentMultiSelectOptionView.swift
@@ -36,34 +36,17 @@ class MobileContentMultiSelectOptionView: MobileContentStackView {
     }
     
     private func setupLayout() {
-                      
+                        
+        layer.cornerRadius = 10
+        
+        drawShadow()
     }
     
     private func setupBinding() {
         
         viewModel.backgroundColor.addObserver(self) { [weak self] (backgroundColor: UIColor) in
-            self?.setContentBackgroundColor(color: backgroundColor)
-            self?.shadowView.backgroundColor = backgroundColor
+            self?.backgroundColor = backgroundColor
         }
-    }
-    
-    func drawShadow(shadowEdgeInsetsToSuperView: UIEdgeInsets, cornerRadius: CGFloat) {
-        
-        guard !subviews.contains(shadowView) else {
-            return
-        }
-        
-        insertSubview(shadowView, at: 0)
-        shadowView.constrainEdgesToSuperview(edgeInsets: shadowEdgeInsetsToSuperView)
-        shadowView.backgroundColor = .white
-        shadowView.layer.cornerRadius = cornerRadius
-        shadowView.layer.shadowOffset = CGSize(width: 1, height: 1)
-        shadowView.layer.shadowColor = UIColor.black.cgColor
-        shadowView.layer.shadowRadius = 3
-        shadowView.layer.shadowOpacity = 0.3
-        
-        setContentCornerRadius(cornerRadius: cornerRadius)
-        setContentClipsToBounds(clipsToBounds: true)
     }
     
     @objc func overlayButtonTapped() {

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentStack/MobileContentStackView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentStack/MobileContentStackView.swift
@@ -142,18 +142,6 @@ class MobileContentStackView: MobileContentView {
         scrollView?.showsHorizontalScrollIndicator = !hidden
     }
     
-    func setContentBackgroundColor(color: UIColor) {
-        contentView.backgroundColor = color
-    }
-    
-    func setContentCornerRadius(cornerRadius: CGFloat) {
-        contentView.layer.cornerRadius = cornerRadius
-    }
-    
-    func setContentClipsToBounds(clipsToBounds: Bool) {
-        contentView.clipsToBounds = clipsToBounds
-    }
-    
     func setScrollViewDelegate(delegate: UIScrollViewDelegate) {
         scrollView?.delegate = delegate
     }
@@ -289,7 +277,6 @@ extension MobileContentStackView {
             scrollView.addConstraint(equalWidths)
         }
         
-        backgroundColor = .clear
         contentView.backgroundColor = .clear
         
         // build layout if needed

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/MobileContentView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/MobileContentView.swift
@@ -133,10 +133,6 @@ class MobileContentView: UIView {
     
     func drawShadow(shadowOffset: CGSize = CGSize(width: 1, height: 1), shadowRadius: CGFloat = 3, shadowOpacity: Float = 0.3) {
         
-        guard !drawsShadow else {
-            return
-        }
-        
         drawsShadow = true
         
         layer.shadowOffset = shadowOffset

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/MobileContentView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/MobileContentView.swift
@@ -15,6 +15,7 @@ class MobileContentView: UIView {
     
     private(set) var children: [MobileContentView] = Array()
     private(set) var visibilityState: MobileContentViewVisibilityState = .visible
+    private(set) var drawsShadow: Bool = false
     
     var paddingInsets: UIEdgeInsets {
         return .zero
@@ -126,6 +127,22 @@ class MobileContentView: UIView {
     
     func viewDidDisappear() {
         // NOTE: Subclasses should override and do any clean up here on view did disappear.
+    }
+    
+    // MARK: - Shadow
+    
+    func drawShadow(shadowOffset: CGSize = CGSize(width: 1, height: 1), shadowRadius: CGFloat = 3, shadowOpacity: Float = 0.3) {
+        
+        guard !drawsShadow else {
+            return
+        }
+        
+        drawsShadow = true
+        
+        layer.shadowOffset = shadowOffset
+        layer.shadowColor = UIColor.black.cgColor
+        layer.shadowRadius = shadowRadius
+        layer.shadowOpacity = shadowOpacity
     }
     
     // MARK: - Events

--- a/godtools/App/Services/Renderer/Views/Tool/Views/Card/ToolPageCardView.swift
+++ b/godtools/App/Services/Renderer/Views/Tool/Views/Card/ToolPageCardView.swift
@@ -134,10 +134,7 @@ class ToolPageCardView: MobileContentView {
         
         // shadow
         layer.cornerRadius = cardCornerRadius
-        layer.shadowColor = UIColor.black.cgColor
-        layer.shadowRadius = 6.0
-        layer.shadowOffset = CGSize(width: 1.5, height: 1.5)
-        layer.shadowOpacity = 0.3
+        drawShadow(shadowOffset: CGSize(width: 1.5, height: 1.5), shadowRadius: 6, shadowOpacity: 0.3)
         
         // background corner radius
         let rootView: UIView? = subviews.first


### PR DESCRIPTION
In this PR I added drawShadow() to the base MobileContentView class which is the base class for all mobile content renderer UI elements.  I removed shadow drawing code in subclasses and subclasses utilize the base drawShadow().

I also made a change to MobileContentStackView background color.  The MobileContentStackView consists of a view hierarchy like so. UIView (rootView) > UIScrollView? > UIView (contentView) where background color was applied to the contentView.  A change was made to set UIScrollView and contentView background colors to clear and background color will instead be applied to the rootView.  