### PR TITLE
GT-1512 Fixed spacing issue in tract renderer

### DIFF
--- a/godtools/App/Services/Renderer/Views/Tool/Views/Header/ToolPageHeaderView.swift
+++ b/godtools/App/Services/Renderer/Views/Tool/Views/Header/ToolPageHeaderView.swift
@@ -18,6 +18,7 @@ class ToolPageHeaderView: MobileContentView, NibBased {
     private var trainingTipView: TrainingTipView?
     private var numberLabelStartingLeadingToHeaderView: CGFloat = 0
     private var trainingTipStartingLeadingToTitle: CGFloat = 0
+    private var trainingTipStartingTopToTextBackground: CGFloat = 0
     
     @IBOutlet weak private var backgroundView: UIView!
     @IBOutlet weak private var numberLabel: UILabel!
@@ -25,7 +26,10 @@ class ToolPageHeaderView: MobileContentView, NibBased {
     @IBOutlet weak private var trainingTipContainerView: UIView!
     
     @IBOutlet weak private var numberLabelLeadingToHeaderView: NSLayoutConstraint!
+    @IBOutlet weak private var trainingTipTopToTextBackground: NSLayoutConstraint!
     @IBOutlet weak private var trainingTipLeadingToTitle: NSLayoutConstraint!
+    @IBOutlet weak private var trainingTipBottomToView: NSLayoutConstraint!
+    @IBOutlet weak private var trainingTipHeight: NSLayoutConstraint!
     
     private var numberLabelWidthConstraint: NSLayoutConstraint?
     
@@ -41,6 +45,7 @@ class ToolPageHeaderView: MobileContentView, NibBased {
         
         numberLabelStartingLeadingToHeaderView = numberLabelLeadingToHeaderView.constant
         trainingTipStartingLeadingToTitle = trainingTipLeadingToTitle.constant
+        trainingTipStartingTopToTextBackground = trainingTipTopToTextBackground.constant
         
         setupLayout()
         setupBinding()
@@ -51,9 +56,9 @@ class ToolPageHeaderView: MobileContentView, NibBased {
     }
     
     private func setupLayout() {
-                            
+                    
         trainingTipContainerView.backgroundColor = .clear
-        trainingTipContainerView.isHidden = true
+        setTrainingTipHidden(hidden: true)
     }
     
     private func setupBinding() {
@@ -95,6 +100,26 @@ class ToolPageHeaderView: MobileContentView, NibBased {
         layoutIfNeeded()
     }
     
+    private func setTrainingTipHidden(hidden: Bool) {
+        
+        trainingTipContainerView.isHidden = hidden
+        
+        let trainingTipTopConstant: CGFloat
+        
+        if hidden {
+            
+            trainingTipTopConstant = (trainingTipHeight.constant + trainingTipBottomToView.constant) * -1
+        }
+        else {
+            
+            trainingTipTopConstant = trainingTipStartingTopToTextBackground
+        }
+        
+        trainingTipTopToTextBackground.constant = trainingTipTopConstant
+        
+        layoutIfNeeded()
+    }
+    
     private func addWidthConstraintToNumberLabelForHiddenState() {
         
         guard numberLabelWidthConstraint == nil else {
@@ -125,7 +150,7 @@ class ToolPageHeaderView: MobileContentView, NibBased {
             trainingTipContainerView.addSubview(trainingTipView)
             trainingTipView.translatesAutoresizingMaskIntoConstraints = false
             trainingTipView.constrainEdgesToView(view: trainingTipContainerView)
-            trainingTipContainerView.isHidden = false
+            setTrainingTipHidden(hidden: false)
         }
     }
 }

--- a/godtools/App/Services/Renderer/Views/Tool/Views/Header/ToolPageHeaderView.xib
+++ b/godtools/App/Services/Renderer/Views/Tool/Views/Header/ToolPageHeaderView.xib
@@ -14,8 +14,11 @@
                 <outlet property="numberLabel" destination="PU9-rf-kta" id="a2p-by-xtk"/>
                 <outlet property="numberLabelLeadingToHeaderView" destination="inK-rr-Gfe" id="TR1-rR-fcs"/>
                 <outlet property="titleLabel" destination="gDD-DD-R3G" id="3AA-ca-Abx"/>
+                <outlet property="trainingTipBottomToView" destination="EXv-JH-sl4" id="L2E-E7-YsW"/>
                 <outlet property="trainingTipContainerView" destination="O9b-bx-Kxd" id="5tr-Dl-mZH"/>
+                <outlet property="trainingTipHeight" destination="akS-VK-7P0" id="ZI4-wN-UxQ"/>
                 <outlet property="trainingTipLeadingToTitle" destination="ihZ-UF-bM4" id="AG8-fv-s2z"/>
+                <outlet property="trainingTipTopToTextBackground" destination="oVR-Dh-vEL" id="KCO-rh-Hdb"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>


### PR DESCRIPTION
This PR fixes extra spacing that was getting applied from the tract header training tip.  When the training tip is hidden, spacing is still getting accounted for.  This fix addresses that by adjusting the header's training tip top layout constraint when hidden vs visible.