### PR TITLE
GT Increase FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: macos-12
     env:
       DEVELOPER_DIR: /Applications/Xcode_13.4.1.app/Contents/Developer
+      FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: 60
 
     steps:
       

--- a/.github/workflows/download_onesky_translations.yml
+++ b/.github/workflows/download_onesky_translations.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: macos-12
     env:
       DEVELOPER_DIR: /Applications/Xcode_13.4.1.app/Contents/Developer
+      FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: 60
 
     steps:
 


### PR DESCRIPTION
Increasing fastlane build settings timeout to 60 seconds.  Noticed quite often showBuildSettings will fail in GitHub actions after 4 tries.  Will see if increasing the timeout will help.

<img width="1205" alt="xcodebuild-settings-timeout" src="https://user-images.githubusercontent.com/59846460/178371681-c2aacfaa-ae7e-4d23-a5c0-b8bd19cba6bb.png">
