### PR TITLE
GT-1674 Favorites data loading

### DIFF
--- a/godtools/App/Features/Tools/SwiftUI/Favorites/FavoriteToolsView/ViewModels/BaseFavoriteToolsViewModel.swift
+++ b/godtools/App/Features/Tools/SwiftUI/Favorites/FavoriteToolsView/ViewModels/BaseFavoriteToolsViewModel.swift
@@ -41,6 +41,7 @@ class BaseFavoriteToolsViewModel: ToolCardProvider {
         
         super.init()
         
+        reloadFavoritedResourcesFromCache()
         setupBinding()
         setText()
     }

--- a/godtools/App/Features/Tools/SwiftUI/Favorites/FeaturedLessonsView/LessonCardsView/LessonCardsViewModel.swift
+++ b/godtools/App/Features/Tools/SwiftUI/Favorites/FeaturedLessonsView/LessonCardsView/LessonCardsViewModel.swift
@@ -31,6 +31,8 @@ class LessonCardsViewModel: LessonCardProvider {
         
         super.init()
         
+        reloadLessonsFromCache()
+        
         setup()
     }
     


### PR DESCRIPTION
This PR updates the Favorites features lessons and favorited tools lists to be reloaded from the cache when the viewModels are initialized.  That way cached results are displayed immediately. 