### PR TITLE
GT Trigger observable for cached resources availability

### DIFF
--- a/godtools/App/Services/InitialDataDownloader/InitialDataDownloader.swift
+++ b/godtools/App/Services/InitialDataDownloader/InitialDataDownloader.swift
@@ -33,6 +33,11 @@ class InitialDataDownloader {
         
         self.resourcesRepository = resourcesRepository
         self.resourcesCache = resourcesCache
+        
+        // TODO: This can be removed after we do some refactoring to remove the ObservableValues and SignalValues in this class which will be replaced by domain layer use cases. ~Levi
+        if resourcesRepository.numberOfResources > 0 {
+            cachedResourcesAvailable.accept(value: true)
+        }
     }
     
     func downloadInitialData() {

--- a/godtools/App/Share/Data/ResourcesRepository/ResourcesRepository.swift
+++ b/godtools/App/Share/Data/ResourcesRepository/ResourcesRepository.swift
@@ -28,6 +28,10 @@ class ResourcesRepository {
         self.languagesRepository = languagesRepository
     }
     
+    var numberOfResources: Int {
+        return cache.numberOfResources
+    }
+    
     func getResourcesChanged() -> AnyPublisher<Void, Never> {
         return cache.getResourcesChanged()
     }


### PR DESCRIPTION
We still have some viewModels observing the cachedResourcesAvailable Observable on InitialDataDownloader.  Eventually these will go away once we have switched over to using Combine + Domain Layer Use Cases.