### PR TITLE
GT Removing TODO for meta tool navigation in ToolNavigationFlow

### DIFF
--- a/godtools/App/Flows/ToolNavigation/ToolNavigationFlow.swift
+++ b/godtools/App/Flows/ToolNavigation/ToolNavigationFlow.swift
@@ -158,6 +158,10 @@ extension ToolNavigationFlow {
                 toolTranslations: toolTranslations
             )
             
+        case .metaTool:
+            // NOTE: Navigation is not needed here because MetaTools are not visible in the app (All Tools).
+            break
+            
         case .unknown:
             navigationController.presentAlertMessage(alertMessage: AlertMessage(title: "Internal Error", message: "Attempted to navigate to a tool with an unknown resource type."))
         }

--- a/godtools/App/Flows/ToolNavigation/ToolNavigationFlow.swift
+++ b/godtools/App/Flows/ToolNavigation/ToolNavigationFlow.swift
@@ -158,10 +158,6 @@ extension ToolNavigationFlow {
                 toolTranslations: toolTranslations
             )
             
-        case .metaTool:
-            // TODO: Complete in GT-1418. ~Levi
-            break
-            
         case .unknown:
             navigationController.presentAlertMessage(alertMessage: AlertMessage(title: "Internal Error", message: "Attempted to navigate to a tool with an unknown resource type."))
         }


### PR DESCRIPTION
Removed TODO and left a comment that navigation is not necessary for meta tools.