### PR TITLE
GT-1693 add delete account screen

### DIFF
--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		45127A24287C994D00CC21C4 /* DeleteAccountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45127A23287C994D00CC21C4 /* DeleteAccountView.swift */; };
 		45127A26287C998800CC21C4 /* DeleteAccountViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45127A25287C998800CC21C4 /* DeleteAccountViewModel.swift */; };
 		45127A28287C9C4300CC21C4 /* DeleteAccountHostingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45127A27287C9C4300CC21C4 /* DeleteAccountHostingView.swift */; };
+		45127A2A287CB42200CC21C4 /* Flow+PresentNativeMailApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45127A29287CB42200CC21C4 /* Flow+PresentNativeMailApp.swift */; };
 		4513C2E8270467F400614F79 /* SetupParallelLanguageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4513C2E7270467F400614F79 /* SetupParallelLanguageView.swift */; };
 		4513C2EA2704681300614F79 /* SetupParallelLanguageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4513C2E92704681300614F79 /* SetupParallelLanguageViewModel.swift */; };
 		4513C2EC2704681F00614F79 /* SetupParallelLanguageViewModelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4513C2EB2704681F00614F79 /* SetupParallelLanguageViewModelType.swift */; };
@@ -1220,6 +1221,7 @@
 		45127A23287C994D00CC21C4 /* DeleteAccountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteAccountView.swift; sourceTree = "<group>"; };
 		45127A25287C998800CC21C4 /* DeleteAccountViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteAccountViewModel.swift; sourceTree = "<group>"; };
 		45127A27287C9C4300CC21C4 /* DeleteAccountHostingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteAccountHostingView.swift; sourceTree = "<group>"; };
+		45127A29287CB42200CC21C4 /* Flow+PresentNativeMailApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Flow+PresentNativeMailApp.swift"; sourceTree = "<group>"; };
 		4513C2E7270467F400614F79 /* SetupParallelLanguageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetupParallelLanguageView.swift; sourceTree = "<group>"; };
 		4513C2E92704681300614F79 /* SetupParallelLanguageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetupParallelLanguageViewModel.swift; sourceTree = "<group>"; };
 		4513C2EB2704681F00614F79 /* SetupParallelLanguageViewModelType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetupParallelLanguageViewModelType.swift; sourceTree = "<group>"; };
@@ -4619,6 +4621,7 @@
 				45AD188E25938A4E00A096A0 /* AppRootController.swift */,
 				45AD189025938A4E00A096A0 /* Flow.swift */,
 				45A3A0C726B0BD54005DA490 /* Flow+NavigateToUrl.swift */,
+				45127A29287CB42200CC21C4 /* Flow+PresentNativeMailApp.swift */,
 				45AD189725938A4E00A096A0 /* FlowDelegate.swift */,
 				45AD188C25938A4E00A096A0 /* FlowStep.swift */,
 				D47C49DF2816EEBD0084F4DE /* MockFlowDelegate.swift */,
@@ -8023,6 +8026,7 @@
 				45428A8126712B1C0022A66D /* AppsFlyerAnalytics+MobileContentAnalyticsSystem.swift in Sources */,
 				45AD208625938B6A00A096A0 /* KeyboardStateChange.swift in Sources */,
 				45AD1FDB25938A9800A096A0 /* WebArchiveQueue.swift in Sources */,
+				45127A2A287CB42200CC21C4 /* Flow+PresentNativeMailApp.swift in Sources */,
 				45C93AEB261D310900592FFF /* ArticleJcrContent.swift in Sources */,
 				D1C8FEB92714E7010071BD07 /* TutorialCellViewModelType.swift in Sources */,
 				45AD1F8A25938A9800A096A0 /* TranslationModelType.swift in Sources */,

--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -80,6 +80,8 @@
 		4511D248286CB9D200276174 /* ResourceBannerImageRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4511D246286CB9D200276174 /* ResourceBannerImageRepository.swift */; };
 		4511D249286CB9D200276174 /* BundleResourceBannerImages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4511D247286CB9D200276174 /* BundleResourceBannerImages.swift */; };
 		4511D24B286CBA0100276174 /* LanguageSupportedText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4511D24A286CBA0100276174 /* LanguageSupportedText.swift */; };
+		45127A24287C994D00CC21C4 /* DeleteAccountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45127A23287C994D00CC21C4 /* DeleteAccountView.swift */; };
+		45127A26287C998800CC21C4 /* DeleteAccountViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45127A25287C998800CC21C4 /* DeleteAccountViewModel.swift */; };
 		4513C2E8270467F400614F79 /* SetupParallelLanguageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4513C2E7270467F400614F79 /* SetupParallelLanguageView.swift */; };
 		4513C2EA2704681300614F79 /* SetupParallelLanguageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4513C2E92704681300614F79 /* SetupParallelLanguageViewModel.swift */; };
 		4513C2EC2704681F00614F79 /* SetupParallelLanguageViewModelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4513C2EB2704681F00614F79 /* SetupParallelLanguageViewModelType.swift */; };
@@ -387,8 +389,8 @@
 		4596757028611CE40028B5A3 /* TutorialSupportedLanguages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45F88B012860BA8700C8027F /* TutorialSupportedLanguages.swift */; };
 		4599251B2704F36A008F7844 /* ChooseScaleSliderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4599251A2704F36A008F7844 /* ChooseScaleSliderView.swift */; };
 		4599251D2704F37B008F7844 /* ChooseScaleSliderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4599251C2704F37B008F7844 /* ChooseScaleSliderView.xib */; };
-		459C56D225FF954F00F15967 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		459C56D325FF954F00F15967 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		459C56D225FF954F00F15967 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		459C56D325FF954F00F15967 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		459C93A427581B23006207D2 /* OktaAuthentication in Frameworks */ = {isa = PBXBuildFile; productRef = 459C93A327581B23006207D2 /* OktaAuthentication */; };
 		459C93B027581FD0006207D2 /* OktaUserAuthentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 459C93AF27581FD0006207D2 /* OktaUserAuthentication.swift */; };
 		45A3A0C826B0BD54005DA490 /* Flow+NavigateToUrl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45A3A0C726B0BD54005DA490 /* Flow+NavigateToUrl.swift */; };
@@ -799,15 +801,15 @@
 		45AFC62D27CD74100090E381 /* MobileContentBackgroundImageAlignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4578782F27C41C08004552D5 /* MobileContentBackgroundImageAlignment.swift */; };
 		45B116C22625FC6D007A7127 /* LanguageDirection+SemanticContentAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B116C12625FC6D007A7127 /* LanguageDirection+SemanticContentAttribute.swift */; };
 		45B248582734676F00B7AD5E /* AppsFlyerLib in Frameworks */ = {isa = PBXBuildFile; productRef = 45B248572734676F00B7AD5E /* AppsFlyerLib */; };
-		45B6480925E581660098BAF1 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		45B6480A25E581660098BAF1 /* BuildFile in Resources */ = {isa = PBXBuildFile; };
-		45B6480B25E581660098BAF1 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		45B6480C25E581660098BAF1 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		45B6481625E58ECC0098BAF1 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		45B6482025E58EE70098BAF1 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		45B6482825E593110098BAF1 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		45B6482925E593110098BAF1 /* BuildFile in Resources */ = {isa = PBXBuildFile; };
-		45B6482A25E593110098BAF1 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		45B6480925E581660098BAF1 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		45B6480A25E581660098BAF1 /* (null) in Resources */ = {isa = PBXBuildFile; };
+		45B6480B25E581660098BAF1 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		45B6480C25E581660098BAF1 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		45B6481625E58ECC0098BAF1 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		45B6482025E58EE70098BAF1 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		45B6482825E593110098BAF1 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		45B6482925E593110098BAF1 /* (null) in Resources */ = {isa = PBXBuildFile; };
+		45B6482A25E593110098BAF1 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		45B778AF27C5351500BAAF1E /* ToolPageHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 45B778AE27C5351500BAAF1E /* ToolPageHeaderView.xib */; };
 		45B9875D283BFE5300E1DA7F /* DownloadedTranslationResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B9874B283BFE5300E1DA7F /* DownloadedTranslationResult.swift */; };
 		45B9875E283BFE5300E1DA7F /* TranslationDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B9874C283BFE5300E1DA7F /* TranslationDownloader.swift */; };
