### PR TITLE
GT-1657 Fix navigation to tools from quick links

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -47,7 +47,7 @@ SPEC CHECKSUMS:
   FBSDKCoreKit: 4afd6ff53d8133a433dbcda44451c9498f8c6ce4
   FMDB: 2ce00b547f966261cd18927a3ddb07cb6f3db82a
   Fuzi: 4c10d6449c0b49a85cd75b13844c559c0fc71220
-  GodtoolsToolParser: 2ddd8446e94b514782d0f57ce551b69495ae1eb3
+  GodtoolsToolParser: f44b011048f398b0e7fec6fb03224106b15de190
   GoogleConversionTracking: ca8c89abda2bd28bb6472b316eeb4ece9264e279
   SnowplowTracker: c393b26c456142ad5a78f4e4d771c71cb194f06c
   SSZipArchive: fe6a26b2a54d5a0890f2567b5cc6de5caa600aef

--- a/godtools/App/Flows/App/AppFlow.swift
+++ b/godtools/App/Flows/App/AppFlow.swift
@@ -302,35 +302,34 @@ class AppFlow: NSObject, ToolNavigationFlow, Flow {
             
         case .onboardingFlowCompleted(let onboardingFlowCompletedState):
             
-            navigateToToolsMenu()
-                        
-            dismissOnboarding(animated: true) { [weak self] in
+            switch onboardingFlowCompletedState {
+            
+            case .readArticles:
+                   
+                navigateToToolsMenu()
                 
-                switch onboardingFlowCompletedState {
+                let toolDeepLink = ToolDeepLink(
+                    resourceAbbreviation: "es",
+                    primaryLanguageCodes: ["en"],
+                    parallelLanguageCodes: [],
+                    liveShareStream: nil,
+                    page: nil,
+                    pageId: nil
+                )
                 
-                case .readArticles:
-                                        
-                    let toolDeepLink = ToolDeepLink(
-                        resourceAbbreviation: "es",
-                        primaryLanguageCodes: ["en"],
-                        parallelLanguageCodes: [],
-                        liveShareStream: nil,
-                        page: nil,
-                        pageId: nil
-                    )
-                    
-                    self?.navigateToToolFromToolDeepLink(toolDeepLink: toolDeepLink, didCompleteToolNavigation: nil)
-                    
-                case .tryLessons:
-                    self?.navigateToToolsMenu(startingPage: .lessons)
-                    
-                case .chooseTool:
-                    self?.navigateToToolsMenu(startingPage: .allTools)
-                    
-                default:
-                    self?.navigateToToolsMenu()
-                }
+                navigateToToolFromToolDeepLink(toolDeepLink: toolDeepLink, didCompleteToolNavigation: nil)
+                
+            case .tryLessons:
+                navigateToToolsMenu(startingPage: .lessons)
+                
+            case .chooseTool:
+                navigateToToolsMenu(startingPage: .allTools)
+                
+            default:
+                navigateToToolsMenu()
             }
+            
+            dismissOnboarding(animated: true)
                     
         case .openTutorialTappedFromTools:
             navigateToTutorial()


### PR DESCRIPTION
This PR fixes navigation to tools (lessons, favorites, all tools) from a quick link.  I moved the logic for navigating to the tools menu to occur before dismissing the onboarding flow.  This way when onboarding is dismissed a user is seeing the correct tools list.
Previously there was a navigation to tools menu happening before dismissing onboarding and another happening when dismissing onboarding completed.