### PR TITLE
Gt 1514 fix Vietnamese prayer pathway registration bug

### DIFF
--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -311,6 +311,7 @@
 		459C56D325FF954F00F15967 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		459C93A427581B23006207D2 /* OktaAuthentication in Frameworks */ = {isa = PBXBuildFile; productRef = 459C93A327581B23006207D2 /* OktaAuthentication */; };
 		459C93B027581FD0006207D2 /* OktaUserAuthentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 459C93AF27581FD0006207D2 /* OktaUserAuthentication.swift */; };
+		459F7F8328246CA5002C75FA /* ProcessedEventResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 459F7F8228246CA5002C75FA /* ProcessedEventResult.swift */; };
 		45A3A0C826B0BD54005DA490 /* Flow+NavigateToUrl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45A3A0C726B0BD54005DA490 /* Flow+NavigateToUrl.swift */; };
 		45A45CED2731B8C5005D4E74 /* MobileContentBackgroundImageRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 457032A426D0055A00F5BADC /* MobileContentBackgroundImageRenderer.swift */; };
 		45A45CEE2731B8C9005D4E74 /* MobileContentBackgroundImageRendererType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 457032A626D0056F00F5BADC /* MobileContentBackgroundImageRendererType.swift */; };
@@ -1332,6 +1333,7 @@
 		4599251A2704F36A008F7844 /* ChooseScaleSliderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChooseScaleSliderView.swift; sourceTree = "<group>"; };
 		4599251C2704F37B008F7844 /* ChooseScaleSliderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ChooseScaleSliderView.xib; sourceTree = "<group>"; };
 		459C93AF27581FD0006207D2 /* OktaUserAuthentication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OktaUserAuthentication.swift; sourceTree = "<group>"; };
+		459F7F8228246CA5002C75FA /* ProcessedEventResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessedEventResult.swift; sourceTree = "<group>"; };
 		45A3A0C726B0BD54005DA490 /* Flow+NavigateToUrl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Flow+NavigateToUrl.swift"; sourceTree = "<group>"; };
 		45A5200D26C481DB009B68D4 /* ManifestResourcesCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ManifestResourcesCache.swift; sourceTree = "<group>"; };
 		45A63AB2265441B60090E09D /* ExitLinkModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExitLinkModel.swift; sourceTree = "<group>"; };
@@ -2343,6 +2345,7 @@
 			isa = PBXGroup;
 			children = (
 				451CCF1227A9AA4600E8D2D3 /* PositionState */,
+				459F7F8128246C93002C75FA /* ProcessedEventResult */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -3474,6 +3477,14 @@
 				459C93AF27581FD0006207D2 /* OktaUserAuthentication.swift */,
 			);
 			path = Okta;
+			sourceTree = "<group>";
+		};
+		459F7F8128246C93002C75FA /* ProcessedEventResult */ = {
+			isa = PBXGroup;
+			children = (
+				459F7F8228246CA5002C75FA /* ProcessedEventResult.swift */,
+			);
+			path = ProcessedEventResult;
 			sourceTree = "<group>";
 		};
 		45A7BAF3252CBC5500D70465 /* Extensions */ = {
@@ -7038,6 +7049,7 @@
 				45AE975A27C97A9500C2CB33 /* Accordion+MobileContentRenderableModel.swift in Sources */,
 				45AD1AFB25938A4E00A096A0 /* MailViewModel.swift in Sources */,
 				45AD202825938A9800A096A0 /* LocalizationServices.swift in Sources */,
+				459F7F8328246CA5002C75FA /* ProcessedEventResult.swift in Sources */,
 				D1C8FEB0275E9BBB00C71E80 /* ParallelLanguageListViewModel.swift in Sources */,
 				4561AC9A279C4CC6003718C0 /* MobileContentCardCollectionPageView.swift in Sources */,
 				45FB161827DBDDB60009DF8E /* AppFlow.swift in Sources */,

--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -311,7 +311,6 @@
 		459C56D325FF954F00F15967 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		459C93A427581B23006207D2 /* OktaAuthentication in Frameworks */ = {isa = PBXBuildFile; productRef = 459C93A327581B23006207D2 /* OktaAuthentication */; };
 		459C93B027581FD0006207D2 /* OktaUserAuthentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 459C93AF27581FD0006207D2 /* OktaUserAuthentication.swift */; };
-		459F7F8328246CA5002C75FA /* ProcessedEventResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 459F7F8228246CA5002C75FA /* ProcessedEventResult.swift */; };
 		45A3A0C826B0BD54005DA490 /* Flow+NavigateToUrl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45A3A0C726B0BD54005DA490 /* Flow+NavigateToUrl.swift */; };
 		45A45CED2731B8C5005D4E74 /* MobileContentBackgroundImageRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 457032A426D0055A00F5BADC /* MobileContentBackgroundImageRenderer.swift */; };
 		45A45CEE2731B8C9005D4E74 /* MobileContentBackgroundImageRendererType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 457032A626D0056F00F5BADC /* MobileContentBackgroundImageRendererType.swift */; };