@@ -1214,6 +1216,8 @@
 		4511D246286CB9D200276174 /* ResourceBannerImageRepository.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResourceBannerImageRepository.swift; sourceTree = "<group>"; };
 		4511D247286CB9D200276174 /* BundleResourceBannerImages.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BundleResourceBannerImages.swift; sourceTree = "<group>"; };
 		4511D24A286CBA0100276174 /* LanguageSupportedText.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LanguageSupportedText.swift; sourceTree = "<group>"; };
+		45127A23287C994D00CC21C4 /* DeleteAccountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteAccountView.swift; sourceTree = "<group>"; };
+		45127A25287C998800CC21C4 /* DeleteAccountViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteAccountViewModel.swift; sourceTree = "<group>"; };
 		4513C2E7270467F400614F79 /* SetupParallelLanguageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetupParallelLanguageView.swift; sourceTree = "<group>"; };
 		4513C2E92704681300614F79 /* SetupParallelLanguageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetupParallelLanguageViewModel.swift; sourceTree = "<group>"; };
 		4513C2EB2704681F00614F79 /* SetupParallelLanguageViewModelType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetupParallelLanguageViewModelType.swift; sourceTree = "<group>"; };
@@ -2505,6 +2509,7 @@
 		450E44372756B61900D4311E /* Presentation */ = {
 			isa = PBXGroup;
 			children = (
+				45127A22287C994400CC21C4 /* DeleteAccount */,
 				450E44382756B66300D4311E /* Menu */,
 			);
 			path = Presentation;
@@ -2656,6 +2661,15 @@
 				4511D246286CB9D200276174 /* ResourceBannerImageRepository.swift */,
 			);
 			path = ResourceBannerImageRepository;
+			sourceTree = "<group>";
+		};
+		45127A22287C994400CC21C4 /* DeleteAccount */ = {
+			isa = PBXGroup;
+			children = (
+				45127A23287C994D00CC21C4 /* DeleteAccountView.swift */,
+				45127A25287C998800CC21C4 /* DeleteAccountViewModel.swift */,
+			);
+			path = DeleteAccount;
 			sourceTree = "<group>";
 		};
 		4513C2E6270467E600614F79 /* LessonEvaluation */ = {
@@ -6987,13 +7001,13 @@
 			);
 			mainGroup = 4F5732801EA69CF00082035C;
 			packageReferences = (
-				45B248562734676F00B7AD5E /* XCRemoteSwiftPackageReference "AppsFlyerFramework.git" */,
-				45EDBCEE27359CD70099495B /* XCRemoteSwiftPackageReference "realm-cocoa.git" */,
-				45E39EDA27457E0C006A59E4 /* XCRemoteSwiftPackageReference "lottie-ios.git" */,
-				459C93A227581B23006207D2 /* XCRemoteSwiftPackageReference "okta-authentication-ios.git" */,
-				45CF096E2784B910007F13D3 /* XCRemoteSwiftPackageReference "request-operation-ios.git" */,
-				45CDFB4B281730FA00AC4F2E /* XCRemoteSwiftPackageReference "google-tag-manager-ios-sdk.git" */,
-				45CDFB4E2817324B00AC4F2E /* XCRemoteSwiftPackageReference "firebase-ios-sdk.git" */,
+				45B248562734676F00B7AD5E /* XCRemoteSwiftPackageReference "AppsFlyerFramework" */,
+				45EDBCEE27359CD70099495B /* XCRemoteSwiftPackageReference "realm-cocoa" */,
+				45E39EDA27457E0C006A59E4 /* XCRemoteSwiftPackageReference "lottie-ios" */,
+				459C93A227581B23006207D2 /* XCRemoteSwiftPackageReference "okta-authentication-ios" */,
+				45CF096E2784B910007F13D3 /* XCRemoteSwiftPackageReference "request-operation-ios" */,
+				45CDFB4B281730FA00AC4F2E /* XCRemoteSwiftPackageReference "google-tag-manager-ios-sdk" */,
+				45CDFB4E2817324B00AC4F2E /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 			);
 			productRefGroup = 4F57328A1EA69CF00082035C /* Products */;
 			projectDirPath = "";
@@ -7062,7 +7076,7 @@
 				D188EA8327146AB000B10ABA /* onboarding_distance.json in Resources */,
 				D1330728273ABFF20058450B /* OnboardingQuickStartCell.xib in Resources */,
 				45CB9FF8261FB0BE0036BEB3 /* LessonsListView.xib in Resources */,
-				45B6482925E593110098BAF1 /* BuildFile in Resources */,
+				45B6482925E593110098BAF1 /* (null) in Resources */,
 				451EBE2E24AD968B00C4D6DD /* 1958f6ba22b659adfc7eb43dcfac7cc5cfe192df45437355aa99a8752192ed92.jpg in Resources */,
 				455583FC269F2DA500C3FF14 /* MobileContentInputView.xib in Resources */,
 				451A17542756C10400D35D78 /* tutorial_tooltip.json in Resources */,
@@ -7141,7 +7155,7 @@
 				4555840F269F2DA500C3FF14 /* MobileContentTextView.xib in Resources */,
 				451EBE3D24AD968B00C4D6DD /* e961f409d06308e87deb9ed9166264c7c732d9dc24e70f886944636308810d6e.png in Resources */,
 				4556AED523E221FE002C15E8 /* AbyssinicaSIL-R.ttf in Resources */,
-				45B6480A25E581660098BAF1 /* BuildFile in Resources */,
+				45B6480A25E581660098BAF1 /* (null) in Resources */,
 				45DEF22E2576A6A20007AC64 /* learn_to_share_tool_with_anyone.json in Resources */,
 				457C8586242E50D70025E079 /* GoogleService-Info-Debug.plist in Resources */,
 				45CB9FFF261FB0BE0036BEB3 /* LessonListItemView.xib in Resources */,
@@ -7317,7 +7331,7 @@
 				455583CF269F2DA500C3FF14 /* MobileContentFormView.swift in Sources */,
 				D45922BF2864EBD400904B87 /* AllFavoriteToolsHostingView.swift in Sources */,
 				455583C4269F2DA500C3FF14 /* MobileContentPageViewFactoryType.swift in Sources */,
-				459C56D225FF954F00F15967 /* BuildFile in Sources */,
+				459C56D225FF954F00F15967 /* (null) in Sources */,
 				45AD1B6225938A4F00A096A0 /* GlobalActivityCell.swift in Sources */,
 				45A93C71286DE4BA00090E01 /* ToolDetailsTitleHeaderView.swift in Sources */,
 				450E441627565D1C00D4311E /* GetTutorialUseCase.swift in Sources */,
@@ -7334,7 +7348,7 @@
 				45FB160E27DBDDB60009DF8E /* TractFlowCompletedState.swift in Sources */,
 				45AE975D27C97A9500C2CB33 /* Tip+MobileContentRenderableModel.swift in Sources */,
 				45C93AE0261D310900592FFF /* ArticleAemCacheArchivedObject.swift in Sources */,
-				45B6481625E58ECC0098BAF1 /* BuildFile in Sources */,
+				45B6481625E58ECC0098BAF1 /* (null) in Sources */,
 				455582E8269F2C1000C3FF14 /* TrainingPageViewModelType.swift in Sources */,
 				4559D67C270B5600006C015C /* LessonFeedbackHelpful.swift in Sources */,
 				455583D7269F2DA500C3FF14 /* MobileContentTabsView.swift in Sources */,
