### PR TITLE
GT-1673 Change tool settings options line limit to 2

### DIFF
--- a/godtools/App/Features/ToolSettings/Presentation/ToolSettings/Views/ToolSettingsOptions/ToolSettingsOptionsItemView.swift
+++ b/godtools/App/Features/ToolSettings/Presentation/ToolSettings/Views/ToolSettingsOptions/ToolSettingsOptionsItemView.swift
@@ -31,7 +31,7 @@ struct ToolSettingsOptionsItemView: View {
                     .foregroundColor(titleColorStyle.getColor())
                     .font(FontLibrary.sfProTextRegular.font(size: 14))
                     .multilineTextAlignment(.center)
-                    .lineLimit(1)
+                    .lineLimit(2)
                     .padding(EdgeInsets(top: 0, leading: 2, bottom: 0, trailing: 2))
             }
             .frame(


### PR DESCRIPTION
Changed line limit on tool settings options from 1 to 2.

![option-linelimit-2](https://user-images.githubusercontent.com/59846460/177627154-55a5d5dd-3ed0-44cc-9281-e8b25314d727.png)
