### PR TITLE
GT keep translations in database

### DIFF
--- a/godtools/App/Share/Data/LanguagesRepository/Api/Models/LanguageModel.swift
+++ b/godtools/App/Share/Data/LanguagesRepository/Api/Models/LanguageModel.swift
@@ -45,9 +45,9 @@ struct LanguageModel: LanguageModelType, Decodable {
         }
         
         // attributes
-        code = try attributesContainer?.decode(String.self, forKey: .code) ?? ""
-        direction = try attributesContainer?.decode(String.self, forKey: .direction) ?? ""
-        name = try attributesContainer?.decode(String.self, forKey: .name) ?? ""
+        code = try attributesContainer?.decodeIfPresent(String.self, forKey: .code) ?? ""
+        direction = try attributesContainer?.decodeIfPresent(String.self, forKey: .direction) ?? ""
+        name = try attributesContainer?.decodeIfPresent(String.self, forKey: .name) ?? ""
     }
     
     init(model: LanguageModelType) {

--- a/godtools/App/Share/Data/ResourcesRepository/Cache/RealmResourcesCache.swift
+++ b/godtools/App/Share/Data/ResourcesRepository/Cache/RealmResourcesCache.swift
@@ -92,8 +92,6 @@ class RealmResourcesCache {
             return nil
         }
         
-        
-                        
         guard let realmTranslation = realmResource.latestTranslations
             .filter(NSPredicate(format: "\(#keyPath(RealmTranslation.language.code)) = [c] %@", languageCode.lowercased()))
             .sorted(byKeyPath: #keyPath(RealmTranslation.version), ascending: false).first else {

--- a/godtools/App/Share/Data/ResourcesRepository/Cache/Sync/RealmResourcesCacheSync.swift
+++ b/godtools/App/Share/Data/ResourcesRepository/Cache/Sync/RealmResourcesCacheSync.swift
@@ -150,7 +150,8 @@ class RealmResourcesCacheSync {
                 let attachmentsToRemove: [RealmAttachment] = Array(realm.objects(RealmAttachment.self).filter("id IN %@", attachmentIdsRemoved))
                 
                 realmObjectsToRemove.append(contentsOf: resourcesToRemove)
-                realmObjectsToRemove.append(contentsOf: translationsToRemove)
+                // TODO: Will complete in GT-1413. ~Levi
+                //realmObjectsToRemove.append(contentsOf: translationsToRemove)
                 realmObjectsToRemove.append(contentsOf: attachmentsToRemove)
 
                 do {


### PR DESCRIPTION
- Changed to decodeIfPresent in LanguageModel.
- Need to keep older translations in the realm database until some more testing can be done around removing those.