@@ -798,6 +797,7 @@
 		45BF6EBA27050A29003596A4 /* TransparentModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45BF6EB927050A29003596A4 /* TransparentModalView.swift */; };
 		45BF6EBC27050A3F003596A4 /* TransparentModalView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 45BF6EBB27050A3F003596A4 /* TransparentModalView.xib */; };
 		45BF6EBF27050D35003596A4 /* FadeAnimationTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45BF6EBE27050D35003596A4 /* FadeAnimationTransition.swift */; };
+		45C1A43528256B3300B8469A /* ProcessedEventResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45C1A43428256B3300B8469A /* ProcessedEventResult.swift */; };
 		45C5386124B8EFA700CABDAC /* godtoolsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45C5386024B8EFA700CABDAC /* godtoolsUITests.swift */; };
 		45C61DB1280896E60058946F /* AppsFlyerDeepLinkValueComponentsParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45C61DB0280896E50058946F /* AppsFlyerDeepLinkValueComponentsParser.swift */; };
 		45C61DC32808B1790058946F /* DashboardDeepLinkParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45C61DC22808B1790058946F /* DashboardDeepLinkParser.swift */; };
@@ -1333,7 +1333,6 @@
 		4599251A2704F36A008F7844 /* ChooseScaleSliderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChooseScaleSliderView.swift; sourceTree = "<group>"; };
 		4599251C2704F37B008F7844 /* ChooseScaleSliderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ChooseScaleSliderView.xib; sourceTree = "<group>"; };
 		459C93AF27581FD0006207D2 /* OktaUserAuthentication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OktaUserAuthentication.swift; sourceTree = "<group>"; };
-		459F7F8228246CA5002C75FA /* ProcessedEventResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessedEventResult.swift; sourceTree = "<group>"; };
 		45A3A0C726B0BD54005DA490 /* Flow+NavigateToUrl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Flow+NavigateToUrl.swift"; sourceTree = "<group>"; };
 		45A5200D26C481DB009B68D4 /* ManifestResourcesCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ManifestResourcesCache.swift; sourceTree = "<group>"; };
 		45A63AB2265441B60090E09D /* ExitLinkModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExitLinkModel.swift; sourceTree = "<group>"; };
@@ -1805,6 +1804,7 @@
 		45BF6EB927050A29003596A4 /* TransparentModalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransparentModalView.swift; sourceTree = "<group>"; };
 		45BF6EBB27050A3F003596A4 /* TransparentModalView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TransparentModalView.xib; sourceTree = "<group>"; };
 		45BF6EBE27050D35003596A4 /* FadeAnimationTransition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FadeAnimationTransition.swift; sourceTree = "<group>"; };
+		45C1A43428256B3300B8469A /* ProcessedEventResult.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProcessedEventResult.swift; sourceTree = "<group>"; };
 		45C5386024B8EFA700CABDAC /* godtoolsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = godtoolsUITests.swift; sourceTree = "<group>"; };
 		45C61DB0280896E50058946F /* AppsFlyerDeepLinkValueComponentsParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppsFlyerDeepLinkValueComponentsParser.swift; sourceTree = "<group>"; };
 		45C61DC22808B1790058946F /* DashboardDeepLinkParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DashboardDeepLinkParser.swift; sourceTree = "<group>"; };
@@ -2345,7 +2345,7 @@
 			isa = PBXGroup;
 			children = (
 				451CCF1227A9AA4600E8D2D3 /* PositionState */,
-				459F7F8128246C93002C75FA /* ProcessedEventResult */,
+				45C1A43328256B3300B8469A /* ProcessedEventResult */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -3477,14 +3477,6 @@
 				459C93AF27581FD0006207D2 /* OktaUserAuthentication.swift */,
 			);
 			path = Okta;
-			sourceTree = "<group>";
-		};
-		459F7F8128246C93002C75FA /* ProcessedEventResult */ = {
-			isa = PBXGroup;
-			children = (
-				459F7F8228246CA5002C75FA /* ProcessedEventResult.swift */,
-			);
-			path = ProcessedEventResult;
 			sourceTree = "<group>";
 		};
 		45A7BAF3252CBC5500D70465 /* Extensions */ = {
@@ -5206,6 +5198,14 @@
 				45BF6EBE27050D35003596A4 /* FadeAnimationTransition.swift */,
 			);
 			path = AnimationTransitions;
