### PR TITLE
GT-1611 ToolDetails gray background and shadow 

### DIFF
--- a/godtools/App/Features/ToolDetails/Presentation/ToolDetails/ToolDetailsView.swift
+++ b/godtools/App/Features/ToolDetails/Presentation/ToolDetails/ToolDetailsView.swift
@@ -28,17 +28,24 @@ struct ToolDetailsView: View {
                 
                 ScrollView(.vertical, showsIndicators: true) {
                     
-                    ToolDetailsTitleHeaderView(viewModel: viewModel)
-                        .padding(EdgeInsets(top: 40, leading: contentInsets.leading, bottom: 0, trailing: contentInsets.trailing))
-                    
-                    ToolDetailsPrimaryButtonsView(viewModel: viewModel, primaryButtonWidth: contentWidth)
-                        .padding(EdgeInsets(top: 16, leading: contentInsets.leading, bottom: 0, trailing: contentInsets.trailing))                    
-                                        
-                    SegmentControl(selectedIndex: $selectedSegmentIndex, segments: viewModel.segments, segmentTappedClosure: { (index: Int) in
+                    VStack(alignment: .center, spacing: 0) {
+                                                
+                        ToolDetailsTitleHeaderView(viewModel: viewModel)
+                            .padding(EdgeInsets(top: 40, leading: contentInsets.leading, bottom: 0, trailing: contentInsets.trailing))
                         
-                        viewModel.segmentTapped(index: index)
-                    })
-                    .padding(EdgeInsets(top: 50, leading: 0, bottom: 0, trailing: 0))
+                        ToolDetailsPrimaryButtonsView(viewModel: viewModel, primaryButtonWidth: contentWidth)
+                            .padding(EdgeInsets(top: 16, leading: contentInsets.leading, bottom: 0, trailing: contentInsets.trailing))
+                                            
+                        SegmentControl(selectedIndex: $selectedSegmentIndex, segments: viewModel.segments, segmentTappedClosure: { (index: Int) in
+                            
+                            viewModel.segmentTapped(index: index)
+                        })
+                        .padding(EdgeInsets(top: 50, leading: 0, bottom: 0, trailing: 0))
+                    }
+                    .background(Rectangle()
+                        .fill(Color.white)
+                        .shadow(color: Color.black.opacity(0.3), radius: 4, x: 0, y: 1)
+                    )
                     
                     Rectangle()
                         .frame(width: geometry.size.width, height: 20)
@@ -53,9 +60,14 @@ struct ToolDetailsView: View {
                     case .versions:
                         ToolDetailsVersionsView(viewModel: viewModel)
                     }
+                    
+                    Rectangle()
+                        .frame(width: geometry.size.width, height: 20)
+                        .foregroundColor(.clear)
                 }
             }
         }
+        .background(Color(.sRGB, red: 245 / 255, green: 245 / 255, blue: 245 / 255, opacity: 1))
         .onAppear {
             viewModel.pageViewed()
         }


### PR DESCRIPTION
This PR adds the gray background for the About and Versions content in ToolDetails and adds the gray shadow separator underneath the About and Versions selectors. 
I also add a bottom spacing of 20 points between the bottom of the screen and the About content and Versions content.

![shadow-gray-background](https://user-images.githubusercontent.com/59846460/176544046-d6332da4-dca8-48bd-8afd-766460722951.png)
