### PR TITLE
GT-1567 tool settings change line spacing and parallel language spacing

### DIFF
--- a/godtools/App/Features/ToolSettings/Presentation/ToolSettings/ToolSettingsView.swift
+++ b/godtools/App/Features/ToolSettings/Presentation/ToolSettings/ToolSettingsView.swift
@@ -12,7 +12,7 @@ struct ToolSettingsView: View {
     @ObservedObject var viewModel: ToolSettingsViewModel
     
     private let contentInsets: EdgeInsets = EdgeInsets(top: 20, leading: 20, bottom: 0, trailing: 20)
-    private let separatorLineSpacing: CGFloat = 25
+    private let separatorLineSpacing: CGFloat = 20
     private let primaryTextColor: Color = Color(.sRGB, red: 84 / 256, green: 84 / 256, blue: 84 / 256, opacity: 1)
     private let bottomSpace: CGFloat = 15
     

--- a/godtools/App/Features/ToolSettings/Presentation/ToolSettings/ToolSettingsViewModel.swift
+++ b/godtools/App/Features/ToolSettings/Presentation/ToolSettings/ToolSettingsViewModel.swift
@@ -32,6 +32,7 @@ class ToolSettingsViewModel: ObservableObject {
     @Published var trainingTipsIcon: SwiftUI.Image = Image("")
     @Published var trainingTipsTitle: String = ""
     @Published var chooseLanguageTitle: String = ""
+    @Published var chooseLanguageToggleMessage: String = ""
     @Published var primaryLanguageTitle: String = ""
     @Published var parallelLanguageTitle: String = ""
     @Published var hidesShareables: Bool = false
@@ -59,6 +60,7 @@ class ToolSettingsViewModel: ObservableObject {
             self?.trainingTipsIcon = trainingTipsEnabled ? Image(ImageCatalog.toolSettingsOptionHideTips.name) : Image(ImageCatalog.toolSettingsOptionTrainingTips.name)
         }
         chooseLanguageTitle = localizationServices.stringForMainBundle(key: "toolSettings.chooseLanguage.title")
+        chooseLanguageToggleMessage = localizationServices.stringForMainBundle(key: "toolSettings.chooseLanguage.toggleMessage")
         hidesShareables = shareables.isEmpty
         shareablesTitle = localizationServices.stringForMainBundle(key: "toolSettings.shareables.title")
         numberOfShareableItems = shareables.count

--- a/godtools/App/Features/ToolSettings/Presentation/ToolSettings/ToolSettingsViewPreview.swift
+++ b/godtools/App/Features/ToolSettings/Presentation/ToolSettings/ToolSettingsViewPreview.swift
@@ -13,6 +13,11 @@ struct ToolSettingsViewPreview: PreviewProvider {
     
     static var previews: some View {
         
+        ToolSettingsView(viewModel: ToolSettingsViewPreview.getToolSettingsViewModel())
+    }
+    
+    static func getToolSettingsViewModel() -> ToolSettingsViewModel {
+        
         let appDiContainer: AppDiContainer = SwiftUIPreviewDiContainer().getAppDiContainer()
         
         let languagesRepository: LanguagesRepository = appDiContainer.getLanguagesRepository()
@@ -28,6 +33,6 @@ struct ToolSettingsViewPreview: PreviewProvider {
             shareables: []
         )
         
-        ToolSettingsView(viewModel: viewModel)
+        return viewModel
     }
 }

--- a/godtools/App/Features/ToolSettings/Presentation/ToolSettings/Views/ToolSettingsChooseLanguage/ToolSettingsChooseLanguageView.swift
+++ b/godtools/App/Features/ToolSettings/Presentation/ToolSettings/Views/ToolSettingsChooseLanguage/ToolSettingsChooseLanguageView.swift
@@ -20,18 +20,16 @@ struct ToolSettingsChooseLanguageView: View {
         
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            HStack(alignment: .center, spacing: 0) {
-                VStack (alignment: .leading, spacing: 4) {
-                    Text(viewModel.chooseLanguageTitle)
-                        .foregroundColor(primaryTextColor)
-                        .font(FontLibrary.sfProTextRegular.font(size: 19))
-                    Text("Toggle between the two different languages in this tool.")
-                        .foregroundColor(primaryTextColor)
-                        .font(FontLibrary.sfProTextRegular.font(size: 14))
-                }
-                .frame(width: geometryProxy.size.width * 0.65)
-                .padding(EdgeInsets(top: 0, leading: leadingInset, bottom: 0, trailing: 0))
+            VStack (alignment: .leading, spacing: 4) {
+                Text(viewModel.chooseLanguageTitle)
+                    .foregroundColor(primaryTextColor)
+                    .font(FontLibrary.sfProTextRegular.font(size: 19))
+                Text("Toggle between the two different languages in this tool.")
+                    .frame(maxWidth: geometryProxy.size.width * 0.65, alignment: .leading)
+                    .foregroundColor(primaryTextColor)
+                    .font(FontLibrary.sfProTextRegular.font(size: 14))
             }
+            .padding(EdgeInsets(top: 0, leading: leadingInset, bottom: 0, trailing: 0))
             Rectangle()
                 .frame(width: geometryProxy.size.width, height: 20, alignment: .leading)
                 .foregroundColor(.clear)
@@ -63,6 +61,23 @@ struct ToolSettingsChooseLanguageView: View {
                 alignment: .leading
             )
             .padding(EdgeInsets(top: 0, leading: leadingInset, bottom: 0, trailing: trailingInset))
+        }
+    }
+}
+
+struct ToolSettingsChooseLanguageViewPreview: PreviewProvider {
+    
+    static var previews: some View {
+        
+        GeometryReader { geometry in
+            
+            ToolSettingsChooseLanguageView(
+                viewModel: ToolSettingsViewPreview.getToolSettingsViewModel(),
+                geometryProxy: geometry,
+                leadingInset: 30,
+                trailingInset: 30,
+                primaryTextColor: .black
+            )
         }
     }
 }

--- a/godtools/App/Features/ToolSettings/Presentation/ToolSettings/Views/ToolSettingsChooseLanguage/ToolSettingsChooseLanguageView.swift
+++ b/godtools/App/Features/ToolSettings/Presentation/ToolSettings/Views/ToolSettingsChooseLanguage/ToolSettingsChooseLanguageView.swift
@@ -24,7 +24,7 @@ struct ToolSettingsChooseLanguageView: View {
                 Text(viewModel.chooseLanguageTitle)
                     .foregroundColor(primaryTextColor)
                     .font(FontLibrary.sfProTextRegular.font(size: 19))
-                Text("Toggle between the two different languages in this tool.")
+                Text(viewModel.chooseLanguageToggleMessage)
                     .frame(maxWidth: geometryProxy.size.width * 0.65, alignment: .leading)
                     .foregroundColor(primaryTextColor)
                     .font(FontLibrary.sfProTextRegular.font(size: 14))

--- a/godtools/Base.lproj/Localizable.strings
+++ b/godtools/Base.lproj/Localizable.strings
@@ -321,6 +321,7 @@ Press the About button on any tool for more info.";
 "toolSettings.option.trainingTips.show.title" = "Training tips";
 "toolSettings.option.trainingTips.hide.title" = "Hide tips";
 "toolSettings.chooseLanguage.title" = "Parallel Language";
+"toolSettings.chooseLanguage.toggleMessage" = "Toggle between the two different languages in this tool.";
 "toolSettings.chooseLanguage.noParallelLanguageTitle" = "Parallel";
 "toolSettings.shareables.title" = "Related graphics";
 "toolSettings.languagesList.deleteLanguage.title" = "None";


### PR DESCRIPTION
This PR updates some UI in Tool Settings:
- Reduced vertical spacing between separator lines.
- Fixed choose primary and parallel language Text to be set correctly along the left insets.
- Added localization for the toggle language messaging.