### PR TITLE
GT-1662 Temporary fix for the ToolDetails about section scroll issue

### DIFF
--- a/godtools/App/Features/ToolDetails/ToolDetailsViewModel.swift
+++ b/godtools/App/Features/ToolDetails/ToolDetailsViewModel.swift
@@ -279,6 +279,16 @@ extension ToolDetailsViewModel {
     
     func segmentTapped(index: Int) {
         selectedSegment = segmentTypes[index]
+        
+        // NOTE: This is a temporary fix that solves an issue when switching back to the about section, a user is unable to scroll through all of the text in the
+        // about section. This is basically acting as a way to force the view to refresh again after 0.1 seconds.
+        // This has something to do with using UIViewRepresentable that wraps a UITextView.  If we were using a SwiftUI Text element this issue wouldn't exist.
+        // Once minimum iOS 15 is supported see if TextWithLinks can be dropped.  See GT-1670. ~Levi
+        if selectedSegment == .about {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                self.selectedSegment = .about
+            }
+        }
     }
     
     func urlTapped(url: URL) {


### PR DESCRIPTION
This fixes a bug in ToolDetails about section.  This bug can be reproduced when tapping the versions tab to view a tools versions, and then tapping the about section again to go back to the about details text.  The bug that occurs from this is you're unable to scroll all the way down to the bottom of the about details text when switching to versions and back to about.
This bug is related to using a UIViewRepresentable UITextView (UIKit) and does not occur if I have a plain Text (SwiftUI) element with a lot of text. For now this temporary hack will have to do until Text (SwiftUI) with tappable url links can be fully supported and the UIViewRepresentable UITextView> (UIKit) can be dropped.