### PR TITLE
GT-1418 Update tool version card selection state

### DIFF
--- a/godtools/App/Features/ToolDetails/Domain/GetToolVersionsUseCase/GetToolVersionsUseCase.swift
+++ b/godtools/App/Features/ToolDetails/Domain/GetToolVersionsUseCase/GetToolVersionsUseCase.swift
@@ -27,39 +27,43 @@ class GetToolVersionsUseCase {
     
     func getToolVersions(resourceId: String) -> [ToolVersionDomainModel] {
         
-        let variants: [ResourceModel] = resourcesCache.getResourceVariants(resourceId: resourceId)
-        
-        guard !variants.isEmpty else {
+        guard let resource = resourcesCache.getResource(id: resourceId) else {
             return []
         }
         
-        return variants.map({
-            getToolVersion(resource: $0)
+        let resourceVersions: [ResourceModel] = resourcesCache.getResourceVariants(resourceId: resourceId)
+        
+        guard !resourceVersions.isEmpty else {
+            return []
+        }
+        
+        return resourceVersions.map({
+            getToolVersion(resource: resource, resourceVersion: $0)
         })
     }
     
-    private func getToolVersion(resource: ResourceModel) -> ToolVersionDomainModel {
+    private func getToolVersion(resource: ResourceModel, resourceVersion: ResourceModel) -> ToolVersionDomainModel {
         
-        let toolLanguages: [ToolLanguageModel] = getToolLanguagesUseCase.getToolLanguages(resource: resource)
+        let toolLanguages: [ToolLanguageModel] = getToolLanguagesUseCase.getToolLanguages(resource: resourceVersion)
         let toolLanguagesIds: [String] = toolLanguages.map({$0.id})
                 
         let name: String
         let languageBundle: Bundle
         
         // TODO: Another place that needs to be completed in GT-1625. ~Levi
-        if let primaryLanguage = languageSettingsService.primaryLanguage.value, let primaryTranslation = resourcesCache.getResourceLanguageTranslation(resourceId: resource.id, languageId: primaryLanguage.id) {
+        if let primaryLanguage = languageSettingsService.primaryLanguage.value, let primaryTranslation = resourcesCache.getResourceLanguageTranslation(resourceId: resourceVersion.id, languageId: primaryLanguage.id) {
             
             name = primaryTranslation.translatedName
             languageBundle = localizationServices.bundleLoader.bundleForResource(resourceName: primaryLanguage.code) ?? Bundle.main
         }
-        else if let englishTranslation = resourcesCache.getResourceLanguageTranslation(resourceId: resource.id, languageCode: "en") {
+        else if let englishTranslation = resourcesCache.getResourceLanguageTranslation(resourceId: resourceVersion.id, languageCode: "en") {
             
             name = englishTranslation.translatedName
             languageBundle = localizationServices.bundleLoader.englishBundle ?? Bundle.main
         }
         else {
             
-            name = resource.name
+            name = resourceVersion.name
             languageBundle = localizationServices.bundleLoader.englishBundle ?? Bundle.main
         }
         
@@ -92,15 +96,16 @@ class GetToolVersionsUseCase {
         }
                 
         return ToolVersionDomainModel(
-            id: resource.id,
-            bannerImageId: resource.attrBanner,
+            id: resourceVersion.id,
+            bannerImageId: resourceVersion.attrBanner,
             name: name,
-            description: resource.resourceDescription,
+            description: resourceVersion.resourceDescription,
             languages: String.localizedStringWithFormat(localizationServices.stringForBundle(bundle: languageBundle, key: "total_languages"), toolLanguages.count),
             primaryLanguage: primaryLanguage,
             primaryLanguageIsSupported: supportsPrimaryLanguage,
             parallelLanguage: parallelLanguage,
-            parallelLanguageIsSupported: supportsParallelLanguage
+            parallelLanguageIsSupported: supportsParallelLanguage,
+            isDefaultVersion: resourceVersion.abbreviation.lowercased() == resource.attrDefaultVariant.lowercased()
         )
     }
 }

--- a/godtools/App/Features/ToolDetails/Domain/GetToolVersionsUseCase/ToolVersionDomainModel.swift
+++ b/godtools/App/Features/ToolDetails/Domain/GetToolVersionsUseCase/ToolVersionDomainModel.swift
@@ -19,4 +19,5 @@ struct ToolVersionDomainModel: Identifiable {
     let primaryLanguageIsSupported: Bool
     let parallelLanguage: String?
     let parallelLanguageIsSupported: Bool
+    let isDefaultVersion: Bool
 }

--- a/godtools/App/Features/ToolDetails/Presentation/ToolDetails/ToolDetailsViewModel.swift
+++ b/godtools/App/Features/ToolDetails/Presentation/ToolDetails/ToolDetailsViewModel.swift
@@ -38,6 +38,7 @@ class ToolDetailsViewModel: NSObject, ObservableObject {
     @Published var selectedSegment: ToolDetailsSegmentType = .about
     @Published var aboutDetails: String = ""
     @Published var toolVersions: [ToolVersionDomainModel] = Array()
+    @Published var selectedToolVersion: ToolVersionDomainModel?
     
     init(flowDelegate: FlowDelegate, resource: ResourceModel, dataDownloader: InitialDataDownloader, languageSettingsService: LanguageSettingsService, localizationServices: LocalizationServices, favoritedResourcesCache: FavoritedResourcesCache, analytics: AnalyticsContainer, getToolTranslationsUseCase: GetToolTranslationsUseCase, languagesRepository: LanguagesRepository, getToolVersionsUseCase: GetToolVersionsUseCase, bannerImageRepository: ResourceBannerImageRepository) {
         
@@ -61,6 +62,7 @@ class ToolDetailsViewModel: NSObject, ObservableObject {
         setupBinding()
         reloadLearnToShareToolButtonState()
         toolVersions = getToolVersionsUseCase.getToolVersions(resourceId: resource.id)
+        selectedToolVersion = toolVersions.filter({$0.isDefaultVersion}).first
     }
     
     deinit {
@@ -267,11 +269,16 @@ class ToolDetailsViewModel: NSObject, ObservableObject {
         flowDelegate?.navigate(step: .urlLinkTappedFromToolDetail(url: url, exitLink: exitLink))
     }
     
+    func toolVersionTapped(toolVersion: ToolVersionDomainModel) {
+        selectedToolVersion = toolVersion
+    }
+    
     func getToolVersionCardViewModel(toolVersion: ToolVersionDomainModel) -> ToolDetailsVersionsCardViewModel {
         
         return ToolDetailsVersionsCardViewModel(
             toolVersion: toolVersion,
-            bannerImageRepository: bannerImageRepository
+            bannerImageRepository: bannerImageRepository,
+            isSelected: selectedToolVersion?.id == toolVersion.id
         )
     }
 }

--- a/godtools/App/Features/ToolDetails/Presentation/ToolDetails/Views/ToolDetailsVersionsView.swift
+++ b/godtools/App/Features/ToolDetails/Presentation/ToolDetails/Views/ToolDetailsVersionsView.swift
@@ -21,6 +21,9 @@ struct ToolDetailsVersionsView: View {
                 ToolDetailsVersionsCardView(
                     viewModel: viewModel.getToolVersionCardViewModel(toolVersion: toolVersion)
                 )
+                .onTapGesture {
+                    viewModel.toolVersionTapped(toolVersion: toolVersion)
+                }
             }
         }
     }

--- a/godtools/App/Features/ToolDetails/Presentation/ToolDetails/Views/VersionsCard/ToolDetailsVersionsCardView.swift
+++ b/godtools/App/Features/ToolDetails/Presentation/ToolDetails/Views/VersionsCard/ToolDetailsVersionsCardView.swift
@@ -13,9 +13,7 @@ struct ToolDetailsVersionsCardView: View {
     private let bannerHeight: CGFloat = 87
     
     @ObservedObject var viewModel: ToolDetailsVersionsCardViewModel
-    
-    @State var isSelected: Bool = false
-    
+        
     var body: some View {
         
         ZStack {
@@ -39,7 +37,7 @@ struct ToolDetailsVersionsCardView: View {
                 
                 HStack(alignment: .top, spacing: 0) {
                     
-                    CircleSelectorView(isSelected: $isSelected)
+                    CircleSelectorView(isSelected: viewModel.isSelected)
                         .padding(EdgeInsets(top: 3, leading: 0, bottom: 0, trailing: 0))
                     
                     Rectangle()
@@ -109,12 +107,14 @@ struct ToolDetailsVersionsCardView_Preview: PreviewProvider {
             primaryLanguage: "English",
             primaryLanguageIsSupported: true,
             parallelLanguage: "Spanish",
-            parallelLanguageIsSupported: false
+            parallelLanguageIsSupported: false,
+            isDefaultVersion: false
         )
         
         let viewModel = ToolDetailsVersionsCardViewModel(
             toolVersion: toolVersion,
-            bannerImageRepository: appDiContainer.getResourceBannerImageRepository()
+            bannerImageRepository: appDiContainer.getResourceBannerImageRepository(),
+            isSelected: false
         )
         
         ToolDetailsVersionsCardView(viewModel: viewModel)

--- a/godtools/App/Features/ToolDetails/Presentation/ToolDetails/Views/VersionsCard/ToolDetailsVersionsCardViewModel.swift
+++ b/godtools/App/Features/ToolDetails/Presentation/ToolDetails/Views/VersionsCard/ToolDetailsVersionsCardViewModel.swift
@@ -14,6 +14,7 @@ class ToolDetailsVersionsCardViewModel: ObservableObject {
     private let bannerImageRepository: ResourceBannerImageRepository
     
     let bannerImage: Image?
+    let isSelected: Bool
     let name: String
     let description: String
     let languages: String
@@ -22,11 +23,12 @@ class ToolDetailsVersionsCardViewModel: ObservableObject {
     let parallelLanguageName: String?
     let parallelLanguageIsSupported: Bool
     
-    init(toolVersion: ToolVersionDomainModel, bannerImageRepository: ResourceBannerImageRepository) {
+    init(toolVersion: ToolVersionDomainModel, bannerImageRepository: ResourceBannerImageRepository, isSelected: Bool) {
         
         self.bannerImageRepository = bannerImageRepository
         
         bannerImage = bannerImageRepository.getBannerImage(resourceId: toolVersion.id, bannerId: toolVersion.bannerImageId)
+        self.isSelected = isSelected
         name = toolVersion.name
         description = toolVersion.description
         languages = toolVersion.languages

--- a/godtools/App/Share/SwiftUI Views/CircleSelector/CircleSelectorView.swift
+++ b/godtools/App/Share/SwiftUI Views/CircleSelector/CircleSelectorView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 
 struct CircleSelectorView: View {
         
-    @Binding var isSelected: Bool
+    let isSelected: Bool
     
     var body: some View {
         


### PR DESCRIPTION
This PR updates the selected state of the version card in ToolDetails.  The default version will start selected and tapping a new version will update the selected card by filling the circle on the card.
