### PR TITLE
GT-1300 support animations in about banner

### DIFF
--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		45051205275AA7050081BF56 /* MobileContentParagraphView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45051204275AA7050081BF56 /* MobileContentParagraphView.swift */; };
 		45051207275AA71F0081BF56 /* MobileContentParagraphViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45051206275AA71F0081BF56 /* MobileContentParagraphViewModel.swift */; };
 		45051209275AA7260081BF56 /* MobileContentParagraphViewModelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45051208275AA7260081BF56 /* MobileContentParagraphViewModelType.swift */; };
+		4505C5DF2829B0BA0047951D /* ToolDetailBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4505C5DE2829B0BA0047951D /* ToolDetailBanner.swift */; };
 		450E441427565D1C00D4311E /* TutorialFlowDiContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450E440827565D1C00D4311E /* TutorialFlowDiContainer.swift */; };
 		450E441527565D1C00D4311E /* TutorialFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450E440927565D1C00D4311E /* TutorialFlow.swift */; };
 		450E441627565D1C00D4311E /* GetTutorialUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450E440C27565D1C00D4311E /* GetTutorialUseCase.swift */; };
@@ -1040,6 +1041,7 @@
 		45051204275AA7050081BF56 /* MobileContentParagraphView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileContentParagraphView.swift; sourceTree = "<group>"; };
 		45051206275AA71F0081BF56 /* MobileContentParagraphViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileContentParagraphViewModel.swift; sourceTree = "<group>"; };
 		45051208275AA7260081BF56 /* MobileContentParagraphViewModelType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileContentParagraphViewModelType.swift; sourceTree = "<group>"; };
+		4505C5DE2829B0BA0047951D /* ToolDetailBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolDetailBanner.swift; sourceTree = "<group>"; };
 		450E440827565D1C00D4311E /* TutorialFlowDiContainer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TutorialFlowDiContainer.swift; sourceTree = "<group>"; };
 		450E440927565D1C00D4311E /* TutorialFlow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TutorialFlow.swift; sourceTree = "<group>"; };
 		450E440C27565D1C00D4311E /* GetTutorialUseCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GetTutorialUseCase.swift; sourceTree = "<group>"; };
@@ -3937,6 +3939,7 @@
 		45AD184025938A4E00A096A0 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				4505C5DE2829B0BA0047951D /* ToolDetailBanner.swift */,
 				45AD184125938A4E00A096A0 /* ToolDetailControl.swift */,
 				45AD184225938A4E00A096A0 /* ToolDetailControlId.swift */,
 			);
@@ -6972,6 +6975,7 @@
 				45C93ADB261D310900592FFF /* ArticleAemCacheErrorData.swift in Sources */,
 				4579A1D427922F6A00F18B3E /* DetermineToolTranslationsToDownloadType.swift in Sources */,
 				45AD20BB25938F1A00A096A0 /* ObservableValue.swift in Sources */,
+				4505C5DF2829B0BA0047951D /* ToolDetailBanner.swift in Sources */,
 				45AD202625938A9800A096A0 /* FirebaseConfiguration.swift in Sources */,
 				45AD1B1125938A4E00A096A0 /* ArticleCategoryCell.swift in Sources */,
 				45AD20B125938EE500A096A0 /* FileCacheLocationType.swift in Sources */,

--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -19,7 +19,7 @@
 		45051205275AA7050081BF56 /* MobileContentParagraphView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45051204275AA7050081BF56 /* MobileContentParagraphView.swift */; };
 		45051207275AA71F0081BF56 /* MobileContentParagraphViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45051206275AA71F0081BF56 /* MobileContentParagraphViewModel.swift */; };
 		45051209275AA7260081BF56 /* MobileContentParagraphViewModelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45051208275AA7260081BF56 /* MobileContentParagraphViewModelType.swift */; };
-		4505C5DF2829B0BA0047951D /* ToolDetailBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4505C5DE2829B0BA0047951D /* ToolDetailBanner.swift */; };
+		4505C5DF2829B0BA0047951D /* ToolDetailBannerType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4505C5DE2829B0BA0047951D /* ToolDetailBannerType.swift */; };
 		450E441427565D1C00D4311E /* TutorialFlowDiContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450E440827565D1C00D4311E /* TutorialFlowDiContainer.swift */; };
 		450E441527565D1C00D4311E /* TutorialFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450E440927565D1C00D4311E /* TutorialFlow.swift */; };
 		450E441627565D1C00D4311E /* GetTutorialUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450E440C27565D1C00D4311E /* GetTutorialUseCase.swift */; };