@@ -7366,7 +7380,7 @@
 				45AD1FFB25938A9800A096A0 /* DetermineNewUserIfPrimaryLanguageSet.swift in Sources */,
 				455583ED269F2DA500C3FF14 /* MobileContentSpacerViewModel.swift in Sources */,
 				455D275E27B6A3F700FB85B3 /* MobileContentSpacerHeight.swift in Sources */,
-				45B6480B25E581660098BAF1 /* BuildFile in Sources */,
+				45B6480B25E581660098BAF1 /* (null) in Sources */,
 				45EC429B272C87430052F2AA /* PassthroughValue.swift in Sources */,
 				45FB160F27DBDDB60009DF8E /* LanguageSettingsFlow.swift in Sources */,
 				45AD1F9925938A9800A096A0 /* RealmResource.swift in Sources */,
@@ -7448,9 +7462,10 @@
 				456431CF284ACC0900846720 /* ToolTranslationsToDownload.swift in Sources */,
 				45E39EC327457856006A59E4 /* TutorialAssetContent.swift in Sources */,
 				45558351269F2D1000C3FF14 /* LessonPageViewModel.swift in Sources */,
+				45127A24287C994D00CC21C4 /* DeleteAccountView.swift in Sources */,
 				4505C694282B4A0B0047951D /* ToolsMenuToolbarItemViewModel.swift in Sources */,
 				45AD1FD325938A9800A096A0 /* HTMLDocument+ResourceUrls.swift in Sources */,
-				45B6482025E58EE70098BAF1 /* BuildFile in Sources */,
+				45B6482025E58EE70098BAF1 /* (null) in Sources */,
 				4505C68B282B4A0B0047951D /* ToolsMenuPageType.swift in Sources */,
 				45C93AF7261D310900592FFF /* CategoryArticleUUID.swift in Sources */,
 				D420DA2B28295E5E0035ABCB /* ToolCardsView.swift in Sources */,
@@ -7541,7 +7556,7 @@
 				45AD1B0525938A4E00A096A0 /* ArticlesErrorMessage.swift in Sources */,
 				45AD1FFE25938A9800A096A0 /* ResourceViewModelType.swift in Sources */,
 				45AD1F9025938A9800A096A0 /* TranslationModel.swift in Sources */,
-				45B6480925E581660098BAF1 /* BuildFile in Sources */,
+				45B6480925E581660098BAF1 /* (null) in Sources */,
 				45F38D352833EEAA009E3E15 /* RealmLanguagesCache.swift in Sources */,
 				45558407269F2DA500C3FF14 /* MobileContentPagesViewModel.swift in Sources */,
 				45E3FAC02759898200D0CAFA /* AuthUserModelType.swift in Sources */,
@@ -7713,7 +7728,7 @@
 				45AE975527C97A9500C2CB33 /* Input+MobileContentRenderableModel.swift in Sources */,
 				45325F30285CF90D0078D932 /* Strings.swift in Sources */,
 				45AD1AF225938A4E00A096A0 /* HelpWebContent.swift in Sources */,
-				459C56D325FF954F00F15967 /* BuildFile in Sources */,
+				459C56D325FF954F00F15967 /* (null) in Sources */,
 				451CCF1427A9AA4700E8D2D3 /* MobileContentViewPositionState.swift in Sources */,
 				45D6D02F2708B8FF0063C38A /* LessonEvaluationRepository.swift in Sources */,
 				450E44462756B66300D4311E /* MenuViewModel.swift in Sources */,
@@ -7763,7 +7778,7 @@
 				455583DC269F2DA500C3FF14 /* MobileContentAccordionViewModelType.swift in Sources */,
 				45AD1AF925938A4E00A096A0 /* MailView.swift in Sources */,
 				45AD1B9625938A4F00A096A0 /* ToolNavBarView.swift in Sources */,
-				45B6482A25E593110098BAF1 /* BuildFile in Sources */,
+				45B6482A25E593110098BAF1 /* (null) in Sources */,
 				D42FEBD62875D8D50002FAD9 /* GetOptInOnboardingTutorialAvailableUseCase.swift in Sources */,
 				45C61DD9280905F40058946F /* DeepLinkingManifest.swift in Sources */,
 				456FBE0327A48D190033FBCB /* HorizontallyCenteredCollectionViewLayout.swift in Sources */,
@@ -7802,7 +7817,7 @@
 				4566A3BA27A5C3BE003EAA39 /* MobileContentCardCollectionPageItemViewModel.swift in Sources */,
 				4555833E269F2C7B00C3FF14 /* ToolPageModalView.swift in Sources */,
 				4581C59A285A5C7A0078425B /* ToolTrainingViewModel.swift in Sources */,
-				45B6480C25E581660098BAF1 /* BuildFile in Sources */,
+				45B6480C25E581660098BAF1 /* (null) in Sources */,
 				455582E5269F2C1000C3FF14 /* TrainingTipView.swift in Sources */,
 				D40EE3AC281C69F800EAD1FE /* FavoritingToolBannerViewModel.swift in Sources */,
 				45AD205925938AC300A096A0 /* SnowplowAnalyticsType.swift in Sources */,
@@ -7873,6 +7888,7 @@
 				45AE976027C97A9500C2CB33 /* MobileContentRenderableModel.swift in Sources */,
 				D42600CC282BFBC400E7A520 /* ResourceCardBannerImageView.swift in Sources */,
 				45AD1F9225938A9800A096A0 /* AttachmentModelType+SHA256FileLocation.swift in Sources */,
+				45127A26287C998800CC21C4 /* DeleteAccountViewModel.swift in Sources */,
 				45AE975327C97A9500C2CB33 /* Tab+MobileContentRenderableModel.swift in Sources */,
 				45428A7B26712A3A0022A66D /* FirebaseAnalytics+MobileContentAnalyticsSystem.swift in Sources */,
 				455583CD269F2DA500C3FF14 /* MobileContentPageView.swift in Sources */,
@@ -7910,7 +7926,7 @@
 				45C93AFA261D310900592FFF /* RealmCategoryArticlesCache.swift in Sources */,
 				455583D3269F2DA500C3FF14 /* MobileContentHeaderView.swift in Sources */,
 				457032A726D0056F00F5BADC /* MobileContentBackgroundImageRendererType.swift in Sources */,
-				45B6482825E593110098BAF1 /* BuildFile in Sources */,
+				45B6482825E593110098BAF1 /* (null) in Sources */,
 				45C93AE2261D310900592FFF /* ArticleAemCacheObject.swift in Sources */,
 				45558327269F2C7B00C3FF14 /* ToolPageCardViewModelType.swift in Sources */,
 				45558415269F2F6100C3FF14 /* MobileContentAnalyticsEvent.swift in Sources */,
