### PR TITLE
GT-1283 emoji survey fix close tool navigation

### DIFF
--- a/godtools/App/Features/Lessons/Lesson/LessonView.swift
+++ b/godtools/App/Features/Lessons/Lesson/LessonView.swift
@@ -70,28 +70,12 @@ class LessonView: MobileContentPagesView {
         viewModel.lessonMostVisiblePageDidChange(page: page)
     }
     
-    override func didConfigurePageView(pageView: MobileContentPageView) {
-        super.didConfigurePageView(pageView: pageView)
-        
-        if let lessonPage = pageView as? LessonPageView {
-            lessonPage.setLessonPageDelegate(delegate: self)
-        }
-    }
-    
     @objc func previousPageButtonTapped() {
         pageNavigationView.scrollToPreviousPage(animated: true)
     }
     
     @objc func nextPageButtonTapped() {
         pageNavigationView.scrollToNextPage(animated: true)
-    }
-}
-
-// MARK: - LessonPageViewDelegate
-
-extension LessonView: LessonPageViewDelegate {
-    func lessonPageCloseLessonTapped(lessonPage: LessonPageView) {
-        viewModel.closeTapped()
     }
 }
 

--- a/godtools/App/Features/Lessons/Lesson/LessonViewModel.swift
+++ b/godtools/App/Features/Lessons/Lesson/LessonViewModel.swift
@@ -21,6 +21,12 @@ class LessonViewModel: MobileContentPagesViewModel, LessonViewModelType {
         fatalError("init(flowDelegate:renderer:page:mobileContentEventAnalytics:initialPageRenderingType:) has not been implemented")
     }
     
+    override func dismissPages() {
+        super.dismissPages()
+        
+        closeTapped()
+    }
+    
     private func updateProgress(page: Int) {
         
         let currentPage: CGFloat = CGFloat(page + 1)

--- a/godtools/App/Flows/FlowStep.swift
+++ b/godtools/App/Flows/FlowStep.swift
@@ -131,4 +131,7 @@ enum FlowStep {
     // choose your own adventure
     case backTappedFromChooseYourOwnAdventure
     case chooseYourOwnAdventureFlowCompleted(state: ChooseYourOwnAdventureFlowCompletedState)
+    
+    // renderer
+    case dismissRendererPages
 }

--- a/godtools/App/Flows/Tract/TractFlow.swift
+++ b/godtools/App/Flows/Tract/TractFlow.swift
@@ -227,6 +227,9 @@ class TractFlow: NSObject, ToolNavigationFlow, Flow {
             
             lessonFlow = nil
             
+        case .dismissRendererPages:
+            closeTool()
+            
         default:
             break
         }

--- a/godtools/App/Services/Renderer/Views/Lesson/Views/Page/LessonPageView.swift
+++ b/godtools/App/Services/Renderer/Views/Lesson/Views/Page/LessonPageView.swift
@@ -9,20 +9,13 @@
 import UIKit
 import GodToolsToolParser
 
-protocol LessonPageViewDelegate: AnyObject {
-    
-    func lessonPageCloseLessonTapped(lessonPage: LessonPageView)
-}
-
 class LessonPageView: MobileContentPageView {
     
     private let viewModel: LessonPageViewModelType
     private let safeArea: UIEdgeInsets
     
     private var contentView: MobileContentStackView?
-    
-    private weak var delegate: LessonPageViewDelegate?
-    
+        
     @IBOutlet weak private var topInset: UIView!
     @IBOutlet weak private var contentContainerView: UIView!
     @IBOutlet weak private var bottomInset: UIView!
@@ -73,10 +66,6 @@ class LessonPageView: MobileContentPageView {
         
     }
     
-    func setLessonPageDelegate(delegate: LessonPageViewDelegate?) {
-        self.delegate = delegate
-    }
-    
     // MARK: - MobileContentView
 
     override func renderChild(childView: MobileContentView) {
@@ -85,17 +74,6 @@ class LessonPageView: MobileContentPageView {
         
         if let contentView = childView as? MobileContentStackView {
             addContentView(contentView: contentView)
-        }
-    }
-    
-    override func didReceiveEvents(eventIds: [EventId]) {
-        
-        super.didReceiveEvents(eventIds: eventIds)
-        
-        for eventId in eventIds {
-            if viewModel.manifestDismissListeners.contains(eventId) {
-                delegate?.lessonPageCloseLessonTapped(lessonPage: self)
-            }
         }
     }
     

--- a/godtools/App/Services/Renderer/Views/Lesson/Views/Page/LessonPageViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/Lesson/Views/Page/LessonPageViewModel.swift
@@ -35,10 +35,6 @@ class LessonPageViewModel: MobileContentPageViewModel, LessonPageViewModelType {
         fatalError("init(flowDelegate:pageModel:renderedPageContext:deepLinkService:hidesBackgroundImage:) has not been implemented")
     }
     
-    var manifestDismissListeners: [EventId] {
-        return Array(renderedPageContext.manifest.dismissListeners)
-    }
-    
     func pageDidAppear() {
         mobileContentDidAppear()
         

--- a/godtools/App/Services/Renderer/Views/Lesson/Views/Page/LessonPageViewModelType.swift
+++ b/godtools/App/Services/Renderer/Views/Lesson/Views/Page/LessonPageViewModelType.swift
@@ -10,8 +10,6 @@ import Foundation
 import GodToolsToolParser
 
 protocol LessonPageViewModelType: MobileContentPageViewModelType {
-    
-    var manifestDismissListeners: [EventId] { get }
-    
+        
     func pageDidAppear()
 }

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/Pages/MobileContentPagesViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/Pages/MobileContentPagesViewModel.swift
@@ -316,9 +316,20 @@ class MobileContentPagesViewModel: NSObject, MobileContentPagesViewModelType {
     func pageDidReceiveEvents(eventIds: [EventId]) {
     
         trackContentEvents(eventIds: eventIds)
+
+        guard let currentPageRenderer = currentPageRenderer else {
+            return
+        }
         
-        if let didReceivePageListenerForPageNumber = currentPageRenderer?.getPageForListenerEvents(eventIds: eventIds),
-           let didReceivePageListenerEventForPageModel = currentPageRenderer?.getPageModel(page: didReceivePageListenerForPageNumber)  {
+        for eventId in eventIds {
+            if currentPageRenderer.manifest.dismissListeners.contains(eventId) {
+                dismissPages()
+                return
+            }
+        }
+                        
+        if let didReceivePageListenerForPageNumber = currentPageRenderer.getPageForListenerEvents(eventIds: eventIds),
+           let didReceivePageListenerEventForPageModel = currentPageRenderer.getPageModel(page: didReceivePageListenerForPageNumber)  {
             
             didReceivePageListenerForPage(
                 page: didReceivePageListenerForPageNumber,
@@ -330,5 +341,10 @@ class MobileContentPagesViewModel: NSObject, MobileContentPagesViewModelType {
     func didChangeMostVisiblePage(page: Int) {
         
         currentPage = page
+    }
+    
+    func dismissPages() {
+        
+        flowDelegate?.navigate(step: .dismissRendererPages)
     }
 }


### PR DESCRIPTION
This PR fixes closing a tract whenever a dismiss manifest event is fired within the content renderer.  This logic is handled in the base MobileContentPagesViewModel which subclasses can override.
Lessons now use this logic provided from the base MobileContentPagesViewModel.