### PR TITLE
GT-1636 fix content sections to render content stack instead of single text element

### DIFF
--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentAccordion/MobileContentAccordionView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentAccordion/MobileContentAccordionView.swift
@@ -10,7 +10,7 @@ import UIKit
 
 protocol MobileContentAccordionViewDelegate: AnyObject {
     
-    func accordionViewDidChangeSectionViewTextHiddenState(accordionView: MobileContentAccordionView, sectionView: MobileContentAccordionSectionView, textIsHidden: Bool, textHeight: CGFloat)
+    func accordionViewDidChangeSectionViewContentHiddenState(accordionView: MobileContentAccordionView, sectionView: MobileContentAccordionSectionView, contentIsHidden: Bool, contentHeight: CGFloat)
 }
 
 class MobileContentAccordionView: MobileContentView {
@@ -43,7 +43,7 @@ class MobileContentAccordionView: MobileContentView {
     
     var isRevealingSectionText: Bool {
         for sectionView in sectionViews {
-            if !sectionView.textIsHidden {
+            if !sectionView.contentIsHidden {
                 return true
             }
         }
@@ -200,21 +200,21 @@ extension MobileContentAccordionView {
 
 extension MobileContentAccordionView: MobileContentAccordionSectionViewDelegate {
     
-    func sectionViewDidChangeTextHiddenState(sectionView: MobileContentAccordionSectionView, textIsHidden: Bool, textHeight: CGFloat) {
+    func sectionViewDidChangeContentHiddenState(sectionView: MobileContentAccordionSectionView, contentIsHidden: Bool, contentHeight: CGFloat) {
         
-        if allowsOnlyOneExpandedSectionAtATime && !textIsHidden {
+        if allowsOnlyOneExpandedSectionAtATime && !contentIsHidden {
             for otherSectionView in sectionViews {
-                if otherSectionView != sectionView && !otherSectionView.textIsHidden {
-                    otherSectionView.setTextHidden(hidden: true, animated: true)
+                if otherSectionView != sectionView && !otherSectionView.contentIsHidden {
+                    otherSectionView.setContentHidden(hidden: true, animated: true)
                 }
             }
         }
         
-        delegate?.accordionViewDidChangeSectionViewTextHiddenState(
+        delegate?.accordionViewDidChangeSectionViewContentHiddenState(
             accordionView: self,
             sectionView: sectionView,
-            textIsHidden: textIsHidden,
-            textHeight: textHeight
+            contentIsHidden: contentIsHidden,
+            contentHeight: contentHeight
         )
     }
 }

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentAccordionSection/MobileContentAccordionSectionView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentAccordionSection/MobileContentAccordionSectionView.swift
@@ -27,8 +27,8 @@ class MobileContentAccordionSectionView: MobileContentView, NibBased {
     @IBOutlet weak private var contentView: UIView!
     @IBOutlet weak private var contentStackContainerView: UIView!
     @IBOutlet weak private var headerContainerView: UIView!
+    @IBOutlet weak private var headerButton: UIButton!
     @IBOutlet weak private var accordionStateImageView: UIImageView!
-    @IBOutlet weak private var revealTextButton: UIButton!
     
     @IBOutlet private var headerContainerBottomToView: NSLayoutConstraint!
     @IBOutlet private var contentStackContainerBottomToView: NSLayoutConstraint!
@@ -49,7 +49,7 @@ class MobileContentAccordionSectionView: MobileContentView, NibBased {
         loadNib()
         setupLayout()
         
-        revealTextButton.addTarget(self, action: #selector(revealTextButtonTapped), for: .touchUpInside)
+        headerButton.addTarget(self, action: #selector(headerTapped), for: .touchUpInside)
     }
     
     required init?(coder: NSCoder) {
@@ -72,12 +72,18 @@ class MobileContentAccordionSectionView: MobileContentView, NibBased {
         contentStackContainerView.addSubview(contentStack)
         contentStack.translatesAutoresizingMaskIntoConstraints = false
         contentStack.constrainEdgesToView(view: contentStackContainerView)
+        
+        // headerButton
+        headerButton.setTitle("", for: .normal)
           
         setContentHidden(hidden: true, animated: false)
     }
     
-    @objc func revealTextButtonTapped() {
-        
+    @objc private func headerTapped() {
+        toggleContentHidden()
+    }
+    
+    private func toggleContentHidden() {
         setContentHidden(hidden: !contentIsHidden, animated: true)
     }
     

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentAccordionSection/MobileContentAccordionSectionView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentAccordionSection/MobileContentAccordionSectionView.swift
@@ -72,6 +72,7 @@ class MobileContentAccordionSectionView: MobileContentView, NibBased {
         contentStackContainerView.addSubview(contentStack)
         contentStack.translatesAutoresizingMaskIntoConstraints = false
         contentStack.constrainEdgesToView(view: contentStackContainerView)
+        super.renderChild(childView: contentStack)
         
         // headerButton
         headerButton.setTitle("", for: .normal)

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentAccordionSection/MobileContentAccordionSectionView.xib
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentAccordionSection/MobileContentAccordionSectionView.xib
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="MobileContentAccordionSectionView" customModule="godtools" customModuleProvider="target">
             <connections>
+                <outlet property="accordionStateImageView" destination="DQm-CI-FHI" id="LXG-V4-yZN"/>
+                <outlet property="contentStackContainerBottomToView" destination="kS1-Gg-ibk" id="2Si-A7-yl1"/>
+                <outlet property="contentStackContainerView" destination="Bho-ue-3qC" id="qM2-2n-GTy"/>
                 <outlet property="contentView" destination="UiB-zw-0fl" id="bCC-gs-XzU"/>
                 <outlet property="headerContainerBottomToView" destination="Eyg-3t-XVl" id="L9a-jL-9p9"/>
                 <outlet property="headerContainerView" destination="fT8-zZ-Ha7" id="Xry-6a-jsV"/>
                 <outlet property="revealTextButton" destination="rxU-wm-wOn" id="FfB-zU-UL5"/>
-                <outlet property="textContainerBottomToView" destination="kS1-Gg-ibk" id="FhA-Zo-N56"/>
-                <outlet property="textContainerView" destination="Bho-ue-3qC" id="W6p-HW-sMq"/>
                 <outlet property="textStateImageTrailing" destination="0Jj-5G-sqx" id="hTZ-g2-Xm7"/>
-                <outlet property="textStateImageView" destination="DQm-CI-FHI" id="1fW-lJ-fZk"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
@@ -28,7 +28,7 @@
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="UiB-zw-0fl" userLabel="contentView">
                     <rect key="frame" x="0.0" y="0.0" width="414" height="74"/>
                     <subviews>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Bho-ue-3qC" userLabel="textContainerView">
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Bho-ue-3qC" userLabel="contentStackContainerView">
                             <rect key="frame" x="0.0" y="74" width="414" height="50"/>
                             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             <constraints>
@@ -38,7 +38,7 @@
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fT8-zZ-Ha7" userLabel="headerContainerView">
                             <rect key="frame" x="0.0" y="0.0" width="414" height="74"/>
                             <subviews>
-                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="accordion_section_plus" translatesAutoresizingMaskIntoConstraints="NO" id="DQm-CI-FHI" userLabel="textStateImageView">
+                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="accordion_section_plus" translatesAutoresizingMaskIntoConstraints="NO" id="DQm-CI-FHI" userLabel="accordionStateImageView">
                                     <rect key="frame" x="379" y="29.5" width="15" height="15"/>
                                     <constraints>
                                         <constraint firstAttribute="width" constant="15" id="GLI-kf-5Ss"/>

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentAccordionSection/MobileContentAccordionSectionView.xib
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentAccordionSection/MobileContentAccordionSectionView.xib
@@ -14,9 +14,9 @@
                 <outlet property="contentStackContainerBottomToView" destination="kS1-Gg-ibk" id="2Si-A7-yl1"/>
                 <outlet property="contentStackContainerView" destination="Bho-ue-3qC" id="qM2-2n-GTy"/>
                 <outlet property="contentView" destination="UiB-zw-0fl" id="bCC-gs-XzU"/>
+                <outlet property="headerButton" destination="ab5-08-I51" id="dRs-v8-mzi"/>
                 <outlet property="headerContainerBottomToView" destination="Eyg-3t-XVl" id="L9a-jL-9p9"/>
                 <outlet property="headerContainerView" destination="fT8-zZ-Ha7" id="Xry-6a-jsV"/>
-                <outlet property="revealTextButton" destination="rxU-wm-wOn" id="FfB-zU-UL5"/>
                 <outlet property="textStateImageTrailing" destination="0Jj-5G-sqx" id="hTZ-g2-Xm7"/>
             </connections>
         </placeholder>
@@ -53,23 +53,26 @@
                                 <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="74" id="pqc-Ix-aEG"/>
                             </constraints>
                         </view>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rxU-wm-wOn" userLabel="revealTextButton">
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ab5-08-I51" userLabel="headerButton">
                             <rect key="frame" x="0.0" y="0.0" width="414" height="74"/>
+                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <state key="normal" title="Button"/>
+                            <buttonConfiguration key="configuration" style="plain"/>
                         </button>
                     </subviews>
                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     <constraints>
-                        <constraint firstItem="rxU-wm-wOn" firstAttribute="leading" secondItem="UiB-zw-0fl" secondAttribute="leading" id="4Ia-V8-Q4r"/>
-                        <constraint firstItem="rxU-wm-wOn" firstAttribute="top" secondItem="UiB-zw-0fl" secondAttribute="top" id="562-6a-ndG"/>
+                        <constraint firstItem="ab5-08-I51" firstAttribute="top" secondItem="fT8-zZ-Ha7" secondAttribute="top" id="5qY-IB-IPG"/>
                         <constraint firstAttribute="trailing" secondItem="Bho-ue-3qC" secondAttribute="trailing" id="AZ6-oN-3HB"/>
                         <constraint firstAttribute="bottom" secondItem="fT8-zZ-Ha7" secondAttribute="bottom" id="Eyg-3t-XVl"/>
                         <constraint firstItem="Bho-ue-3qC" firstAttribute="top" secondItem="fT8-zZ-Ha7" secondAttribute="bottom" id="J5N-DH-H6p"/>
+                        <constraint firstItem="ab5-08-I51" firstAttribute="bottom" secondItem="fT8-zZ-Ha7" secondAttribute="bottom" id="Ois-fJ-7cD"/>
                         <constraint firstItem="Bho-ue-3qC" firstAttribute="leading" secondItem="UiB-zw-0fl" secondAttribute="leading" id="SQh-jd-iSV"/>
                         <constraint firstItem="fT8-zZ-Ha7" firstAttribute="top" secondItem="UiB-zw-0fl" secondAttribute="top" id="dzo-DH-gdI"/>
-                        <constraint firstAttribute="bottom" secondItem="rxU-wm-wOn" secondAttribute="bottom" id="jQm-Iu-nvt"/>
+                        <constraint firstItem="ab5-08-I51" firstAttribute="trailing" secondItem="fT8-zZ-Ha7" secondAttribute="trailing" id="fcd-jk-smj"/>
                         <constraint firstAttribute="trailing" secondItem="fT8-zZ-Ha7" secondAttribute="trailing" id="jqu-6z-ZnR"/>
-                        <constraint firstAttribute="trailing" secondItem="rxU-wm-wOn" secondAttribute="trailing" id="kDg-tw-tcD"/>
                         <constraint firstAttribute="bottom" secondItem="Bho-ue-3qC" secondAttribute="bottom" id="kS1-Gg-ibk"/>
+                        <constraint firstItem="ab5-08-I51" firstAttribute="leading" secondItem="fT8-zZ-Ha7" secondAttribute="leading" id="nOe-Ww-ltv"/>
                         <constraint firstItem="fT8-zZ-Ha7" firstAttribute="leading" secondItem="UiB-zw-0fl" secondAttribute="leading" id="sLU-RJ-vwr"/>
                     </constraints>
                     <variation key="default">

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentStack/MobileContentStackView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentStack/MobileContentStackView.swift
@@ -860,13 +860,13 @@ extension MobileContentStackView {
 
 extension MobileContentStackView: MobileContentAccordionViewDelegate {
     
-    func accordionViewDidChangeSectionViewTextHiddenState(accordionView: MobileContentAccordionView, sectionView: MobileContentAccordionSectionView, textIsHidden: Bool, textHeight: CGFloat) {
+    func accordionViewDidChangeSectionViewContentHiddenState(accordionView: MobileContentAccordionView, sectionView: MobileContentAccordionSectionView, contentIsHidden: Bool, contentHeight: CGFloat) {
         
         layoutIfNeeded()
         
         relayoutForSpacerViews()
         
-        guard let scrollView = self.scrollView, !textIsHidden else {
+        guard let scrollView = self.scrollView, !contentIsHidden else {
             return
         }
         


### PR DESCRIPTION
This PR makes a change to the accordion content section view.  Before, content sections would only render a single text element in the expanded view.  The single text element has been replaced with a content stack which makes this view more dynamic in that it can render a stack of content.
This change can be seen in Staging > The Four (USA) tool in the Did you pray this prayer? accordion content section view.

![accordion_1](https://user-images.githubusercontent.com/59846460/175075422-56eea02b-8cac-46fd-a8e5-ed02d12ca3ae.png)

![accordion_2](https://user-images.githubusercontent.com/59846460/175075445-eff89144-0ca4-4272-8d86-80d1b3fd5bd3.png)

