### PR TITLE
GT-1703 Removed reset method on ToolsMenuView

### DIFF
--- a/godtools/App/Features/Tools/ToolsMenu/ToolsMenuView.swift
+++ b/godtools/App/Features/Tools/ToolsMenu/ToolsMenuView.swift
@@ -117,27 +117,6 @@ class ToolsMenuView: UIViewController {
         viewModel.languageTapped()
     }
     
-    func reset(toolbarItem: ToolsMenuPageType, animated: Bool) {
-        
-        // TODO: Need to implement GT-1545 before Cru22 and before merging iOS 13 branch. ~Levi
-        // https://jira.cru.org/browse/GT-1545
-        
-        guard didLayoutSubviews else {
-            startingPage = toolbarItem
-            return
-        }
-        
-        guard self.view != nil else {
-            return
-        }
-        
-        pages[.lessons]?.scrollToTop(animated: false)
-        pages[.favoritedTools]?.scrollToTop(animated: false)
-        pages[.allTools]?.scrollToTop(animated: false)
-                
-        navigateToPage(pageType: toolbarItem, animated: animated)
-    }
-    
     private func getNewPageViewInstance(pageType: ToolsMenuPageType) -> ToolsMenuPageView {
         
         switch pageType {

--- a/godtools/App/Flows/App/AppFlow.swift
+++ b/godtools/App/Flows/App/AppFlow.swift
@@ -275,13 +275,15 @@ class AppFlow: NSObject, ToolNavigationFlow, Flow {
             }
             
             if state == .userClosedTractToLessonsList {
-                toolsMenuInNavigationStack?.reset(toolbarItem: .lessons, animated: false)
+                
+                navigateToToolsMenu(startingPage: .lessons, animatePopToToolsMenu: true)
             }
-        
-            if let toolsMenuInNavigationStack = toolsMenuInNavigationStack {
+            else if let toolsMenuInNavigationStack = toolsMenuInNavigationStack {
+               
                 navigationController.popToViewController(toolsMenuInNavigationStack, animated: true)
             }
             else {
+                
                 _ = navigationController.popViewController(animated: true)
             }
             
@@ -500,7 +502,7 @@ extension AppFlow {
         return toolsMenuView
     }
     
-    private func navigateToToolsMenu(startingPage: ToolsMenuPageType = AppFlow.defaultStartingToolsMenuPage, animateDismissingPresentedView: Bool = false, didCompleteDismissingPresentedView: (() -> Void)? = nil) {
+    private func navigateToToolsMenu(startingPage: ToolsMenuPageType = AppFlow.defaultStartingToolsMenuPage, animatePopToToolsMenu: Bool = false, animateDismissingPresentedView: Bool = false, didCompleteDismissingPresentedView: (() -> Void)? = nil) {
         
         let toolsMenu: ToolsMenuView = getToolsMenu(startingPage: startingPage)
         
@@ -517,7 +519,7 @@ extension AppFlow {
         tractFlow = nil
         articleFlow = nil
                                 
-        navigationController.popToRootViewController(animated: false)
+        navigationController.popToRootViewController(animated: animatePopToToolsMenu)
         
         navigationController.dismissPresented(
             animated: animateDismissingPresentedView,


### PR DESCRIPTION
Hey @rachaelblue I noticed in your PR for GT-1694 I didn't fully remove the reset method on ToolsMenuView.  This PR finishes that work and there was one additional place this affected was when you are in the Teach Me to Share tool and at the end of the tool you tap the button to Go To Lessons.  When that happens ToolsMenuView is now re-instantiated instead of reset. 