### PR TITLE
GT-1545 instantiate tools menu instead of calling reset

### DIFF
--- a/godtools/App/Flows/App/AppFlow.swift
+++ b/godtools/App/Flows/App/AppFlow.swift
@@ -478,11 +478,7 @@ extension AppFlow {
 
 extension AppFlow {
     
-    private func instantiateToolsMenuIfNeeded() {
-        
-        guard toolsMenuView == nil else {
-            return
-        }
+    private func getToolsMenu(startingPage: ToolsMenuPageType = AppFlow.defaultStartingToolsMenuPage) -> ToolsMenuView {
         
         let toolsMenuViewModel = ToolsMenuViewModel(
             flowDelegate: self,
@@ -500,8 +496,19 @@ extension AppFlow {
         
         let toolsMenuView = ToolsMenuView(
             viewModel: toolsMenuViewModel,
-            startingPage: AppFlow.defaultStartingToolsMenuPage
+            startingPage: startingPage
         )
+        
+        return toolsMenuView
+    }
+    
+    private func instantiateToolsMenuIfNeeded() {
+        
+        guard toolsMenuView == nil else {
+            return
+        }
+        
+        let toolsMenuView = getToolsMenu()
         
         navigationController.setViewControllers([toolsMenuView], animated: false)
                             


### PR DESCRIPTION
This PR will re-instantiate the ToolsMenuView rather than keeping an instance of ToolsMenuView and calling reset.  I think creating a new instance is much preferred, keeping an instance and calling reset adds more management when it comes to resetting that entire view.
ToolsMenuView is re-allocated from deep links, dismissing the tutorial, completing onboarding, and app launch.