@@ -9341,7 +9357,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		459C93A227581B23006207D2 /* XCRemoteSwiftPackageReference "okta-authentication-ios.git" */ = {
+		459C93A227581B23006207D2 /* XCRemoteSwiftPackageReference "okta-authentication-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/CruGlobal/okta-authentication-ios.git";
 			requirement = {
@@ -9349,7 +9365,7 @@
 				minimumVersion = 1.2.0;
 			};
 		};
-		45B248562734676F00B7AD5E /* XCRemoteSwiftPackageReference "AppsFlyerFramework.git" */ = {
+		45B248562734676F00B7AD5E /* XCRemoteSwiftPackageReference "AppsFlyerFramework" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/AppsFlyerSDK/AppsFlyerFramework.git";
 			requirement = {
@@ -9357,7 +9373,7 @@
 				minimumVersion = 6.4.0;
 			};
 		};
-		45CDFB4B281730FA00AC4F2E /* XCRemoteSwiftPackageReference "google-tag-manager-ios-sdk.git" */ = {
+		45CDFB4B281730FA00AC4F2E /* XCRemoteSwiftPackageReference "google-tag-manager-ios-sdk" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/googleanalytics/google-tag-manager-ios-sdk.git";
 			requirement = {
@@ -9365,7 +9381,7 @@
 				minimumVersion = 7.4.0;
 			};
 		};
-		45CDFB4E2817324B00AC4F2E /* XCRemoteSwiftPackageReference "firebase-ios-sdk.git" */ = {
+		45CDFB4E2817324B00AC4F2E /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/firebase/firebase-ios-sdk.git";
 			requirement = {
@@ -9373,7 +9389,7 @@
 				minimumVersion = 8.9.0;
 			};
 		};
-		45CF096E2784B910007F13D3 /* XCRemoteSwiftPackageReference "request-operation-ios.git" */ = {
+		45CF096E2784B910007F13D3 /* XCRemoteSwiftPackageReference "request-operation-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/CruGlobal/request-operation-ios.git";
 			requirement = {
@@ -9381,7 +9397,7 @@
 				minimumVersion = 1.2.0;
 			};
 		};
-		45E39EDA27457E0C006A59E4 /* XCRemoteSwiftPackageReference "lottie-ios.git" */ = {
+		45E39EDA27457E0C006A59E4 /* XCRemoteSwiftPackageReference "lottie-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/airbnb/lottie-ios.git";
 			requirement = {
@@ -9389,7 +9405,7 @@
 				minimumVersion = 3.2.0;
 			};
 		};
-		45EDBCEE27359CD70099495B /* XCRemoteSwiftPackageReference "realm-cocoa.git" */ = {
+		45EDBCEE27359CD70099495B /* XCRemoteSwiftPackageReference "realm-cocoa" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/realm/realm-cocoa.git";
 			requirement = {
@@ -9402,52 +9418,52 @@
 /* Begin XCSwiftPackageProductDependency section */
 		459C93A327581B23006207D2 /* OktaAuthentication */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 459C93A227581B23006207D2 /* XCRemoteSwiftPackageReference "okta-authentication-ios.git" */;
+			package = 459C93A227581B23006207D2 /* XCRemoteSwiftPackageReference "okta-authentication-ios" */;
 			productName = OktaAuthentication;
 		};
 		45B248572734676F00B7AD5E /* AppsFlyerLib */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 45B248562734676F00B7AD5E /* XCRemoteSwiftPackageReference "AppsFlyerFramework.git" */;
+			package = 45B248562734676F00B7AD5E /* XCRemoteSwiftPackageReference "AppsFlyerFramework" */;
 			productName = AppsFlyerLib;
 		};
 		45CDFB4C281730FA00AC4F2E /* GoogleTagManager */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 45CDFB4B281730FA00AC4F2E /* XCRemoteSwiftPackageReference "google-tag-manager-ios-sdk.git" */;
+			package = 45CDFB4B281730FA00AC4F2E /* XCRemoteSwiftPackageReference "google-tag-manager-ios-sdk" */;
 			productName = GoogleTagManager;
 		};
 		45CDFB4F2817324B00AC4F2E /* FirebaseAnalytics */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 45CDFB4E2817324B00AC4F2E /* XCRemoteSwiftPackageReference "firebase-ios-sdk.git" */;
+			package = 45CDFB4E2817324B00AC4F2E /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseAnalytics;
 		};
 		45CDFB512817324B00AC4F2E /* FirebaseCrashlytics */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 45CDFB4E2817324B00AC4F2E /* XCRemoteSwiftPackageReference "firebase-ios-sdk.git" */;
+			package = 45CDFB4E2817324B00AC4F2E /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseCrashlytics;
 		};
 		45CDFB5528173FE400AC4F2E /* FirebaseInAppMessaging-Beta */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 45CDFB4E2817324B00AC4F2E /* XCRemoteSwiftPackageReference "firebase-ios-sdk.git" */;
+			package = 45CDFB4E2817324B00AC4F2E /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = "FirebaseInAppMessaging-Beta";
 		};
 		45CF096F2784B910007F13D3 /* RequestOperation */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 45CF096E2784B910007F13D3 /* XCRemoteSwiftPackageReference "request-operation-ios.git" */;
+			package = 45CF096E2784B910007F13D3 /* XCRemoteSwiftPackageReference "request-operation-ios" */;
 			productName = RequestOperation;
 		};
 		45E39EDB27457E0C006A59E4 /* Lottie */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 45E39EDA27457E0C006A59E4 /* XCRemoteSwiftPackageReference "lottie-ios.git" */;
+			package = 45E39EDA27457E0C006A59E4 /* XCRemoteSwiftPackageReference "lottie-ios" */;
 			productName = Lottie;
 		};
 		45EDBCEF27359CD70099495B /* Realm */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 45EDBCEE27359CD70099495B /* XCRemoteSwiftPackageReference "realm-cocoa.git" */;
+			package = 45EDBCEE27359CD70099495B /* XCRemoteSwiftPackageReference "realm-cocoa" */;
 			productName = Realm;
 		};
 		45EDBCF127359CD70099495B /* RealmSwift */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 45EDBCEE27359CD70099495B /* XCRemoteSwiftPackageReference "realm-cocoa.git" */;
+			package = 45EDBCEE27359CD70099495B /* XCRemoteSwiftPackageReference "realm-cocoa" */;
 			productName = RealmSwift;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -82,6 +82,7 @@
 		4511D24B286CBA0100276174 /* LanguageSupportedText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4511D24A286CBA0100276174 /* LanguageSupportedText.swift */; };
 		45127A24287C994D00CC21C4 /* DeleteAccountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45127A23287C994D00CC21C4 /* DeleteAccountView.swift */; };
 		45127A26287C998800CC21C4 /* DeleteAccountViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45127A25287C998800CC21C4 /* DeleteAccountViewModel.swift */; };
+		45127A28287C9C4300CC21C4 /* DeleteAccountHostingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45127A27287C9C4300CC21C4 /* DeleteAccountHostingView.swift */; };
 		4513C2E8270467F400614F79 /* SetupParallelLanguageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4513C2E7270467F400614F79 /* SetupParallelLanguageView.swift */; };
 		4513C2EA2704681300614F79 /* SetupParallelLanguageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4513C2E92704681300614F79 /* SetupParallelLanguageViewModel.swift */; };
 		4513C2EC2704681F00614F79 /* SetupParallelLanguageViewModelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4513C2EB2704681F00614F79 /* SetupParallelLanguageViewModelType.swift */; };