+			sourceTree = "<group>";
+		};
+		45C1A43328256B3300B8469A /* ProcessedEventResult */ = {
+			isa = PBXGroup;
+			children = (
+				45C1A43428256B3300B8469A /* ProcessedEventResult.swift */,
+			);
+			path = ProcessedEventResult;
 			sourceTree = "<group>";
 		};
 		45C61DC12808B1790058946F /* Dashboard */ = {
@@ -7049,7 +7049,7 @@
 				45AE975A27C97A9500C2CB33 /* Accordion+MobileContentRenderableModel.swift in Sources */,
 				45AD1AFB25938A4E00A096A0 /* MailViewModel.swift in Sources */,
 				45AD202825938A9800A096A0 /* LocalizationServices.swift in Sources */,
-				459F7F8328246CA5002C75FA /* ProcessedEventResult.swift in Sources */,
+				45C1A43528256B3300B8469A /* ProcessedEventResult.swift in Sources */,
 				D1C8FEB0275E9BBB00C71E80 /* ParallelLanguageListViewModel.swift in Sources */,
 				4561AC9A279C4CC6003718C0 /* MobileContentCardCollectionPageView.swift in Sources */,
 				45FB161827DBDDB60009DF8E /* AppFlow.swift in Sources */,

--- a/godtools.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/godtools.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/AppsFlyerSDK/AppsFlyerFramework.git",
       "state" : {
-        "revision" : "dde1f5b04105fa9a27b3ac78b2af88d4164755dc",
-        "version" : "6.4.4"
+        "revision" : "0021c8848a3e1f022989a01763d3678a6b6b15e7",
+        "version" : "6.4.2"
       }
     },
     {
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/gtm-session-fetcher.git",
       "state" : {
-        "revision" : "eca9404a18f53727e4698211aaf2615eb93b962a",
-        "version" : "1.7.1"
+        "revision" : "4e9bbf2808b8fee444e84a48f5f3c12641987d3e",
+        "version" : "1.7.2"
       }
     },
     {

--- a/godtools/App/Services/Renderer/Analytics/MobileContentEventAnalyticsTracking.swift
+++ b/godtools/App/Services/Renderer/Analytics/MobileContentEventAnalyticsTracking.swift
@@ -21,13 +21,6 @@ class MobileContentEventAnalyticsTracking {
         self.firebaseAnalytics = firebaseAnalytics
     }
     
-    func trackContentEvents(eventIds: [EventId], resource: ResourceModel, language: LanguageModel) {
-        
-        for eventId in eventIds {
-            trackContentEvent(eventId: eventId, resource: resource, language: language)
-        }
-    }
-    
     func trackContentEvent(eventId: EventId, resource: ResourceModel, language: LanguageModel) {
         
         let data: [String: Any] = [

--- a/godtools/App/Services/Renderer/Views/MobileContent/Models/ProcessedEventResult/ProcessedEventResult.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Models/ProcessedEventResult/ProcessedEventResult.swift
@@ -1,0 +1,15 @@
+//
+//  ProcessedEventResult.swift
+//  godtools
+//
+//  Created by Levi Eggert on 5/5/22.
+//  Copyright © 2022 Cru. All rights reserved.
+//
+
+import Foundation
+
+struct ProcessedEventResult {
+    
+    let shouldRemoveEventId: Bool
+    let successfullyProcessed: Bool
+}

--- a/godtools/App/Services/Renderer/Views/MobileContent/Models/ProcessedEventResult/ProcessedEventResult.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Models/ProcessedEventResult/ProcessedEventResult.swift
@@ -11,5 +11,4 @@ import Foundation
 struct ProcessedEventResult {
     
     let shouldRemoveEventId: Bool
-    let successfullyProcessed: Bool
 }

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentTabs/MobileContentTabsView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentTabs/MobileContentTabsView.swift
@@ -65,21 +65,18 @@ class MobileContentTabsView: MobileContentView, NibBased {
         return .constrainedToChildren
     }
     
-    override func didReceiveEvent(eventId: EventId, eventIdsGroup: [EventId]) -> MobileContentView.DidSuccessfullyProcessEvent {
-        
-        var didSuccessfullyProcessEvent: Bool = false
-        
+    override func didReceiveEvent(eventId: EventId, eventIdsGroup: [EventId]) -> ProcessedEventResult? {
+                
         for tabIndex in 0 ..< tabViews.count {
             
             let tabListeners: [EventId] = tabViews[tabIndex].viewModel.tabListeners
             
             if tabListeners.contains(eventId) {
                 setSelectedTabIndex(selectedTabIndex: tabIndex)
-                didSuccessfullyProcessEvent = true
             }
         }
         
-        return didSuccessfullyProcessEvent
+        return nil
     }
 }
 

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentTabs/MobileContentTabsView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentTabs/MobileContentTabsView.swift
@@ -65,19 +65,21 @@ class MobileContentTabsView: MobileContentView, NibBased {
         return .constrainedToChildren
     }
     
-    override func didReceiveEvents(eventIds: [EventId]) {
-                
-        for eventId in eventIds {
+    override func didReceiveEvent(eventId: EventId, eventIdsGroup: [EventId]) -> MobileContentView.DidSuccessfullyProcessEvent {
+        
+        var didSuccessfullyProcessEvent: Bool = false
+        
+        for tabIndex in 0 ..< tabViews.count {
             
-            for tabIndex in 0 ..< tabViews.count {
-                
-                let tabListeners: [EventId] = tabViews[tabIndex].viewModel.tabListeners
-                
-                if tabListeners.contains(eventId) {
-                    setSelectedTabIndex(selectedTabIndex: tabIndex)
-                }
+            let tabListeners: [EventId] = tabViews[tabIndex].viewModel.tabListeners
+            
+            if tabListeners.contains(eventId) {
+                setSelectedTabIndex(selectedTabIndex: tabIndex)
+                didSuccessfullyProcessEvent = true
             }
         }
+        
+        return didSuccessfullyProcessEvent
     }
 }
 

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/MobileContentView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/MobileContentView.swift
@@ -151,7 +151,7 @@ class MobileContentView: UIView {
                 
         walkUpHierarchyAndSendEventsToChildren(view: self, eventIds: &eventIds)
                 
-        recurseChildrenAndSendEvents(view: getRootView(), eventIds: &eventIds)
+        recurseChildrenAndSendEventsFromView(view: getRootView(), eventIds: &eventIds)
     }
     
     private func walkUpHierarchyAndSendEventsToChildren(view: MobileContentView, eventIds: inout [EventId]) {
@@ -172,14 +172,14 @@ class MobileContentView: UIView {
         }
     }
     
-    private func recurseChildrenAndSendEvents(view: MobileContentView, eventIds: inout [EventId]) {
+    private func recurseChildrenAndSendEventsFromView(view: MobileContentView, eventIds: inout [EventId]) {
         
         guard !eventIds.isEmpty else {
             return
         }
         
         for childView in view.children {
-            recurseChildrenAndSendEvents(view: childView, eventIds: &eventIds)
+            recurseChildrenAndSendEventsFromView(view: childView, eventIds: &eventIds)
         }
         
         sendEventsToView(view: view, eventIds: &eventIds)

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/MobileContentView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/MobileContentView.swift
@@ -10,9 +10,7 @@ import UIKit
 import GodToolsToolParser
 
 class MobileContentView: UIView {
-        
-    typealias DidSuccessfullyProcessEvent = Bool
-    
+            
     private(set) weak var parent: MobileContentView?
     
     private(set) var children: [MobileContentView] = Array()
@@ -187,11 +185,19 @@ class MobileContentView: UIView {
     
     private func sendEventsToView(view: MobileContentView, eventIds: inout [EventId]) {
 
-        for eventId in eventIds {
+        guard !eventIds.isEmpty else {
+            return
+        }
+        
+        for index in stride(from: eventIds.count - 1, through: 0, by: -1) {
             
-            let didSuccessfullyProcessEvent: Bool = view.didReceiveEvent(eventId: eventId, eventIdsGroup: eventIds)
+            let eventId: EventId = eventIds[index]
             
-            if didSuccessfullyProcessEvent {
+            guard let processedEventResult = view.didReceiveEvent(eventId: eventId, eventIdsGroup: eventIds) else {
+                continue
+            }
+            
+            if processedEventResult.shouldRemoveEventId {
                 removeEventIdFromEventIds(eventIds: &eventIds, eventIdToRemove: eventId)
             }
         }
@@ -203,9 +209,9 @@ class MobileContentView: UIView {
         }
     }
     
-    func didReceiveEvent(eventId: EventId, eventIdsGroup: [EventId]) -> DidSuccessfullyProcessEvent {
+    func didReceiveEvent(eventId: EventId, eventIdsGroup: [EventId]) -> ProcessedEventResult? {
         
-        return false
+        return nil
     }
     
     // MARK: - Url Events

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/MobileContentView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/MobileContentView.swift
@@ -11,6 +11,8 @@ import GodToolsToolParser
 
 class MobileContentView: UIView {
         
+    typealias DidSuccessfullyProcessEvent = Bool
+    
     private(set) weak var parent: MobileContentView?
     
     private(set) var children: [MobileContentView] = Array()
@@ -156,11 +158,20 @@ class MobileContentView: UIView {
             recurseChildrenAndSendEvents(view: childView, eventIds: eventIds)
         }
         
-        view.didReceiveEvents(eventIds: eventIds)
+        sendEventsToView(view: view, eventIds: eventIds)
     }
     
-    func didReceiveEvents(eventIds: [EventId]) {
+    private func sendEventsToView(view: MobileContentView, eventIds: [EventId]) {
+
+        for eventId in eventIds {
+            
+            let didSuccessfullyProcessEvent: Bool = view.didReceiveEvent(eventId: eventId, eventIdsGroup: eventIds)
+        }
+    }
+    
+    func didReceiveEvent(eventId: EventId, eventIdsGroup: [EventId]) -> DidSuccessfullyProcessEvent {
         
+        return false
     }
     
     // MARK: - Url Events

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/Page/MobileContentPageView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/Page/MobileContentPageView.swift
@@ -11,7 +11,7 @@ import GodToolsToolParser
 
 protocol MobileContentPageViewDelegate: AnyObject {
     
-    func pageViewDidReceiveEvents(pageView: MobileContentPageView, eventIds: [EventId])
+    func pageViewDidReceiveEvent(pageView: MobileContentPageView, eventId: EventId) -> MobileContentView.DidSuccessfullyProcessEvent
 }
 
 class MobileContentPageView: MobileContentView, NibBased {
@@ -76,10 +76,9 @@ class MobileContentPageView: MobileContentView, NibBased {
         
     // MARK: - MobileContentView
     
-    override func didReceiveEvents(eventIds: [EventId]) {
-        super.didReceiveEvents(eventIds: eventIds)
+    override func didReceiveEvent(eventId: EventId, eventIdsGroup: [EventId]) -> MobileContentView.DidSuccessfullyProcessEvent {
         
-        delegate?.pageViewDidReceiveEvents(pageView: self, eventIds: eventIds)
+        return delegate?.pageViewDidReceiveEvent(pageView: self, eventId: eventId) ?? false
     }
     
     override func didReceiveButtonWithUrlEvent(url: String) {

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/Page/MobileContentPageView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/Page/MobileContentPageView.swift
@@ -11,7 +11,7 @@ import GodToolsToolParser
 
 protocol MobileContentPageViewDelegate: AnyObject {
     
-    func pageViewDidReceiveEvent(pageView: MobileContentPageView, eventId: EventId) -> MobileContentView.DidSuccessfullyProcessEvent
+    func pageViewDidReceiveEvent(pageView: MobileContentPageView, eventId: EventId) -> ProcessedEventResult?
 }
 
 class MobileContentPageView: MobileContentView, NibBased {
@@ -76,9 +76,9 @@ class MobileContentPageView: MobileContentView, NibBased {
         
     // MARK: - MobileContentView
     
-    override func didReceiveEvent(eventId: EventId, eventIdsGroup: [EventId]) -> MobileContentView.DidSuccessfullyProcessEvent {
+    override func didReceiveEvent(eventId: EventId, eventIdsGroup: [EventId]) -> ProcessedEventResult? {
         
-        return delegate?.pageViewDidReceiveEvent(pageView: self, eventId: eventId) ?? false
+        return delegate?.pageViewDidReceiveEvent(pageView: self, eventId: eventId)
     }
     
     override func didReceiveButtonWithUrlEvent(url: String) {

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/Pages/MobileContentPagesView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/Pages/MobileContentPagesView.swift
@@ -325,7 +325,7 @@ extension MobileContentPagesView: PageNavigationCollectionViewDelegate {
 
 extension MobileContentPagesView: MobileContentPageViewDelegate {
     
-    func pageViewDidReceiveEvent(pageView: MobileContentPageView, eventId: EventId) -> MobileContentView.DidSuccessfullyProcessEvent {
+    func pageViewDidReceiveEvent(pageView: MobileContentPageView, eventId: EventId) -> ProcessedEventResult? {
         return viewModel.pageDidReceiveEvent(eventId: eventId)
     }
 }

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/Pages/MobileContentPagesView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/Pages/MobileContentPagesView.swift
@@ -325,7 +325,7 @@ extension MobileContentPagesView: PageNavigationCollectionViewDelegate {
 
 extension MobileContentPagesView: MobileContentPageViewDelegate {
     
-    func pageViewDidReceiveEvents(pageView: MobileContentPageView, eventIds: [EventId]) {
-        viewModel.pageDidReceiveEvents(eventIds: eventIds)
+    func pageViewDidReceiveEvent(pageView: MobileContentPageView, eventId: EventId) -> MobileContentView.DidSuccessfullyProcessEvent {
+        return viewModel.pageDidReceiveEvent(eventId: eventId)
     }
 }

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/Pages/MobileContentPagesViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/Pages/MobileContentPagesViewModel.swift
@@ -315,17 +315,16 @@ class MobileContentPagesViewModel: NSObject, MobileContentPagesViewModelType {
     }
     
     
-    func pageDidReceiveEvent(eventId: EventId) -> MobileContentPageView.DidSuccessfullyProcessEvent {
+    func pageDidReceiveEvent(eventId: EventId) -> ProcessedEventResult? {
         
         trackContentEvent(eventId: eventId)
         
         guard let currentPageRenderer = currentPageRenderer else {
-            return false
+            return nil
         }
         
         if currentPageRenderer.manifest.dismissListeners.contains(eventId) {
             handleDismissToolEvent()
-            return true
         }
                                 
         if let didReceivePageListenerForPageNumber = currentPageRenderer.getPageForListenerEvents(eventIds: [eventId]),
@@ -335,11 +334,9 @@ class MobileContentPagesViewModel: NSObject, MobileContentPagesViewModelType {
                 page: didReceivePageListenerForPageNumber,
                 pageModel: didReceivePageListenerEventForPageModel
             )
-            
-            return true
         }
         
-        return false
+        return nil
     }
     
     func didChangeMostVisiblePage(page: Int) {

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/Pages/MobileContentPagesViewModelType.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/Pages/MobileContentPagesViewModelType.swift
@@ -22,6 +22,6 @@ protocol MobileContentPagesViewModelType {
     func pageWillAppear(page: Int) -> MobileContentView?
     func pageDidAppear(page: Int)
     func pageDidDisappear(page: Int)
-    func pageDidReceiveEvent(eventId: EventId) -> MobileContentView.DidSuccessfullyProcessEvent
+    func pageDidReceiveEvent(eventId: EventId) -> ProcessedEventResult?
     func didChangeMostVisiblePage(page: Int)
 }

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/Pages/MobileContentPagesViewModelType.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/Pages/MobileContentPagesViewModelType.swift
@@ -22,6 +22,6 @@ protocol MobileContentPagesViewModelType {
     func pageWillAppear(page: Int) -> MobileContentView?
     func pageDidAppear(page: Int)
     func pageDidDisappear(page: Int)
-    func pageDidReceiveEvents(eventIds: [EventId])
+    func pageDidReceiveEvent(eventId: EventId) -> MobileContentView.DidSuccessfullyProcessEvent
     func didChangeMostVisiblePage(page: Int)
 }

--- a/godtools/App/Services/Renderer/Views/Tool/Views/Cards/ToolPageCardsView.swift
+++ b/godtools/App/Services/Renderer/Views/Tool/Views/Cards/ToolPageCardsView.swift
@@ -107,23 +107,19 @@ class ToolPageCardsView: MobileContentView {
         }
     }
     
-    override func didReceiveEvent(eventId: EventId, eventIdsGroup: [EventId]) -> MobileContentView.DidSuccessfullyProcessEvent {
-        
-        var didSuccessfullyProcessEvent: Bool = false
-        
+    override func didReceiveEvent(eventId: EventId, eventIdsGroup: [EventId]) -> ProcessedEventResult? {
+                
         for cardView in cardViews {
             
             if cardView.viewModel.dismissListeners.contains(eventId) {
                 dismissCard(cardView: cardView)
-                didSuccessfullyProcessEvent = true
             }
             else if cardView.viewModel.listeners.contains(eventId) {
                 presentCard(cardView: cardView)
-                didSuccessfullyProcessEvent = true
             }
         }
         
-        return didSuccessfullyProcessEvent
+        return nil
     }
     
     // MARK: -

--- a/godtools/App/Services/Renderer/Views/Tool/Views/Cards/ToolPageCardsView.swift
+++ b/godtools/App/Services/Renderer/Views/Tool/Views/Cards/ToolPageCardsView.swift
@@ -109,23 +109,21 @@ class ToolPageCardsView: MobileContentView {
     
     override func didReceiveEvent(eventId: EventId, eventIdsGroup: [EventId]) -> MobileContentView.DidSuccessfullyProcessEvent {
         
-        let didSuccessfullyProcessEvent: Bool
-    }
-    
-    override func didReceiveEvents(eventIds: [EventId]) {
-                
-        for eventId in eventIds {
+        var didSuccessfullyProcessEvent: Bool = false
+        
+        for cardView in cardViews {
             
-            for cardView in cardViews {
-                
-                if cardView.viewModel.dismissListeners.contains(eventId) {
-                    dismissCard(cardView: cardView)
-                }
-                else if cardView.viewModel.listeners.contains(eventId) {
-                    presentCard(cardView: cardView)
-                }
+            if cardView.viewModel.dismissListeners.contains(eventId) {
+                dismissCard(cardView: cardView)
+                didSuccessfullyProcessEvent = true
+            }
+            else if cardView.viewModel.listeners.contains(eventId) {
+                presentCard(cardView: cardView)
+                didSuccessfullyProcessEvent = true
             }
         }
+        
+        return didSuccessfullyProcessEvent
     }
     
     // MARK: -

--- a/godtools/App/Services/Renderer/Views/Tool/Views/Cards/ToolPageCardsView.swift
+++ b/godtools/App/Services/Renderer/Views/Tool/Views/Cards/ToolPageCardsView.swift
@@ -107,6 +107,11 @@ class ToolPageCardsView: MobileContentView {
         }
     }
     
+    override func didReceiveEvent(eventId: EventId, eventIdsGroup: [EventId]) -> MobileContentView.DidSuccessfullyProcessEvent {
+        
+        let didSuccessfullyProcessEvent: Bool
+    }
+    
     override func didReceiveEvents(eventIds: [EventId]) {
                 
         for eventId in eventIds {

--- a/godtools/App/Services/Renderer/Views/Tool/Views/Form/ToolPageFormView.swift
+++ b/godtools/App/Services/Renderer/Views/Tool/Views/Form/ToolPageFormView.swift
@@ -65,7 +65,7 @@ class ToolPageFormView: MobileContentFormView {
                 
         if isFollowUpEvent {
             pageFormViewModel.sendFollowUp(inputModels: super.getInputModels(), eventIds: eventIdsGroup)
-            return ProcessedEventResult(shouldRemoveEventId: true, successfullyProcessed: true)
+            return ProcessedEventResult(shouldRemoveEventId: true)
         }
         
         return nil

--- a/godtools/App/Services/Renderer/Views/Tool/Views/Form/ToolPageFormView.swift
+++ b/godtools/App/Services/Renderer/Views/Tool/Views/Form/ToolPageFormView.swift
@@ -59,12 +59,20 @@ class ToolPageFormView: MobileContentFormView {
     
     // MARK: - MobileContenView
     
-    override func didReceiveEvents(eventIds: [EventId]) {
-                      
-        if eventIds.contains(EventId.Companion().FOLLOWUP) {
-            pageFormViewModel.sendFollowUp(inputModels: super.getInputModels(), eventIds: eventIds)
+    override func didReceiveEvent(eventId: EventId, eventIdsGroup: [EventId]) -> MobileContentView.DidSuccessfullyProcessEvent {
+        
+        let isFollowUpEvent: Bool = eventId == EventId.Companion().FOLLOWUP
+        
+        let didSuccessfullyProcessEvent: Bool
+        
+        if isFollowUpEvent {
+            pageFormViewModel.sendFollowUp(inputModels: super.getInputModels(), eventIds: eventIdsGroup)
+            didSuccessfullyProcessEvent = true
         }
+        else {
+            didSuccessfullyProcessEvent = false
+        }
+        
+        return didSuccessfullyProcessEvent
     }
-    
-    // MARK: -
 }

--- a/godtools/App/Services/Renderer/Views/Tool/Views/Form/ToolPageFormView.swift
+++ b/godtools/App/Services/Renderer/Views/Tool/Views/Form/ToolPageFormView.swift
@@ -59,7 +59,7 @@ class ToolPageFormView: MobileContentFormView {
     
     // MARK: - MobileContenView
     
-    override func didReceiveEvent(eventId: EventId, eventIdsGroup: [EventId]) -> ProcessedEventResult? {
+    override func didReceiveAncestryEventFromWalkingUpViewHierarchy(eventId: EventId, eventIdsGroup: [EventId]) -> ProcessedEventResult? {
         
         let isFollowUpEvent: Bool = eventId == EventId.Companion().FOLLOWUP
                 

--- a/godtools/App/Services/Renderer/Views/Tool/Views/Form/ToolPageFormView.swift
+++ b/godtools/App/Services/Renderer/Views/Tool/Views/Form/ToolPageFormView.swift
@@ -59,20 +59,15 @@ class ToolPageFormView: MobileContentFormView {
     
     // MARK: - MobileContenView
     
-    override func didReceiveEvent(eventId: EventId, eventIdsGroup: [EventId]) -> MobileContentView.DidSuccessfullyProcessEvent {
+    override func didReceiveEvent(eventId: EventId, eventIdsGroup: [EventId]) -> ProcessedEventResult? {
         
         let isFollowUpEvent: Bool = eventId == EventId.Companion().FOLLOWUP
-        
-        let didSuccessfullyProcessEvent: Bool
-        
+                
         if isFollowUpEvent {
             pageFormViewModel.sendFollowUp(inputModels: super.getInputModels(), eventIds: eventIdsGroup)
-            didSuccessfullyProcessEvent = true
-        }
-        else {
-            didSuccessfullyProcessEvent = false
+            return ProcessedEventResult(shouldRemoveEventId: true, successfullyProcessed: true)
         }
         
-        return didSuccessfullyProcessEvent
+        return nil
     }
 }

--- a/godtools/App/Services/Renderer/Views/Tool/Views/Modal/ToolPageModalView.swift
+++ b/godtools/App/Services/Renderer/Views/Tool/Views/Modal/ToolPageModalView.swift
@@ -87,27 +87,17 @@ class ToolPageModalView: MobileContentView, NibBased {
         centerContentStackVerticallyIfNeeded()
     }
     
-    override func didReceiveEvent(eventId: EventId, eventIdsGroup: [EventId]) -> MobileContentView.DidSuccessfullyProcessEvent {
+    override func didReceiveEvent(eventId: EventId, eventIdsGroup: [EventId]) -> ProcessedEventResult? {
         
         let isFollowUpEvent: Bool = eventId == EventId.Companion().FOLLOWUP
-        
-        let didSuccessfullyProcessEvent: Bool
-        
+                
         if viewModel.listeners.contains(eventId) && !isFollowUpEvent {
-            
             delegate?.toolPageModalListenerActivated(modalView: self)
-            didSuccessfullyProcessEvent = true
         }
         else if viewModel.dismissListeners.contains(eventId) {
-            
             delegate?.toolPageModalDismissListenerActivated(modalView: self)
-            didSuccessfullyProcessEvent = true
-        }
-        else {
-            
-            didSuccessfullyProcessEvent = false
         }
         
-        return didSuccessfullyProcessEvent
+        return nil
     }
 }

--- a/godtools/App/Services/Renderer/Views/Tool/Views/Modal/ToolPageModalView.swift
+++ b/godtools/App/Services/Renderer/Views/Tool/Views/Modal/ToolPageModalView.swift
@@ -87,18 +87,27 @@ class ToolPageModalView: MobileContentView, NibBased {
         centerContentStackVerticallyIfNeeded()
     }
     
-    override func didReceiveEvents(eventIds: [EventId]) {
-            
-        let eventsContainFollowUp: Bool = eventIds.contains(EventId.Companion().FOLLOWUP)
+    override func didReceiveEvent(eventId: EventId, eventIdsGroup: [EventId]) -> MobileContentView.DidSuccessfullyProcessEvent {
         
-        for eventId in eventIds {
+        let isFollowUpEvent: Bool = eventId == EventId.Companion().FOLLOWUP
+        
+        let didSuccessfullyProcessEvent: Bool
+        
+        if viewModel.listeners.contains(eventId) && !isFollowUpEvent {
             
-            if viewModel.listeners.contains(eventId) && !eventsContainFollowUp {
-                delegate?.toolPageModalListenerActivated(modalView: self)
-            }
-            else if viewModel.dismissListeners.contains(eventId) {
-                delegate?.toolPageModalDismissListenerActivated(modalView: self)
-            }
+            delegate?.toolPageModalListenerActivated(modalView: self)
+            didSuccessfullyProcessEvent = true
         }
+        else if viewModel.dismissListeners.contains(eventId) {
+            
+            delegate?.toolPageModalDismissListenerActivated(modalView: self)
+            didSuccessfullyProcessEvent = true
+        }
+        else {
+            
+            didSuccessfullyProcessEvent = false
+        }
+        
+        return didSuccessfullyProcessEvent
     }
 }

--- a/godtools/App/Services/Renderer/Views/Tool/Views/Modal/ToolPageModalView.swift
+++ b/godtools/App/Services/Renderer/Views/Tool/Views/Modal/ToolPageModalView.swift
@@ -94,7 +94,7 @@ class ToolPageModalView: MobileContentView, NibBased {
         if viewModel.listeners.contains(eventId) && !isFollowUpEvent {
             delegate?.toolPageModalListenerActivated(modalView: self)
         }
-        else if viewModel.dismissListeners.contains(eventId) {
+        else if viewModel.dismissListeners.contains(eventId) && !isFollowUpEvent {
             delegate?.toolPageModalDismissListenerActivated(modalView: self)
         }
         


### PR DESCRIPTION
This PR fixes an issue where the ```followup:send``` event was getting sent to all forms in a page when it should only be sent to the form in the view hierarchy that the event was generated from.  
This was fixed by changing how events are sent to views in a page.  Originally, whenever an event is triggered, it will start at the rootView (page) of the view hierarchy and recurse all children passing the eventIds to each child for processing.  This means that the ```followup:send``` event would get passed to each form in the page hierarchy which is what we don't want.  

To fix this, a couple things were done:

1. Changed the didReceiveEvents method to process a single eventId at a time and added a ```ProcessedEventResult?``` return type.  This return type contains a flag ```shouldRemoveEventId``` which gives more granular control on which eventIds should be removed if successfully processed.

2. Changed how events are passed to views when an event is triggered.  Now when an event is triggered from a view, we walk up the view hierarchy starting from that view and process the event on the children of each parent as we walk up.  This gives direct ascendants a chance to process events before reaching the root view and sending events to all children in the view hierarchy.
