### PR TITLE
GT-1513 update stack renderer to support shadows

### DIFF
--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentCard/MobileContentCardView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentCard/MobileContentCardView.swift
@@ -46,11 +46,6 @@ class MobileContentCardView: MobileContentStackView {
         
     }
     
-    override func renderChild(childView: MobileContentView) {
-        
-        super.renderChild(childView: childView)
-    }
-    
     override func finishedRenderingChildren() {
         super.finishedRenderingChildren()
         

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentCard/MobileContentCardView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentCard/MobileContentCardView.swift
@@ -20,7 +20,7 @@ class MobileContentCardView: MobileContentStackView {
         
         self.viewModel = viewModel
         
-        super.init(contentInsets: .zero, itemSpacing: 0, scrollIsEnabled: false)
+        super.init(contentInsets: UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 8), itemSpacing: 0, scrollIsEnabled: false)
         
         setupLayout()
         setupBinding()
@@ -46,8 +46,9 @@ class MobileContentCardView: MobileContentStackView {
         
     }
     
-    override var paddingInsets: UIEdgeInsets {
-        return UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 8)
+    override func renderChild(childView: MobileContentView) {
+        
+        super.renderChild(childView: childView)
     }
     
     override func finishedRenderingChildren() {

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentCard/MobileContentCardView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentCard/MobileContentCardView.swift
@@ -20,7 +20,7 @@ class MobileContentCardView: MobileContentStackView {
         
         self.viewModel = viewModel
         
-        super.init(contentInsets: UIEdgeInsets(top: 20, left: 15, bottom: 20, right: 15), itemSpacing: 0, scrollIsEnabled: false)
+        super.init(contentInsets: .zero, itemSpacing: 0, scrollIsEnabled: false)
         
         setupLayout()
         setupBinding()

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentStack/MobileContentStackView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentStack/MobileContentStackView.swift
@@ -11,13 +11,16 @@ import GodToolsToolParser
 
 class MobileContentStackView: MobileContentView {
         
+    private let minimumContentInsetToPreventShadowClippingOnScrollableContent: CGFloat = 10
+    
     private var scrollView: UIScrollView?
     private var contentView: UIView = UIView()
     private var childViews: [MobileContentView] = Array()
     private var lastAddedChildView: MobileContentView?
     private var lastAddedChildBottomConstraint: NSLayoutConstraint?
     private var autoSpacerViews: [MobileContentSpacerView] = Array()
-    private var contentInsets: UIEdgeInsets = .zero
+    private var contentInsetsForScrollableContent: UIEdgeInsets = .zero
+    private var contentInsetsForNonScrollableContent: UIEdgeInsets = .zero
     private var itemSpacing: CGFloat = 0
     private var scrollIsEnabled: Bool = true
             
@@ -70,6 +73,27 @@ class MobileContentStackView: MobileContentView {
     }
     
     // MARK: -
+    
+    private var contentInsets: UIEdgeInsets {
+        
+        get {
+            
+            return scrollIsEnabled ? contentInsetsForScrollableContent : contentInsetsForNonScrollableContent
+        }
+        set (newValue) {
+            
+            let minimumContentInsetsToScrollViewToPreventShadowClipping = UIEdgeInsets(
+                top: max(newValue.top, minimumContentInsetToPreventShadowClippingOnScrollableContent),
+                left: max(newValue.left, minimumContentInsetToPreventShadowClippingOnScrollableContent),
+                bottom: max(newValue.bottom, minimumContentInsetToPreventShadowClippingOnScrollableContent),
+                right: max(newValue.right, minimumContentInsetToPreventShadowClippingOnScrollableContent)
+            )
+            
+            self.contentInsetsForScrollableContent = minimumContentInsetsToScrollViewToPreventShadowClipping
+            
+            self.contentInsetsForNonScrollableContent = newValue
+        }
+    }
     
     var isEmpty: Bool {
         return contentView.subviews.isEmpty


### PR DESCRIPTION
In this PR I updated MobileContentStackView to support content insets between scrollable content and non scrollable content.  Not all MobileContentStackView's are scrollable, but if one is, then its minimum content insets will be 10 by default to prevent any clipping of inner elements that have shadows.

Also changed the content card content insets to 8 instead of padding.  That way the background stays fixed to the edges of the card and inner content would be spaced 8 points from the background edge. 