@@ -1218,6 +1219,7 @@
 		4511D24A286CBA0100276174 /* LanguageSupportedText.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LanguageSupportedText.swift; sourceTree = "<group>"; };
 		45127A23287C994D00CC21C4 /* DeleteAccountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteAccountView.swift; sourceTree = "<group>"; };
 		45127A25287C998800CC21C4 /* DeleteAccountViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteAccountViewModel.swift; sourceTree = "<group>"; };
+		45127A27287C9C4300CC21C4 /* DeleteAccountHostingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteAccountHostingView.swift; sourceTree = "<group>"; };
 		4513C2E7270467F400614F79 /* SetupParallelLanguageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetupParallelLanguageView.swift; sourceTree = "<group>"; };
 		4513C2E92704681300614F79 /* SetupParallelLanguageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetupParallelLanguageViewModel.swift; sourceTree = "<group>"; };
 		4513C2EB2704681F00614F79 /* SetupParallelLanguageViewModelType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetupParallelLanguageViewModelType.swift; sourceTree = "<group>"; };
@@ -2666,6 +2668,7 @@
 		45127A22287C994400CC21C4 /* DeleteAccount */ = {
 			isa = PBXGroup;
 			children = (
+				45127A27287C9C4300CC21C4 /* DeleteAccountHostingView.swift */,
 				45127A23287C994D00CC21C4 /* DeleteAccountView.swift */,
 				45127A25287C998800CC21C4 /* DeleteAccountViewModel.swift */,
 			);
@@ -7935,6 +7938,7 @@
 				45AD202B25938A9800A096A0 /* CardJumpUserDefaultsCache.swift in Sources */,
 				451A175D2757B1FF00D35D78 /* MenuDataSource.swift in Sources */,
 				45558402269F2DA500C3FF14 /* MobileContentBackgroundImageView.swift in Sources */,
+				45127A28287C9C4300CC21C4 /* DeleteAccountHostingView.swift in Sources */,
 				D47C49E02816EEBD0084F4DE /* MockFlowDelegate.swift in Sources */,
 				45051205275AA7050081BF56 /* MobileContentParagraphView.swift in Sources */,
 				4515E9BF284FD2A600D3D197 /* MobileContentRendererNavigationDeepLinkType.swift in Sources */,

--- a/godtools/App/Features/Mail/MailView.swift
+++ b/godtools/App/Features/Mail/MailView.swift
@@ -32,19 +32,16 @@ class MailView: UIViewController {
         super.viewDidLoad()
         print("view didload: \(type(of: self))")
         
-        if viewModel.canSendViaMailApp {
-            
-            mailComposeViewController.setToRecipients(viewModel.toRecipients)
-            mailComposeViewController.setSubject(viewModel.subject)
-            mailComposeViewController.setMessageBody(viewModel.message, isHTML: viewModel.isHtml)
-            mailComposeViewController.mailComposeDelegate = self
-            
-            addChild(mailComposeViewController)
-            view.addSubview(mailComposeViewController.view)
-            mailComposeViewController.didMove(toParent: self)
-            
-            mailComposeViewController.view.frame = view.bounds
-        }
+        mailComposeViewController.setToRecipients(viewModel.toRecipients)
+        mailComposeViewController.setSubject(viewModel.subject)
+        mailComposeViewController.setMessageBody(viewModel.message, isHTML: viewModel.isHtml)
+        mailComposeViewController.mailComposeDelegate = self
+        
+        addChild(mailComposeViewController)
+        view.addSubview(mailComposeViewController.view)
+        mailComposeViewController.didMove(toParent: self)
+        
+        mailComposeViewController.view.frame = view.bounds
     }
 }
 

