### PR TITLE
GT-1701 fix tool details versions layout bug

### DIFF
--- a/godtools/App/Features/ToolDetails/Subviews/ToolDetailsVersionsView.swift
+++ b/godtools/App/Features/ToolDetails/Subviews/ToolDetailsVersionsView.swift
@@ -10,12 +10,16 @@ import SwiftUI
 
 struct ToolDetailsVersionsView: View {
         
+    private let cardHorizontalInsets: CGFloat = 20
+    private let cardSpacing: CGFloat = 15
+    
     @ObservedObject var viewModel: ToolDetailsViewModel
     
+    let geometry: GeometryProxy
     let toolVersionTappedClosure: (() -> Void)
         
     var body: some View {
-        
+                
         VStack(alignment: .leading, spacing: 0) {
             
             Text(viewModel.versionsMessage)
@@ -24,10 +28,16 @@ struct ToolDetailsVersionsView: View {
                 .padding(EdgeInsets(top: 0, leading: 30, bottom: 10, trailing: 30))
             
             ForEach(viewModel.toolVersions) { toolVersion in
-                                
+                         
+                Rectangle()
+                    .frame(width: geometry.size.width, height: cardSpacing)
+                    .foregroundColor(.clear)
+                
                 ToolDetailsVersionsCardView(
-                    viewModel: viewModel.toolVersionCardWillAppear(toolVersion: toolVersion)
+                    viewModel: viewModel.toolVersionCardWillAppear(toolVersion: toolVersion),
+                    width: geometry.size.width - (cardHorizontalInsets * 2)
                 )
+                .padding(EdgeInsets(top: 0, leading: cardHorizontalInsets, bottom: 0, trailing: cardHorizontalInsets))
                 .onTapGesture {
                     viewModel.toolVersionTapped(toolVersion: toolVersion)
                     toolVersionTappedClosure()

--- a/godtools/App/Features/ToolDetails/Subviews/VersionsCard/ToolDetailsVersionsCardView.swift
+++ b/godtools/App/Features/ToolDetails/Subviews/VersionsCard/ToolDetailsVersionsCardView.swift
@@ -13,6 +13,8 @@ struct ToolDetailsVersionsCardView: View {
     private let bannerHeight: CGFloat = 87
     
     @ObservedObject var viewModel: ToolDetailsVersionsCardViewModel
+    
+    let width: CGFloat
         
     var body: some View {
         
@@ -26,13 +28,13 @@ struct ToolDetailsVersionsCardView: View {
                     bannerImage
                         .resizable()
                         .scaledToFill()
-                        .frame(height: bannerHeight)
+                        .frame(width: width, height: bannerHeight)
                         .clipped()
                 }
                 else {
                     Rectangle()
                         .fill(ColorPalette.gtLightestGrey.color)
-                        .frame(height: bannerHeight)
+                        .frame(width: width, height: bannerHeight)
                 }
                 
                 HStack(alignment: .top, spacing: 0) {
@@ -88,7 +90,6 @@ struct ToolDetailsVersionsCardView: View {
         }
         .cornerRadius(6)
         .shadow(color: Color.black.opacity(0.3), radius: 4, x: 1, y: 1)
-        .padding(EdgeInsets(top: 15, leading: 20, bottom: 0, trailing: 20))
     }
 }
 
@@ -118,6 +119,6 @@ struct ToolDetailsVersionsCardView_Preview: PreviewProvider {
             isSelected: false
         )
         
-        ToolDetailsVersionsCardView(viewModel: viewModel)
+        ToolDetailsVersionsCardView(viewModel: viewModel, width: 320)
     }
 }

--- a/godtools/App/Features/ToolDetails/ToolDetailsView.swift
+++ b/godtools/App/Features/ToolDetails/ToolDetailsView.swift
@@ -58,43 +58,51 @@ struct ToolDetailsView: View {
     @ViewBuilder
     private func getScrollViewContent(geometry: GeometryProxy, contentWidth: CGFloat, toolVersionTappedClosure: @escaping (() -> Void)) -> some View {
         
-       VStack(alignment: .center, spacing: 0) {
-                                    
-            ToolDetailsTitleHeaderView(viewModel: viewModel)
-                .padding(EdgeInsets(top: 40, leading: contentInsets.leading, bottom: 0, trailing: contentInsets.trailing))
-                .id(ToolDetailsView.headerViewId)
+        VStack(alignment: .leading, spacing: 0) {
             
-            ToolDetailsPrimaryButtonsView(viewModel: viewModel, primaryButtonWidth: contentWidth)
-                .padding(EdgeInsets(top: 16, leading: contentInsets.leading, bottom: 0, trailing: contentInsets.trailing))
-                                
-            SegmentControl(selectedIndex: $selectedSegmentIndex, segments: viewModel.segments, segmentTappedClosure: { (index: Int) in
-                
-                viewModel.segmentTapped(index: index)
-            })
-            .padding(EdgeInsets(top: 50, leading: 0, bottom: 0, trailing: 0))
+            VStack(alignment: .center, spacing: 0) {
+                                         
+                 ToolDetailsTitleHeaderView(viewModel: viewModel)
+                     .padding(EdgeInsets(top: 40, leading: contentInsets.leading, bottom: 0, trailing: contentInsets.trailing))
+                     .id(ToolDetailsView.headerViewId)
+                 
+                 ToolDetailsPrimaryButtonsView(viewModel: viewModel, primaryButtonWidth: contentWidth)
+                     .padding(EdgeInsets(top: 16, leading: contentInsets.leading, bottom: 0, trailing: contentInsets.trailing))
+                                     
+                 SegmentControl(selectedIndex: $selectedSegmentIndex, segments: viewModel.segments, segmentTappedClosure: { (index: Int) in
+                     
+                     viewModel.segmentTapped(index: index)
+                 })
+                 .padding(EdgeInsets(top: 50, leading: 0, bottom: 0, trailing: 0))
+             }
+             .background(Rectangle()
+                 .fill(Color.white)
+                 .shadow(color: Color.black.opacity(0.3), radius: 4, x: 0, y: 1)
+             )
+             
+             Rectangle()
+                 .frame(width: geometry.size.width, height: 20)
+                 .foregroundColor(.clear)
+             
+             switch viewModel.selectedSegment {
+             
+             case .about:
+                 ToolDetailsAboutView(viewModel: viewModel, width: contentWidth)
+                     .padding(EdgeInsets(top: 0, leading: contentInsets.leading, bottom: 0, trailing: contentInsets.trailing))
+             
+             case .versions:
+                 ToolDetailsVersionsView(
+                    viewModel: viewModel,
+                    geometry: geometry,
+                    toolVersionTappedClosure: toolVersionTappedClosure
+                 )
+             }
+             
+             Rectangle()
+                 .frame(width: geometry.size.width, height: 20)
+                 .foregroundColor(.clear)
         }
-        .background(Rectangle()
-            .fill(Color.white)
-            .shadow(color: Color.black.opacity(0.3), radius: 4, x: 0, y: 1)
-        )
-        
-        Rectangle()
-            .frame(width: geometry.size.width, height: 20)
-            .foregroundColor(.clear)
-        
-        switch viewModel.selectedSegment {
-        
-        case .about:
-            ToolDetailsAboutView(viewModel: viewModel, width: contentWidth)
-                .padding(EdgeInsets(top: 0, leading: contentInsets.leading, bottom: 0, trailing: contentInsets.trailing))
-        
-        case .versions:
-            ToolDetailsVersionsView(viewModel: viewModel, toolVersionTappedClosure: toolVersionTappedClosure)
-        }
-        
-        Rectangle()
-            .frame(width: geometry.size.width, height: 20)
-            .foregroundColor(.clear)
+        .frame(width: geometry.size.width)
     }
 }
 


### PR DESCRIPTION
Had to force a width on the versions cards for the banner images.  Without it the banner images couldn't resize to anything and was taking the raw image width into account.