### PR TITLE
GT-1283 Fix to center gravity in flow 

### DIFF
--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentFlowRow/MobileContentFlowRowItem.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentFlowRow/MobileContentFlowRowItem.swift
@@ -12,11 +12,16 @@ protocol MobileContentFlowRowItem: MobileContentView {
     
     var itemWidth: MobileContentViewWidth { get }
     var widthConstraint: NSLayoutConstraint? { get set }
+    var widthConstraintConstant: CGFloat { get }
     
     func setWidthConstraint(constant: CGFloat)
 }
 
 extension MobileContentFlowRowItem {
+    
+    var widthConstraintConstant: CGFloat {
+        return widthConstraint?.constant ?? 0
+    }
     
     func setWidthConstraint(constant: CGFloat) {
         


### PR DESCRIPTION
In this PR a couple of things were done:
1. Added code to equally center flow items in a flow when gravity is set to center.  This is done by taking the remaining space available in a row (minus combined width of added flow items) and evenly distributing this space between flow items and the first items leading space to the row and the last items trailing space to the row.
2. Ensure the first flow items leading constraint is attached to the rows leading and the last flow items trailing is attached to the rows trailing so all horizontal constraints are satisfied. 