--- a/godtools/App/Features/Mail/MailViewModel.swift
+++ b/godtools/App/Features/Mail/MailViewModel.swift
@@ -17,14 +17,12 @@ class MailViewModel: MailViewModelType {
     let subject: String
     let message: String
     let isHtml: Bool
-    let canSendViaMailApp: Bool
     
     required init(toRecipients: [String], subject: String, message: String, isHtml: Bool, finishedSendingMailHandler: CallbackHandler) {
         self.toRecipients = toRecipients
         self.subject = subject
         self.message = message
         self.isHtml = isHtml
-        self.canSendViaMailApp = MFMailComposeViewController.canSendMail()
         self.finishedSendingMailHandler = finishedSendingMailHandler
     }
     

--- a/godtools/App/Features/Mail/MailViewModelType.swift
+++ b/godtools/App/Features/Mail/MailViewModelType.swift
@@ -15,7 +15,6 @@ protocol MailViewModelType {
     var subject: String { get }
     var message: String { get }
     var isHtml: Bool { get }
-    var canSendViaMailApp: Bool { get }
     
     func finishedSendingMail(result: MFMailComposeResult, error: Error?)
 }

--- a/godtools/App/Features/Menu/Presentation/DeleteAccount/DeleteAccountHostingView.swift
+++ b/godtools/App/Features/Menu/Presentation/DeleteAccount/DeleteAccountHostingView.swift
@@ -26,6 +26,8 @@ class DeleteAccountHostingView: UIHostingController<DeleteAccountView> {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+    
+        title = viewModel.navTitle
         
         _ = addDefaultNavBackItem(target: self, action: #selector(navigationBackButtonTapped))
     }

--- a/godtools/App/Features/Menu/Presentation/DeleteAccount/DeleteAccountHostingView.swift
+++ b/godtools/App/Features/Menu/Presentation/DeleteAccount/DeleteAccountHostingView.swift
@@ -1,0 +1,37 @@
+//
+//  DeleteAccountHostingView.swift
+//  godtools
+//
+//  Created by Levi Eggert on 7/11/22.
+//  Copyright © 2022 Cru. All rights reserved.
+//
+
+import UIKit
+import SwiftUI
+
+class DeleteAccountHostingView: UIHostingController<DeleteAccountView> {
+    
+    private let viewModel: DeleteAccountViewModel
+    
+    init(view: DeleteAccountView) {
+        
+        self.viewModel = view.viewModel
+        
+        super.init(rootView: view)
+    }
+    
+    @MainActor required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        _ = addDefaultNavBackItem(target: self, action: #selector(navigationBackButtonTapped))
+    }
+    
+    @objc private func navigationBackButtonTapped() {
+
+        viewModel.backTapped()
+    }
+}

--- a/godtools/App/Features/Menu/Presentation/DeleteAccount/DeleteAccountView.swift
+++ b/godtools/App/Features/Menu/Presentation/DeleteAccount/DeleteAccountView.swift
@@ -10,12 +10,28 @@ import SwiftUI
 
 struct DeleteAccountView: View {
     
+    private let contentInsets: EdgeInsets = EdgeInsets(top: 0, leading: 30, bottom: 0, trailing: 30)
+    
     @ObservedObject var viewModel: DeleteAccountViewModel
     
     var body: some View {
         
-        VStack{
+        GeometryReader { geometry in
             
+            VStack{
+                
+                TextWithLinks(
+                    text: viewModel.deleteOktaAccountInstructions,
+                    textColor: ColorPalette.gtGrey.uiColor,
+                    font: FontLibrary.sfProTextRegular.uiFont(size: 18),
+                    lineSpacing: 2,
+                    width: geometry.size.width,
+                    didInteractWithUrlClosure: { (url: URL) in
+                        
+                        print("did interact with url: \(url.absoluteString)")
+                    }
+                )
+            }
         }
     }
 }
@@ -24,8 +40,11 @@ struct DeleteAccountView_Preview: PreviewProvider {
     
     static var previews: some View {
         
+        let appDiContainer: AppDiContainer = SwiftUIPreviewDiContainer().getAppDiContainer()
+        
         let viewModel = DeleteAccountViewModel(
-            flowDelegate: MockFlowDelegate()
+            flowDelegate: MockFlowDelegate(),
+            localizationServices: appDiContainer.localizationServices
         )
         
         return DeleteAccountView(viewModel: viewModel)

--- a/godtools/App/Features/Menu/Presentation/DeleteAccount/DeleteAccountView.swift
+++ b/godtools/App/Features/Menu/Presentation/DeleteAccount/DeleteAccountView.swift
@@ -1,0 +1,31 @@
+//
+//  DeleteAccountView.swift
+//  godtools
+//
+//  Created by Levi Eggert on 7/11/22.
+//  Copyright © 2022 Cru. All rights reserved.
+//
+
+import SwiftUI
+
+struct DeleteAccountView: View {
+    
+    @ObservedObject var viewModel: DeleteAccountViewModel
+    
+    var body: some View {
+        
+        VStack{
+            
+        }
+    }
+}
+
+struct DeleteAccountView_Preview: PreviewProvider {
+    
+    static var previews: some View {
+        
+        let viewModel = DeleteAccountViewModel()
+        
+        return DeleteAccountView(viewModel: viewModel)
+    }
+}

--- a/godtools/App/Features/Menu/Presentation/DeleteAccount/DeleteAccountView.swift
+++ b/godtools/App/Features/Menu/Presentation/DeleteAccount/DeleteAccountView.swift
@@ -32,7 +32,9 @@ struct DeleteAccountView: View {
                     width: geometry.size.width - contentInsets.leading - contentInsets.trailing,
                     didInteractWithUrlClosure: { (url: URL) in
                         
-                        print("did interact with url: \(url.absoluteString)")
+                        viewModel.emailHelpDeskToDeleteOktaAccountTapped()
+                        
+                        return false
                     }
                 )
             }

--- a/godtools/App/Features/Menu/Presentation/DeleteAccount/DeleteAccountView.swift
+++ b/godtools/App/Features/Menu/Presentation/DeleteAccount/DeleteAccountView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 
 struct DeleteAccountView: View {
     
-    private let contentInsets: EdgeInsets = EdgeInsets(top: 0, leading: 30, bottom: 0, trailing: 30)
+    private let contentInsets: EdgeInsets = EdgeInsets(top: 40, leading: 30, bottom: 0, trailing: 30)
     
     @ObservedObject var viewModel: DeleteAccountViewModel
     
@@ -18,20 +18,25 @@ struct DeleteAccountView: View {
         
         GeometryReader { geometry in
             
-            VStack{
+            VStack(alignment: .leading, spacing: 0) {
+                
+                Rectangle()
+                    .frame(height: contentInsets.top)
+                    .foregroundColor(.clear)
                 
                 TextWithLinks(
                     text: viewModel.deleteOktaAccountInstructions,
                     textColor: ColorPalette.gtGrey.uiColor,
                     font: FontLibrary.sfProTextRegular.uiFont(size: 18),
                     lineSpacing: 2,
-                    width: geometry.size.width,
+                    width: geometry.size.width - contentInsets.leading - contentInsets.trailing,
                     didInteractWithUrlClosure: { (url: URL) in
                         
                         print("did interact with url: \(url.absoluteString)")
                     }
                 )
             }
+            .padding(EdgeInsets(top: 0, leading: contentInsets.leading, bottom: 0, trailing: contentInsets.trailing))
         }
     }
 }

--- a/godtools/App/Features/Menu/Presentation/DeleteAccount/DeleteAccountView.swift
+++ b/godtools/App/Features/Menu/Presentation/DeleteAccount/DeleteAccountView.swift
@@ -24,7 +24,9 @@ struct DeleteAccountView_Preview: PreviewProvider {
     
     static var previews: some View {
         
-        let viewModel = DeleteAccountViewModel()
+        let viewModel = DeleteAccountViewModel(
+            flowDelegate: MockFlowDelegate()
+        )
         
         return DeleteAccountView(viewModel: viewModel)
     }

--- a/godtools/App/Features/Menu/Presentation/DeleteAccount/DeleteAccountViewModel.swift
+++ b/godtools/App/Features/Menu/Presentation/DeleteAccount/DeleteAccountViewModel.swift
@@ -9,9 +9,12 @@
 import Foundation
 
 class DeleteAccountViewModel: ObservableObject {
-    
-    init() {
         
+    private weak var flowDelegate: FlowDelegate?
+    
+    init(flowDelegate: FlowDelegate) {
+        
+        self.flowDelegate = flowDelegate
     }
 }
 
@@ -19,4 +22,8 @@ class DeleteAccountViewModel: ObservableObject {
 
 extension DeleteAccountViewModel {
     
+    func backTapped() {
+        
+        flowDelegate?.navigate(step: .backTappedFromDeleteAccount)
+    }
 }

--- a/godtools/App/Features/Menu/Presentation/DeleteAccount/DeleteAccountViewModel.swift
+++ b/godtools/App/Features/Menu/Presentation/DeleteAccount/DeleteAccountViewModel.swift
@@ -12,9 +12,13 @@ class DeleteAccountViewModel: ObservableObject {
         
     private weak var flowDelegate: FlowDelegate?
     
-    init(flowDelegate: FlowDelegate) {
+    @Published var deleteOktaAccountInstructions: String = ""
+    
+    init(flowDelegate: FlowDelegate, localizationServices: LocalizationServices) {
         
         self.flowDelegate = flowDelegate
+        
+        deleteOktaAccountInstructions = localizationServices.stringForMainBundle(key: "deleteAccount.deleteOktaAccountInstructions")
     }
 }
 

--- a/godtools/App/Features/Menu/Presentation/DeleteAccount/DeleteAccountViewModel.swift
+++ b/godtools/App/Features/Menu/Presentation/DeleteAccount/DeleteAccountViewModel.swift
@@ -12,12 +12,14 @@ class DeleteAccountViewModel: ObservableObject {
         
     private weak var flowDelegate: FlowDelegate?
     
+    @Published var navTitle: String = ""
     @Published var deleteOktaAccountInstructions: String = ""
     
     init(flowDelegate: FlowDelegate, localizationServices: LocalizationServices) {
         
         self.flowDelegate = flowDelegate
         
+        navTitle = localizationServices.stringForMainBundle(key: "deleteAccount.navTitle")
         deleteOktaAccountInstructions = localizationServices.stringForMainBundle(key: "deleteAccount.deleteOktaAccountInstructions")
     }
 }

--- a/godtools/App/Features/Menu/Presentation/DeleteAccount/DeleteAccountViewModel.swift
+++ b/godtools/App/Features/Menu/Presentation/DeleteAccount/DeleteAccountViewModel.swift
@@ -1,0 +1,22 @@
+//
+//  DeleteAccountViewModel.swift
+//  godtools
+//
+//  Created by Levi Eggert on 7/11/22.
+//  Copyright © 2022 Cru. All rights reserved.
+//
+
+import Foundation
+
+class DeleteAccountViewModel: ObservableObject {
+    
+    init() {
+        
+    }
+}
+
+// MARK: - Inputs
+
+extension DeleteAccountViewModel {
+    
+}

--- a/godtools/App/Features/Menu/Presentation/DeleteAccount/DeleteAccountViewModel.swift
+++ b/godtools/App/Features/Menu/Presentation/DeleteAccount/DeleteAccountViewModel.swift
@@ -32,4 +32,9 @@ extension DeleteAccountViewModel {
         
         flowDelegate?.navigate(step: .backTappedFromDeleteAccount)
     }
+    
+    func emailHelpDeskToDeleteOktaAccountTapped() {
+        
+        flowDelegate?.navigate(step: .emailHelpDeskToDeleteOktaAccountTappedFromDeleteAccount)
+    }
 }

--- a/godtools/App/Features/Menu/Presentation/Menu/MenuDataSource/MenuItem.swift
+++ b/godtools/App/Features/Menu/Presentation/Menu/MenuDataSource/MenuItem.swift
@@ -14,6 +14,7 @@ enum MenuItem {
     case about
     case help
     case contactUs
+    case deleteAccount
     case logout
     case login
     case createAccount

--- a/godtools/App/Features/Menu/Presentation/Menu/MenuView.swift
+++ b/godtools/App/Features/Menu/Presentation/Menu/MenuView.swift
@@ -146,6 +146,9 @@ extension MenuView: UITableViewDelegate {
         
         case .contactUs:
             viewModel.contactUsTapped()
+            
+        case .deleteAccount:
+            viewModel.deleteAccountTapped()
         
         case .logout:
             viewModel.logoutTapped(fromViewController: self)

--- a/godtools/App/Features/Menu/Presentation/Menu/MenuViewModel.swift
+++ b/godtools/App/Features/Menu/Presentation/Menu/MenuViewModel.swift
@@ -248,7 +248,7 @@ extension MenuViewModel {
     }
     
     func deleteAccountTapped() {
-        
+        flowDelegate?.navigate(step: .deleteAccountTappedFromMenu)
     }
 }
 

--- a/godtools/App/Features/Menu/Presentation/Menu/MenuViewModel.swift
+++ b/godtools/App/Features/Menu/Presentation/Menu/MenuViewModel.swift
@@ -123,10 +123,10 @@ class MenuViewModel: NSObject, MenuViewModelType {
             case .account:
                 
                 if isAuthorized {
-                    items = [.myAccount, .logout]
+                    items = [.myAccount, .logout, .deleteAccount]
                 }
                 else {
-                    items = [.createAccount, .login]
+                    items = [.createAccount, .login, .deleteAccount]
                 }
                 
             case .share:
@@ -246,6 +246,10 @@ extension MenuViewModel {
     func copyrightInfoTapped() {
         flowDelegate?.navigate(step: .copyrightInfoTappedFromMenu)
     }
+    
+    func deleteAccountTapped() {
+        
+    }
 }
 
 extension MenuViewModel {
@@ -292,6 +296,9 @@ extension MenuViewModel {
             
         case .contactUs:
             localizedKey = "contact_us"
+            
+        case .deleteAccount:
+            localizedKey = "menu.deleteAccount"
             
         case .logout:
             localizedKey = "logout"

--- a/godtools/App/Features/Menu/Presentation/Menu/MenuViewModelType.swift
+++ b/godtools/App/Features/Menu/Presentation/Menu/MenuViewModelType.swift
@@ -32,4 +32,5 @@ protocol MenuViewModelType {
     func termsOfUseTapped()
     func privacyPolicyTapped()
     func copyrightInfoTapped()
+    func deleteAccountTapped()
 }

--- a/godtools/App/Features/ToolDetails/Subviews/ToolDetailsAboutView.swift
+++ b/godtools/App/Features/ToolDetails/Subviews/ToolDetailsAboutView.swift
@@ -26,6 +26,7 @@ struct ToolDetailsAboutView: View {
                 width: width,
                 didInteractWithUrlClosure: { (url: URL) in
                     viewModel.urlTapped(url: url)
+                    return true
                 }
             )
             

--- a/godtools/App/Flows/Flow+PresentNativeMailApp.swift
+++ b/godtools/App/Flows/Flow+PresentNativeMailApp.swift
@@ -14,8 +14,20 @@ extension Flow {
     func navigateToNativeMailApp(viewModel: MailViewModelType) {
         
         guard MFMailComposeViewController.canSendMail() else {
+                        
+            let localizationServices: LocalizationServices = appDiContainer.localizationServices
             
-            // TODO: Present alert that native Mail app is not configured or available on the device. ~Levi
+            let viewModel = AlertMessageViewModel(
+                title: localizationServices.stringForMainBundle(key: "alert.mailAppUnavailable.title"),
+                message: localizationServices.stringForMainBundle(key: "alert.mailAppUnavailable.message"),
+                cancelTitle: nil,
+                acceptTitle: localizationServices.stringForMainBundle(key: "OK"),
+                acceptHandler: nil
+            )
+            
+            let view = AlertMessageView(viewModel: viewModel)
+            
+            navigationController.present(view.controller, animated: true)
             
             return
         }

--- a/godtools/App/Flows/Flow+PresentNativeMailApp.swift
+++ b/godtools/App/Flows/Flow+PresentNativeMailApp.swift
@@ -1,0 +1,28 @@
+//
+//  Flow+PresentNativeMailApp.swift
+//  godtools
+//
+//  Created by Levi Eggert on 7/11/22.
+//  Copyright © 2022 Cru. All rights reserved.
+//
+
+import Foundation
+import MessageUI
+
+extension Flow {
+    
+    func navigateToNativeMailApp(viewModel: MailViewModelType) {
+        
+        guard MFMailComposeViewController.canSendMail() else {
+            
+            // TODO: Present alert that native Mail app is not configured or available on the device. ~Levi
+            
+            return
+        }
+        
+        let view = MailView(viewModel: viewModel)
+        
+        navigationController.present(view, animated: true)
+    }
+}
+

--- a/godtools/App/Flows/FlowStep.swift
+++ b/godtools/App/Flows/FlowStep.swift
@@ -101,6 +101,7 @@ enum FlowStep {
     case termsOfUseTappedFromMenu
     case privacyPolicyTappedFromMenu
     case copyrightInfoTappedFromMenu
+    case deleteAccountTappedFromMenu
     
     // language settings
     case choosePrimaryLanguageTappedFromLanguageSettings

--- a/godtools/App/Flows/FlowStep.swift
+++ b/godtools/App/Flows/FlowStep.swift
@@ -103,6 +103,9 @@ enum FlowStep {
     case copyrightInfoTappedFromMenu
     case deleteAccountTappedFromMenu
     
+    // delete account
+    case backTappedFromDeleteAccount
+    
     // language settings
     case choosePrimaryLanguageTappedFromLanguageSettings
     case chooseParallelLanguageTappedFromLanguageSettings

--- a/godtools/App/Flows/FlowStep.swift
+++ b/godtools/App/Flows/FlowStep.swift
@@ -105,6 +105,7 @@ enum FlowStep {
     
     // delete account
     case backTappedFromDeleteAccount
+    case emailHelpDeskToDeleteOktaAccountTappedFromDeleteAccount
     
     // language settings
     case choosePrimaryLanguageTappedFromLanguageSettings

--- a/godtools/App/Flows/Menu/MenuFlow.swift
+++ b/godtools/App/Flows/Menu/MenuFlow.swift
@@ -221,7 +221,7 @@ class MenuFlow: Flow {
             let viewModel = MailViewModel(
                 toRecipients: ["help@cru.org"],
                 subject: "Please delete my account",
-                message: "I have created an account on the GodToolsapp and I would like to request that you delete my Okta account.",
+                message: "I have created an account on the GodTools app and I would like to request that you delete my Okta account.",
                 isHtml: false,
                 finishedSendingMailHandler: finishedSendingMail
             )

--- a/godtools/App/Flows/Menu/MenuFlow.swift
+++ b/godtools/App/Flows/Menu/MenuFlow.swift
@@ -217,7 +217,22 @@ class MenuFlow: Flow {
             navigationController.popViewController(animated: true)
             
         case .emailHelpDeskToDeleteOktaAccountTappedFromDeleteAccount:
-            break
+            
+            let finishedSendingMail = CallbackHandler { [weak self] in
+                self?.navigationController.dismiss(animated: true, completion: nil)
+            }
+            
+            let viewModel = MailViewModel(
+                toRecipients: ["help@cru.org"],
+                subject: "Please delete my account",
+                message: "I have created an account on the GodToolsapp and I would like to request that you delete my Okta account.",
+                isHtml: false,
+                finishedSendingMailHandler: finishedSendingMail
+            )
+            
+            let view = MailView(viewModel: viewModel)
+            
+            navigationController.present(view, animated: true)
                         
         default:
             break

--- a/godtools/App/Flows/Menu/MenuFlow.swift
+++ b/godtools/App/Flows/Menu/MenuFlow.swift
@@ -202,7 +202,8 @@ class MenuFlow: Flow {
         case .deleteAccountTappedFromMenu:
             
             let viewModel = DeleteAccountViewModel(
-                flowDelegate: self
+                flowDelegate: self,
+                localizationServices: appDiContainer.localizationServices
             )
             
             let view = DeleteAccountView(viewModel: viewModel)

--- a/godtools/App/Flows/Menu/MenuFlow.swift
+++ b/godtools/App/Flows/Menu/MenuFlow.swift
@@ -201,13 +201,19 @@ class MenuFlow: Flow {
             
         case .deleteAccountTappedFromMenu:
             
-            let viewModel = DeleteAccountViewModel()
+            let viewModel = DeleteAccountViewModel(
+                flowDelegate: self
+            )
             
             let view = DeleteAccountView(viewModel: viewModel)
             
-            let hostingView: UIHostingController<DeleteAccountView> = UIHostingController(rootView: view)
-            
+            let hostingView = DeleteAccountHostingView(view: view)
+                        
             navigationController.pushViewController(hostingView, animated: true)
+            
+        case .backTappedFromDeleteAccount:
+            
+            navigationController.popViewController(animated: true)
                         
         default:
             break

--- a/godtools/App/Flows/Menu/MenuFlow.swift
+++ b/godtools/App/Flows/Menu/MenuFlow.swift
@@ -215,6 +215,9 @@ class MenuFlow: Flow {
         case .backTappedFromDeleteAccount:
             
             navigationController.popViewController(animated: true)
+            
+        case .emailHelpDeskToDeleteOktaAccountTappedFromDeleteAccount:
+            break
                         
         default:
             break

--- a/godtools/App/Flows/Menu/MenuFlow.swift
+++ b/godtools/App/Flows/Menu/MenuFlow.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 import MessageUI
+import SwiftUI
 
 class MenuFlow: Flow {
     
@@ -197,6 +198,16 @@ class MenuFlow: Flow {
             let copyrightInfoWebContent = CopyrightInfoWebContent(localizationServices: appDiContainer.localizationServices)
             
             navigateToWebContentView(webContent: copyrightInfoWebContent)
+            
+        case .deleteAccountTappedFromMenu:
+            
+            let viewModel = DeleteAccountViewModel()
+            
+            let view = DeleteAccountView(viewModel: viewModel)
+            
+            let hostingView: UIHostingController<DeleteAccountView> = UIHostingController(rootView: view)
+            
+            navigationController.pushViewController(hostingView, animated: true)
                         
         default:
             break

--- a/godtools/App/Flows/Menu/MenuFlow.swift
+++ b/godtools/App/Flows/Menu/MenuFlow.swift
@@ -138,9 +138,7 @@ class MenuFlow: Flow {
                     finishedSendingMailHandler: finishedSendingMail
                 )
                 
-                let view = MailView(viewModel: viewModel)
-                
-                navigationController.present(view, animated: true, completion: nil)
+                navigateToNativeMailApp(viewModel: viewModel)
             }
             else {
                 let contactUsWebContent = ContactUsWebContent(localizationServices: appDiContainer.localizationServices)
@@ -170,9 +168,7 @@ class MenuFlow: Flow {
                     finishedSendingMailHandler: finishedSendingMail
                 )
                 
-                let view = MailView(viewModel: viewModel)
-                
-                navigationController.present(view, animated: true, completion: nil)
+                navigateToNativeMailApp(viewModel: viewModel)                
             }
             else {
                 
@@ -230,9 +226,7 @@ class MenuFlow: Flow {
                 finishedSendingMailHandler: finishedSendingMail
             )
             
-            let view = MailView(viewModel: viewModel)
-            
-            navigationController.present(view, animated: true)
+            navigateToNativeMailApp(viewModel: viewModel)
                         
         default:
             break

--- a/godtools/App/Share/SwiftUI Views/TextWithLinks/TextViewLinksCoordinator.swift
+++ b/godtools/App/Share/SwiftUI Views/TextWithLinks/TextViewLinksCoordinator.swift
@@ -11,9 +11,9 @@ import UIKit
 class TextViewLinksCoordinator: NSObject, UITextViewDelegate {
     
     private let textWithLinks: TextWithLinks
-    private let didInteractWithUrlClosure: ((_ url: URL) -> Void)
+    private let didInteractWithUrlClosure: ((_ url: URL) -> Bool)
     
-    init(textWithLinks: TextWithLinks, didInteractWithUrlClosure: @escaping ((_ url: URL) -> Void)) {
+    init(textWithLinks: TextWithLinks, didInteractWithUrlClosure: @escaping ((_ url: URL) -> Bool)) {
         
         self.textWithLinks = textWithLinks
         self.didInteractWithUrlClosure = didInteractWithUrlClosure
@@ -23,8 +23,6 @@ class TextViewLinksCoordinator: NSObject, UITextViewDelegate {
     
     func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
                 
-        didInteractWithUrlClosure(URL)
-        
-        return true
+        return didInteractWithUrlClosure(URL)
     }
 }

--- a/godtools/App/Share/SwiftUI Views/TextWithLinks/TextWithLinks.swift
+++ b/godtools/App/Share/SwiftUI Views/TextWithLinks/TextWithLinks.swift
@@ -17,9 +17,9 @@ struct TextWithLinks: UIViewRepresentable {
     private let lineSpacing: CGFloat?
     private let width: CGFloat
     private let linkTextColor: UIColor
-    private let didInteractWithUrlClosure: ((_ url: URL) -> Void)
+    private let didInteractWithUrlClosure: ((_ url: URL) -> Bool)
         
-    init(text: String, textColor: UIColor, font: UIFont?, lineSpacing: CGFloat?, width: CGFloat, linkTextColor: UIColor = .systemBlue, didInteractWithUrlClosure: @escaping ((_ url: URL) -> Void)) {
+    init(text: String, textColor: UIColor, font: UIFont?, lineSpacing: CGFloat?, width: CGFloat, linkTextColor: UIColor = .systemBlue, didInteractWithUrlClosure: @escaping ((_ url: URL) -> Bool)) {
         
         self.text = text
         self.textColor = textColor

--- a/godtools/Base.lproj/Localizable.strings
+++ b/godtools/Base.lproj/Localizable.strings
@@ -335,3 +335,6 @@ Press the About button on any tool for more info.";
 "onboardingTutorial.appUsageItem.3.message" = "Choose from over 90 languages";
 "onboardingTutorial.appUsageItem.4.message" = "Help someone get started as a Christian";
 "onboardingTutorial.showMoreButton.title" = "Show Me More";
+
+// DeleteAccount
+"deleteAccount.deleteOktaAccountInstructions" = "If you have created an account on the GodTools app you can request to delete your Okta account at help@cru.org";

--- a/godtools/Base.lproj/Localizable.strings
+++ b/godtools/Base.lproj/Localizable.strings
@@ -337,4 +337,5 @@ Press the About button on any tool for more info.";
 "onboardingTutorial.showMoreButton.title" = "Show Me More";
 
 // DeleteAccount
+"deleteAccount.navTitle" = "Delete Account";
 "deleteAccount.deleteOktaAccountInstructions" = "If you have created an account on the GodTools app you can request to delete your Okta account at help@cru.org";

--- a/godtools/Base.lproj/Localizable.strings
+++ b/godtools/Base.lproj/Localizable.strings
@@ -193,6 +193,7 @@ If you don't receive this message until later, the link may not still work. We c
 "language_settings" = "Language Settings";
 "menu.tutorial" = "Tutorial";
 "menu.my_account" = "My Account";
+"menu.deleteAccount" = "Delete Account";
 
 // Login
 "login" = "Login";

--- a/godtools/Base.lproj/Localizable.strings
+++ b/godtools/Base.lproj/Localizable.strings
@@ -265,6 +265,8 @@ The app can be downloaded from https://godtoolsapp.com";
 "OK" = "OK";
 "cancel" = "Cancel";
 "required_field_missing" = "\"%@\" is a required field.";
+"alert.mailAppUnavailable.title" = "Mail App Unavailable";
+"alert.mailAppUnavailable.message" = "The native Mail app is either not configured or is unavailable on this device.";
 
 "onboardingTutorial.getStartedButton.title" = "Get Started";
 


### PR DESCRIPTION
This PR adds an option to the Menu to Delete Account.  Tapping Delete Account will navigate to the DeleteAccountView with instructions on how to make a request to HelpDesk to delete your Okta account.  Tapping the help@cru.org will launch the native mail app (if available) with a prefilled message to send to the Help Desk.

![menu-delete-account](https://user-images.githubusercontent.com/59846460/178347960-7786edaa-dca7-42f6-845e-ef5b3c56ead5.png)

![delete-account-screen](https://user-images.githubusercontent.com/59846460/178347979-b63aaf55-750c-4e90-a27b-db0c8c2e33ba.png)

![delete-account-email](https://user-images.githubusercontent.com/59846460/178348005-e89c5434-2868-4958-907f-9c9d4a5e1539.png)
 