### PR TITLE
GT-Upgrade Xcode version in GitHub actions workflows to 13.4.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     runs-on: macos-12
     env:
-      DEVELOPER_DIR: /Applications/Xcode_13.3.1.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_13.4.1.app/Contents/Developer
 
     steps:
       

--- a/.github/workflows/download_onesky_translations.yml
+++ b/.github/workflows/download_onesky_translations.yml
@@ -16,7 +16,7 @@ jobs:
   build:
     runs-on: macos-12
     env:
-      DEVELOPER_DIR: /Applications/Xcode_13.3.1.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_13.4.1.app/Contents/Developer
 
     steps:
 


### PR DESCRIPTION
GitHub actions has been a little flaky lately.  Sometimes Xcode build settings times out and other times tests will randomly fail.
Going to start by upgrading the workflows to point to Xcode 13.4.1 instead of 13.3.1.