@@ -1041,7 +1041,7 @@
 		45051204275AA7050081BF56 /* MobileContentParagraphView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileContentParagraphView.swift; sourceTree = "<group>"; };
 		45051206275AA71F0081BF56 /* MobileContentParagraphViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileContentParagraphViewModel.swift; sourceTree = "<group>"; };
 		45051208275AA7260081BF56 /* MobileContentParagraphViewModelType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileContentParagraphViewModelType.swift; sourceTree = "<group>"; };
-		4505C5DE2829B0BA0047951D /* ToolDetailBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolDetailBanner.swift; sourceTree = "<group>"; };
+		4505C5DE2829B0BA0047951D /* ToolDetailBannerType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolDetailBannerType.swift; sourceTree = "<group>"; };
 		450E440827565D1C00D4311E /* TutorialFlowDiContainer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TutorialFlowDiContainer.swift; sourceTree = "<group>"; };
 		450E440927565D1C00D4311E /* TutorialFlow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TutorialFlow.swift; sourceTree = "<group>"; };
 		450E440C27565D1C00D4311E /* GetTutorialUseCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GetTutorialUseCase.swift; sourceTree = "<group>"; };
@@ -3939,7 +3939,7 @@
 		45AD184025938A4E00A096A0 /* Models */ = {
 			isa = PBXGroup;
 			children = (
-				4505C5DE2829B0BA0047951D /* ToolDetailBanner.swift */,
+				4505C5DE2829B0BA0047951D /* ToolDetailBannerType.swift */,
 				45AD184125938A4E00A096A0 /* ToolDetailControl.swift */,
 				45AD184225938A4E00A096A0 /* ToolDetailControlId.swift */,
 			);
@@ -6975,7 +6975,7 @@
 				45C93ADB261D310900592FFF /* ArticleAemCacheErrorData.swift in Sources */,
 				4579A1D427922F6A00F18B3E /* DetermineToolTranslationsToDownloadType.swift in Sources */,
 				45AD20BB25938F1A00A096A0 /* ObservableValue.swift in Sources */,
-				4505C5DF2829B0BA0047951D /* ToolDetailBanner.swift in Sources */,
+				4505C5DF2829B0BA0047951D /* ToolDetailBannerType.swift in Sources */,
 				45AD202625938A9800A096A0 /* FirebaseConfiguration.swift in Sources */,
 				45AD1B1125938A4E00A096A0 /* ArticleCategoryCell.swift in Sources */,
 				45AD20B125938EE500A096A0 /* FileCacheLocationType.swift in Sources */,

--- a/godtools/App/Features/ToolDetails/Models/ToolDetailBanner.swift
+++ b/godtools/App/Features/ToolDetails/Models/ToolDetailBanner.swift
@@ -1,0 +1,26 @@
+//
+//  ToolDetailBanner.swift
+//  godtools
+//
+//  Created by Levi Eggert on 5/9/22.
+//  Copyright © 2022 Cru. All rights reserved.
+//
+
+import UIKit
+
+enum ToolDetailBanner {
+    
+    case animation(viewModel: AnimatedViewModelType)
+    case image(image: UIImage)
+    case youtube(videoId: String, playerParameters: [String: Any]?)
+    case empty
+    
+    func getYoutubeVideoId() -> String? {
+        switch self {
+        case .youtube(let videoId, _):
+            return videoId
+        default:
+            return nil
+        }
+    }
+}

--- a/godtools/App/Features/ToolDetails/Models/ToolDetailBannerType.swift
+++ b/godtools/App/Features/ToolDetails/Models/ToolDetailBannerType.swift
@@ -1,5 +1,5 @@
 //
-//  ToolDetailBanner.swift
+//  ToolDetailBannerType.swift
 //  godtools
 //
 //  Created by Levi Eggert on 5/9/22.
@@ -8,7 +8,7 @@
 
 import UIKit
 
-enum ToolDetailBanner {
+enum ToolDetailBannerType {
     
     case animation(viewModel: AnimatedViewModelType)
     case image(image: UIImage)

--- a/godtools/App/Features/ToolDetails/ToolDetailView.swift
+++ b/godtools/App/Features/ToolDetails/ToolDetailView.swift
@@ -144,7 +144,7 @@ class ToolDetailView: UIViewController {
             self?.title = navTitle
         }
         
-        viewModel.banner.addObserver(self) { [weak self] (value: ToolDetailBanner) in
+        viewModel.banner.addObserver(self) { [weak self] (value: ToolDetailBannerType) in
             
             self?.animationView.stop()
             self?.animationView.isHidden = true

--- a/godtools/App/Features/ToolDetails/ToolDetailView.swift
+++ b/godtools/App/Features/ToolDetails/ToolDetailView.swift
@@ -19,6 +19,7 @@ class ToolDetailView: UIViewController {
     
     //topMediaView
     @IBOutlet weak private var topMediaView: UIView!
+    @IBOutlet weak private var animationView: AnimatedView!
     @IBOutlet weak private var youTubePlayerContentView: UIView!
     @IBOutlet weak private var youTubePlayerView: YTPlayerView!
     @IBOutlet weak private var youTubeLoadingView: UIView!
@@ -143,24 +144,27 @@ class ToolDetailView: UIViewController {
             self?.title = navTitle
         }
         
-        viewModel.bannerImage.addObserver(self) { [weak self] (image: UIImage?) in
-            self?.setTopBannerImage(image: image)
-        }
-        
-        viewModel.hidesBannerImage.addObserver(self) { [weak self] (isHidden: Bool) in
-            self?.bannerImageView.isHidden = isHidden
-        }
-        
-        viewModel.youTubePlayerId.addObserver(self) { [weak self] (youTubePlayerId: String?) in
-            if let youTubePlayerId = youTubePlayerId {
-                self?.loadYoutubePlayerVideo(videoId: youTubePlayerId)
-            }
-        }
-        
-        viewModel.hidesYoutubePlayer.addObserver(self) { [weak self] (isHidden: Bool) in
-            self?.youTubePlayerContentView.isHidden = isHidden
-            if isHidden {
-                self?.youTubePlayerView.stopVideo()
+        viewModel.banner.addObserver(self) { [weak self] (value: ToolDetailBanner) in
+            
+            self?.animationView.stop()
+            self?.animationView.isHidden = true
+            self?.bannerImageView.image = nil
+            self?.bannerImageView.isHidden = true
+            self?.youTubePlayerView.stopVideo()
+            self?.youTubePlayerContentView.isHidden = true
+            
+            switch value {
+            case .animation(let viewModel):
+                self?.animationView.isHidden = false
+                self?.animationView.configure(viewModel: viewModel)
+            case .image(let image):
+                self?.bannerImageView.isHidden = false
+                self?.setTopBannerImage(image: image)
+            case .youtube(let videoId, let playerParameters):
+                self?.youTubePlayerContentView.isHidden = false
+                self?.loadYoutubePlayerVideo(videoId: videoId, playerParameters: playerParameters)
+            case .empty:
+                break
             }
         }
         
@@ -303,16 +307,19 @@ class ToolDetailView: UIViewController {
         }
     }
      
-    private func loadYoutubePlayerVideo(videoId: String) {
+    private func loadYoutubePlayerVideo(videoId: String, playerParameters: [String: Any]?) {
         youTubeActivityIndicator.startAnimating()
         youTubePlayerView.delegate = self
-        youTubePlayerView.load(withVideoId: videoId, playerVars: viewModel.youtubePlayerParameters)
+        youTubePlayerView.load(withVideoId: videoId, playerVars: playerParameters)
     }
     
     private func recueVideo() {
-        guard let youtubeVideoId = viewModel.youTubePlayerId.value else { return }
         
-        youTubePlayerView.cueVideo(byId: youtubeVideoId, startSeconds: 0.0)
+        guard let videoId = viewModel.banner.value.getYoutubeVideoId() else {
+            return
+        }
+        
+        youTubePlayerView.cueVideo(byId: videoId, startSeconds: 0.0)
     }
 
     private func reloadDetailsTextViews() {
@@ -427,9 +434,15 @@ extension ToolDetailView: YTPlayerViewDelegate {
             print("default")
         }
         
-        if state == .ended, let youTubePlayerId = viewModel.youTubePlayerId.value {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
-                self?.loadYoutubePlayerVideo(videoId: youTubePlayerId)
+        if state == .ended {
+            
+            switch viewModel.banner.value {
+            case .youtube(let videoId, let playerParameters):
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+                    self?.loadYoutubePlayerVideo(videoId: videoId, playerParameters: playerParameters)
+                }
+            default:
+                break
             }
         }
     }

--- a/godtools/App/Features/ToolDetails/ToolDetailView.xib
+++ b/godtools/App/Features/ToolDetails/ToolDetailView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -21,6 +21,7 @@
             <connections>
                 <outlet property="aboutDetailsTextView" destination="dRz-gk-4aW" id="B6x-ed-RJI"/>
                 <outlet property="aboutDetailsTextViewLeading" destination="JJz-wz-bKN" id="seH-yh-6tH"/>
+                <outlet property="animationView" destination="yFx-a4-t5O" id="gZ0-iz-sPs"/>
                 <outlet property="bannerImageView" destination="6sd-7g-yCc" id="8eK-eS-AVc"/>
                 <outlet property="bottomView" destination="cn2-k1-rfu" id="ik1-Cc-zH0"/>
                 <outlet property="clipTopDetailsShadow" destination="d8D-pv-wIq" id="orn-ja-foK"/>
@@ -58,6 +59,10 @@
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9Ef-Qo-9Rm" userLabel="topMediaView">
                     <rect key="frame" x="0.0" y="44" width="414" height="242"/>
                     <subviews>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yFx-a4-t5O" userLabel="animationView" customClass="AnimatedView" customModule="godtools" customModuleProvider="target">
+                            <rect key="frame" x="0.0" y="0.0" width="414" height="242"/>
+                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        </view>
                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" placeholderIntrinsicWidth="375" placeholderIntrinsicHeight="178" image="cell_banner_placeholder" highlightedImage="cell_banner_placeholder" translatesAutoresizingMaskIntoConstraints="NO" id="6sd-7g-yCc" userLabel="bannerImageView">
                             <rect key="frame" x="0.0" y="0.0" width="414" height="242"/>
                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -102,9 +107,13 @@
                         <constraint firstAttribute="bottom" secondItem="V1X-l5-dPn" secondAttribute="bottom" id="7az-F0-xbv"/>
                         <constraint firstItem="6sd-7g-yCc" firstAttribute="top" secondItem="9Ef-Qo-9Rm" secondAttribute="top" id="8wc-xD-Pib"/>
                         <constraint firstAttribute="trailing" secondItem="6sd-7g-yCc" secondAttribute="trailing" id="9VN-SE-J1Q"/>
+                        <constraint firstItem="yFx-a4-t5O" firstAttribute="top" secondItem="9Ef-Qo-9Rm" secondAttribute="top" id="D5x-Cc-5KU"/>
+                        <constraint firstAttribute="trailing" secondItem="yFx-a4-t5O" secondAttribute="trailing" id="JjV-Wd-l9b"/>
                         <constraint firstItem="V1X-l5-dPn" firstAttribute="top" secondItem="9Ef-Qo-9Rm" secondAttribute="top" id="K9x-bK-bB5"/>
                         <constraint firstItem="6sd-7g-yCc" firstAttribute="leading" secondItem="9Ef-Qo-9Rm" secondAttribute="leading" id="M6q-do-PeS"/>
+                        <constraint firstAttribute="bottom" secondItem="yFx-a4-t5O" secondAttribute="bottom" id="NRJ-3T-XN1"/>
                         <constraint firstAttribute="trailing" secondItem="V1X-l5-dPn" secondAttribute="trailing" id="O8I-ix-9Uy"/>
+                        <constraint firstItem="yFx-a4-t5O" firstAttribute="leading" secondItem="9Ef-Qo-9Rm" secondAttribute="leading" id="RCq-Fk-JRd"/>
                         <constraint firstAttribute="bottom" secondItem="6sd-7g-yCc" secondAttribute="bottom" id="Zid-M0-wQ5"/>
                         <constraint firstItem="V1X-l5-dPn" firstAttribute="leading" secondItem="9Ef-Qo-9Rm" secondAttribute="leading" id="vpk-cb-EUC"/>
                     </constraints>

--- a/godtools/App/Features/ToolDetails/ToolDetailViewModel.swift
+++ b/godtools/App/Features/ToolDetails/ToolDetailViewModel.swift
@@ -24,7 +24,7 @@ class ToolDetailViewModel: NSObject, ToolDetailViewModelType {
     private weak var flowDelegate: FlowDelegate?
     
     let navTitle: ObservableValue<String> = ObservableValue(value: "")
-    let banner: ObservableValue<ToolDetailBanner>
+    let banner: ObservableValue<ToolDetailBannerType>
     let translationDownloadProgress: ObservableValue<Double> = ObservableValue(value: 0)
     let name: ObservableValue<String> = ObservableValue(value: "")
     let totalViews: ObservableValue<String> = ObservableValue(value: "")
@@ -52,7 +52,7 @@ class ToolDetailViewModel: NSObject, ToolDetailViewModelType {
         self.mobileContentParser = mobileContentParser
         self.analytics = analytics
         
-        let bannerValue: ToolDetailBanner
+        let bannerValue: ToolDetailBannerType
         
         if !resource.attrAboutOverviewVideoYoutube.isEmpty {
             

--- a/godtools/App/Features/ToolDetails/ToolDetailViewModel.swift
+++ b/godtools/App/Features/ToolDetails/ToolDetailViewModel.swift
@@ -24,10 +24,7 @@ class ToolDetailViewModel: NSObject, ToolDetailViewModelType {
     private weak var flowDelegate: FlowDelegate?
     
     let navTitle: ObservableValue<String> = ObservableValue(value: "")
-    let bannerImage: ObservableValue<UIImage?> = ObservableValue(value: nil)
-    let hidesBannerImage: ObservableValue<Bool> = ObservableValue(value: false)
-    let youTubePlayerId: ObservableValue<String?> = ObservableValue(value: nil)
-    let hidesYoutubePlayer: ObservableValue<Bool> = ObservableValue(value: false)
+    let banner: ObservableValue<ToolDetailBanner>
     let translationDownloadProgress: ObservableValue<Double> = ObservableValue(value: 0)
     let name: ObservableValue<String> = ObservableValue(value: "")
     let totalViews: ObservableValue<String> = ObservableValue(value: "")
@@ -54,21 +51,33 @@ class ToolDetailViewModel: NSObject, ToolDetailViewModelType {
         self.translationDownloader = translationDownloader
         self.mobileContentParser = mobileContentParser
         self.analytics = analytics
-                
-        super.init()
+        
+        let bannerValue: ToolDetailBanner
         
         if !resource.attrAboutOverviewVideoYoutube.isEmpty {
-            hidesBannerImage.accept(value: true)
-            hidesYoutubePlayer.accept(value: false)
-            youTubePlayerId.accept(value: resource.attrAboutOverviewVideoYoutube)
+            
+            let playsInFullScreen: Int = 0
+            let playerParameters: [String: Any] = ["playsinline": playsInFullScreen]
+            
+            bannerValue = .youtube(videoId: resource.attrAboutOverviewVideoYoutube, playerParameters: playerParameters)
+        }
+        else if !resource.attrAboutBannerAnimation.isEmpty, let filePath = dataDownloader.attachmentsFileCache.getAttachmentFileUrl(attachmentId: resource.attrAboutBannerAnimation)?.path {
+            
+            let resource: AnimatedResource = .filepathJsonFile(filepath: filePath)
+            let viewModel = AnimatedViewModel(animationDataResource: resource, autoPlay: true, loop: true)
+            
+            bannerValue = .animation(viewModel: viewModel)
+        }
+        else if let image = dataDownloader.attachmentsFileCache.getAttachmentBanner(attachmentId: resource.attrBannerAbout) {
+            bannerValue = .image(image: image)
         }
         else {
-            hidesBannerImage.accept(value: false)
-            hidesYoutubePlayer.accept(value: true)
+            bannerValue = .empty
         }
         
-        let toolDetailImage: UIImage? = dataDownloader.attachmentsFileCache.getAttachmentBanner(attachmentId: resource.attrBannerAbout)
-        bannerImage.accept(value: toolDetailImage)
+        self.banner = ObservableValue(value: bannerValue)
+                
+        super.init()
         
         downloadResourceTranslation()
         
@@ -82,15 +91,7 @@ class ToolDetailViewModel: NSObject, ToolDetailViewModelType {
         favoritedResourcesCache.resourceFavorited.removeObserver(self)
         favoritedResourcesCache.resourceUnfavorited.removeObserver(self)
     }
-    
-    var youtubePlayerParameters: [String : Any]? {
-        let playsInFullScreen = 0
-        
-        return [
-            "playsinline": playsInFullScreen
-        ]
-    }
-    
+
     private func setupBinding() {
         
         favoritedResourcesCache.resourceFavorited.addObserver(self) { [weak self] (resourceId: String) in

--- a/godtools/App/Features/ToolDetails/ToolDetailViewModelType.swift
+++ b/godtools/App/Features/ToolDetails/ToolDetailViewModelType.swift
@@ -11,7 +11,7 @@ import UIKit
 protocol ToolDetailViewModelType {
     
     var navTitle: ObservableValue<String> { get }
-    var banner: ObservableValue<ToolDetailBanner> { get }
+    var banner: ObservableValue<ToolDetailBannerType> { get }
     var translationDownloadProgress: ObservableValue<Double> { get }
     var name: ObservableValue<String> { get }
     var totalViews: ObservableValue<String> { get }

--- a/godtools/App/Features/ToolDetails/ToolDetailViewModelType.swift
+++ b/godtools/App/Features/ToolDetails/ToolDetailViewModelType.swift
@@ -11,10 +11,7 @@ import UIKit
 protocol ToolDetailViewModelType {
     
     var navTitle: ObservableValue<String> { get }
-    var bannerImage: ObservableValue<UIImage?> { get }
-    var hidesBannerImage: ObservableValue<Bool> { get }
-    var youTubePlayerId: ObservableValue<String?> { get }
-    var hidesYoutubePlayer: ObservableValue<Bool> { get }
+    var banner: ObservableValue<ToolDetailBanner> { get }
     var translationDownloadProgress: ObservableValue<Double> { get }
     var name: ObservableValue<String> { get }
     var totalViews: ObservableValue<String> { get }
@@ -29,7 +26,6 @@ protocol ToolDetailViewModelType {
     var selectedDetailControl: ObservableValue<ToolDetailControl?> { get }
     var aboutDetails: ObservableValue<String> { get }
     var languageDetails: ObservableValue<String> { get }
-    var youtubePlayerParameters: [String: Any]? { get }
     
     func pageViewed()
     func openToolTapped()

--- a/godtools/App/Services/Attachments/AttachmentsFileCache.swift
+++ b/godtools/App/Services/Attachments/AttachmentsFileCache.swift
@@ -44,6 +44,20 @@ class AttachmentsFileCache {
         return nil
     }
     
+    func getAttachmentFileUrl(attachmentId: String) -> URL? {
+                        
+        guard let attachment = realmDatabase.mainThreadRealm.object(ofType: RealmAttachment.self, forPrimaryKey: attachmentId) else {
+            return nil
+        }
+        
+        switch sha256FileCache.getFile(location: attachment.sha256FileLocation) {
+        case .success(let url):
+            return url
+        case .failure( _):
+            return nil
+        }
+    }
+    
     func attachmentExists(location: SHA256FileLocation) -> Bool {
         
         switch sha256FileCache.fileExists(location: location) {

--- a/godtools/App/Services/RealmDatabase/RealmDatabase.swift
+++ b/godtools/App/Services/RealmDatabase/RealmDatabase.swift
@@ -12,7 +12,7 @@ import RealmSwift
 class RealmDatabase {
     
     private static let config: Realm.Configuration = RealmDatabase.createConfig
-    private static let schemaVersion: UInt64 = 5
+    private static let schemaVersion: UInt64 = 6
     
     private let backgroundQueue: DispatchQueue = DispatchQueue(label: "realm.background_queue", attributes: .concurrent)
     

--- a/godtools/App/Services/Resources/RealmResourcesCache/Models/RealmResource.swift
+++ b/godtools/App/Services/Resources/RealmResourcesCache/Models/RealmResource.swift
@@ -12,6 +12,7 @@ import RealmSwift
 class RealmResource: Object, ResourceModelType {
     
     @objc dynamic var abbreviation: String = ""
+    @objc dynamic var attrAboutBannerAnimation: String = ""
     @objc dynamic var attrAboutOverviewVideoYoutube: String = ""
     @objc dynamic var attrBanner: String = ""
     @objc dynamic var attrBannerAbout: String = ""
@@ -40,6 +41,7 @@ class RealmResource: Object, ResourceModelType {
     func mapFrom(model: ResourceModel) {
         
         abbreviation = model.abbreviation
+        attrAboutBannerAnimation = model.attrAboutBannerAnimation
         attrAboutOverviewVideoYoutube = model.attrAboutOverviewVideoYoutube
         attrBanner = model.attrBanner
         attrBannerAbout = model.attrBannerAbout

--- a/godtools/App/Services/Resources/ResourcesApi/Models/ResourceModel.swift
+++ b/godtools/App/Services/Resources/ResourcesApi/Models/ResourceModel.swift
@@ -11,6 +11,7 @@ import Foundation
 struct ResourceModel: ResourceModelType, Decodable {
     
     let abbreviation: String
+    let attrAboutBannerAnimation: String
     let attrAboutOverviewVideoYoutube: String
     let attrBanner: String
     let attrBannerAbout: String
@@ -39,6 +40,7 @@ struct ResourceModel: ResourceModelType, Decodable {
     
     enum AttributesKeys: String, CodingKey {
         case abbreviation = "abbreviation"
+        case attrAboutBannerAnimation = "attr-about-banner-animation"
         case attrAboutOverviewVideoYoutube = "attr-about-overview-video-youtube"
         case attrBanner = "attr-banner"
         case attrBannerAbout = "attr-banner-about"
@@ -65,6 +67,7 @@ struct ResourceModel: ResourceModelType, Decodable {
     init(realmResource: RealmResource) {
         
         abbreviation = realmResource.abbreviation
+        attrAboutBannerAnimation = realmResource.attrAboutBannerAnimation
         attrAboutOverviewVideoYoutube = realmResource.attrAboutOverviewVideoYoutube
         attrBanner = realmResource.attrBanner
         attrBannerAbout = realmResource.attrBannerAbout
@@ -109,6 +112,7 @@ struct ResourceModel: ResourceModelType, Decodable {
         
         // attributes
         abbreviation = try attributesContainer?.decodeIfPresent(String.self, forKey: .abbreviation) ?? ""
+        attrAboutBannerAnimation = try attributesContainer?.decodeIfPresent(String.self, forKey: .attrAboutBannerAnimation) ?? ""
         attrAboutOverviewVideoYoutube = try attributesContainer?.decodeIfPresent(String.self, forKey: .attrAboutOverviewVideoYoutube) ?? ""
         attrBanner = try attributesContainer?.decodeIfPresent(String.self, forKey: .attrBanner) ?? ""
         attrBannerAbout = try attributesContainer?.decodeIfPresent(String.self, forKey: .attrBannerAbout) ?? ""

--- a/godtools/App/Services/Resources/ResourcesApi/Models/ResourceModelType.swift
+++ b/godtools/App/Services/Resources/ResourcesApi/Models/ResourceModelType.swift
@@ -14,6 +14,7 @@ protocol ResourceModelType {
     associatedtype AttachmentIds = Sequence
     
     var abbreviation: String { get }
+    var attrAboutBannerAnimation: String { get }
     var attrAboutOverviewVideoYoutube: String { get }
     var attrBanner: String { get }
     var attrBannerAbout: String { get }

--- a/godtools/App/Services/SHA256FileCache/SHA256FileLocation.swift
+++ b/godtools/App/Services/SHA256FileCache/SHA256FileLocation.swift
@@ -10,7 +10,7 @@ import Foundation
 
 struct SHA256FileLocation {
     
-    private static let supportedExtensions: [String] = ["png", "jpg", "xml", "txt", "zip"]
+    private static let supportedExtensions: [String] = ["png", "jpg", "xml", "txt", "zip", "json"]
     
     let sha256: String
     let pathExtension: String


### PR DESCRIPTION
This PR adds support for animations in the ToolDetailView top banner.  Added an enum ToolDetailBanner that the view observes on the viewModel to control if the banner should display an image, youtube video, or animation.
Honor Restored and The Four both support animations in the tool details.