### PR TITLE
GT-1769 fix downloading tool alert

### DIFF
--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -111,6 +111,8 @@
 		4542F406281084D60016C254 /* DeepLinkUrlParserType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4542F405281084D60016C254 /* DeepLinkUrlParserType.swift */; };
 		4542F408281086480016C254 /* DeepLinkAppsFlyerParserType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4542F407281086480016C254 /* DeepLinkAppsFlyerParserType.swift */; };
 		4542F40A2810871F0016C254 /* DeepLinkingParserManifestAppsFlyer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4542F4092810871F0016C254 /* DeepLinkingParserManifestAppsFlyer.swift */; };
+		454365AC28B4EEE300CC97C1 /* Error+NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 454365AB28B4EEE300CC97C1 /* Error+NetworkError.swift */; };
+		454365B028B4F2F900CC97C1 /* Flow+NetworkErrorAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 454365AF28B4F2F900CC97C1 /* Flow+NetworkErrorAlert.swift */; };
 		454D1C4227A4BDD700ED7F99 /* HorizontallyCenteredCollectionViewCellSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 454D1C4127A4BDD700ED7F99 /* HorizontallyCenteredCollectionViewCellSize.swift */; };
 		4554205B28B17AEA00368CFE /* AttachmentFileDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4554205A28B17AEA00368CFE /* AttachmentFileDataModel.swift */; };
 		4554512528948D220072EC6E /* LanguageSettingsRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4554512428948D220072EC6E /* LanguageSettingsRepository.swift */; };
@@ -1239,6 +1241,8 @@
 		4542F405281084D60016C254 /* DeepLinkUrlParserType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkUrlParserType.swift; sourceTree = "<group>"; };
 		4542F407281086480016C254 /* DeepLinkAppsFlyerParserType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkAppsFlyerParserType.swift; sourceTree = "<group>"; };
 		4542F4092810871F0016C254 /* DeepLinkingParserManifestAppsFlyer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkingParserManifestAppsFlyer.swift; sourceTree = "<group>"; };
+		454365AB28B4EEE300CC97C1 /* Error+NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Error+NetworkError.swift"; sourceTree = "<group>"; };
+		454365AF28B4F2F900CC97C1 /* Flow+NetworkErrorAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Flow+NetworkErrorAlert.swift"; sourceTree = "<group>"; };
 		454D1C4127A4BDD700ED7F99 /* HorizontallyCenteredCollectionViewCellSize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HorizontallyCenteredCollectionViewCellSize.swift; sourceTree = "<group>"; };
 		4554205A28B17AEA00368CFE /* AttachmentFileDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentFileDataModel.swift; sourceTree = "<group>"; };
 		4554512428948D220072EC6E /* LanguageSettingsRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageSettingsRepository.swift; sourceTree = "<group>"; };
@@ -2822,6 +2826,14 @@
 				4542F4032810822E0016C254 /* GodToolsDeepLinkingManifest.swift */,
 			);
 			path = GodToolsManifest;
+			sourceTree = "<group>";
+		};
+		454365AE28B4F2E600CC97C1 /* NetworkErrorAlert */ = {
+			isa = PBXGroup;
+			children = (
+				454365AF28B4F2F900CC97C1 /* Flow+NetworkErrorAlert.swift */,
+			);
+			path = NetworkErrorAlert;
 			sourceTree = "<group>";
 		};
 		4554512328948D090072EC6E /* LanguageSettingsRepository */ = {
@@ -4656,6 +4668,7 @@
 				45FB15F727DBDDB50009DF8E /* LearnToShareTool */,
 				45FB15E827DBDDB40009DF8E /* Lesson */,
 				45FB15FE27DBDDB50009DF8E /* Menu */,
+				454365AE28B4F2E600CC97C1 /* NetworkErrorAlert */,
 				45FB15ED27DBDDB50009DF8E /* Onboarding */,
 				45FB15F927DBDDB50009DF8E /* ToolNavigation */,
 				451CEDFB282C322F006E5105 /* ToolSettings */,
@@ -4700,6 +4713,7 @@
 			isa = PBXGroup;
 			children = (
 				D115B25C27C0318100C18EF6 /* Collection+SafeLookup.swift */,
+				454365AB28B4EEE300CC97C1 /* Error+NetworkError.swift */,
 				D44F3AAB2835444F0008390D /* Image+OptionalUIImage.swift */,
 				45B116C12625FC6D007A7127 /* LanguageDirection+SemanticContentAttribute.swift */,
 				D44C69422809B1150000B970 /* LayoutDirection+LanguageDirection.swift */,
@@ -7474,6 +7488,7 @@
 			files = (
 				D41B38BF288F2ED200BD5899 /* LanguageCodes.swift in Sources */,
 				45AD1F6425938A9800A096A0 /* WebSocketChannelPublisherType.swift in Sources */,
+				454365AC28B4EEE300CC97C1 /* Error+NetworkError.swift in Sources */,
 				45AD1F7525938A9800A096A0 /* ViewedTrainingTipsUserDefaultsCache.swift in Sources */,
 				D41B38BD288F2C7200BD5899 /* GetDeviceLanguageUseCase.swift in Sources */,
 				45AD1FDC25938A9800A096A0 /* EmailSignUpService.swift in Sources */,
@@ -7741,6 +7756,7 @@
 				D119788F271A090400E08580 /* TutorialPagerViewModel.swift in Sources */,
 				45AD1FFE25938A9800A096A0 /* ResourceViewModelType.swift in Sources */,
 				45B6480925E581660098BAF1 /* (null) in Sources */,
+				454365B028B4F2F900CC97C1 /* Flow+NetworkErrorAlert.swift in Sources */,
 				45558407269F2DA500C3FF14 /* MobileContentPagesViewModel.swift in Sources */,
 				45E3FAC02759898200D0CAFA /* AuthUserModelType.swift in Sources */,
 				455582E1269F2C1000C3FF14 /* TrainingViewFactory.swift in Sources */,

--- a/godtools/App/Features/DownloadTool/DownloadTool/DownloadToolViewModel.swift
+++ b/godtools/App/Features/DownloadTool/DownloadTool/DownloadToolViewModel.swift
@@ -10,7 +10,6 @@ import Foundation
 
 class DownloadToolViewModel: NSObject, DownloadToolViewModelType {
     
-    private let didCloseClosure: (() -> Void)
     private let downloadProgressNumberFormatter: NumberFormatter = NumberFormatter()
     private let downloadProgressIntervalRatePerSecond: TimeInterval = 60
     
@@ -20,14 +19,16 @@ class DownloadToolViewModel: NSObject, DownloadToolViewModelType {
     private var didStartToolDownload: Bool = false
     private var didCompleteToolDownload: Bool = false
     
+    private weak var flowDelegate: FlowDelegate?
+    
     let message: ObservableValue<String> = ObservableValue(value: "")
     let isLoading: ObservableValue<Bool> = ObservableValue(value: false)
     let downloadProgress: ObservableValue<Double> = ObservableValue(value: 0)
     let progressValue: ObservableValue<String> = ObservableValue(value: "")
     
-    required init(downloadMessage: String, didCloseClosure: @escaping (() -> Void)) {
-        
-        self.didCloseClosure = didCloseClosure
+    required init(flowDelegate: FlowDelegate, downloadMessage: String) {
+                
+        self.flowDelegate = flowDelegate
         
         super.init()
         
@@ -50,7 +51,7 @@ class DownloadToolViewModel: NSObject, DownloadToolViewModelType {
         
         stopDownload()
         
-        didCloseClosure()
+        flowDelegate?.navigate(step: .closeTappedFromDownloadToolProgress)
     }
     
     func completeDownloadProgress(didCompleteDownload: @escaping (() -> Void)) {

--- a/godtools/App/Flows/FlowStep.swift
+++ b/godtools/App/Flows/FlowStep.swift
@@ -145,4 +145,7 @@ enum FlowStep {
     case closeTappedFromReviewShareShareable
     case shareImageTappedFromReviewShareShareable(shareImage: UIImage)
     case toolSettingsFlowCompleted
+    
+    // download tool
+    case closeTappedFromDownloadToolProgress
 }

--- a/godtools/App/Flows/NetworkErrorAlert/Flow+NetworkErrorAlert.swift
+++ b/godtools/App/Flows/NetworkErrorAlert/Flow+NetworkErrorAlert.swift
@@ -1,0 +1,53 @@
+//
+//  Flow+NetworkErrorAlert.swift
+//  godtools
+//
+//  Created by Levi Eggert on 8/23/22.
+//  Copyright © 2022 Cru. All rights reserved.
+//
+
+import Foundation
+
+extension Flow {
+    
+    func presentNetworkError(responseError: URLResponseError) {
+        
+        let localizationServices: LocalizationServices = appDiContainer.localizationServices
+        
+        let title: String
+        let message: String
+        
+        if responseError.getError().notConnectedToInternet {
+
+            title = localizationServices.stringForMainBundle(key: "no_internet_title")
+            message = localizationServices.stringForMainBundle(key: "no_internet")
+        }
+        else {
+            
+            title = localizationServices.stringForMainBundle(key: "error")
+            
+            switch responseError {
+            case .decodeError( _):
+                message = localizationServices.stringForMainBundle(key: "download_error")
+            case .otherError( _):
+                message = localizationServices.stringForMainBundle(key: "download_error")
+            case .requestError(let error):
+                message = error.localizedDescription
+            case .statusCode(let urlResponseObject):
+                message = "Server Error \(String(describing: urlResponseObject.httpStatusCode))."
+            }
+        }
+        
+        let viewModel = AlertMessageViewModel(
+            title: title,
+            message: message,
+            cancelTitle: nil,
+            acceptTitle: localizationServices.stringForMainBundle(key: "OK"),
+            acceptHandler: nil
+        )
+        
+        let view = AlertMessageView(viewModel: viewModel)
+        
+        navigationController.present(view.controller, animated: true, completion: nil)
+    }
+}

--- a/godtools/App/Flows/NetworkErrorAlert/Flow+NetworkErrorAlert.swift
+++ b/godtools/App/Flows/NetworkErrorAlert/Flow+NetworkErrorAlert.swift
@@ -12,6 +12,10 @@ extension Flow {
     
     func presentNetworkError(responseError: URLResponseError) {
         
+        guard !responseError.getError().requestCancelled else {
+            return
+        }
+        
         let localizationServices: LocalizationServices = appDiContainer.localizationServices
         
         let title: String

--- a/godtools/App/Flows/ToolNavigation/ToolNavigationFlow.swift
+++ b/godtools/App/Flows/ToolNavigation/ToolNavigationFlow.swift
@@ -91,9 +91,8 @@ extension ToolNavigationFlow {
                     page: page
                 )
                 
-            case .failure(let error):
-                
-                self?.presentDownloadToolError(downloadToolError: error)
+            case .failure(let responseError):
+                self?.presentNetworkError(responseError: responseError)
             }
             
             self?.downloadToolTranslationFlow = nil
@@ -163,27 +162,5 @@ extension ToolNavigationFlow {
         case .unknown:
             navigationController.presentAlertMessage(alertMessage: AlertMessage(title: "Internal Error", message: "Attempted to navigate to a tool with an unknown resource type."))
         }
-    }
-        
-    private func presentDownloadToolError(downloadToolError: URLResponseError) {
-        
-        let localizationServices: LocalizationServices = appDiContainer.localizationServices
-        
-        let viewModel = AlertMessageViewModel(
-            title: nil,
-            message: downloadToolError.getErrorMessage(),
-            cancelTitle: nil,
-            acceptTitle: localizationServices.stringForMainBundle(key: "OK"),
-            acceptHandler: nil
-        )
-
-        presentAlertMessage(viewModel: viewModel)
-    }
-    
-    private func presentAlertMessage(viewModel: AlertMessageViewModelType) {
-        
-        let view = AlertMessageView(viewModel: viewModel)
-        
-        navigationController.present(view.controller, animated: true, completion: nil)
     }
 }

--- a/godtools/App/Share/Data/TranslationsRepository/TranslationsRepository.swift
+++ b/godtools/App/Share/Data/TranslationsRepository/TranslationsRepository.swift
@@ -201,9 +201,6 @@ extension TranslationsRepository {
                 return self.getTranslationFileFromRemote(translation: translation, fileName: fileName)
                     .eraseToAnyPublisher()
             })
-            .mapError({ error in
-                return URLResponseError.otherError(error: error)
-            })
             .flatMap({ fileCacheLocation -> AnyPublisher<FileCacheLocation, URLResponseError> in
                 
                 return Just(fileCacheLocation).setFailureType(to: URLResponseError.self)

--- a/godtools/App/Share/Data/URLResponseError.swift
+++ b/godtools/App/Share/Data/URLResponseError.swift
@@ -15,6 +15,20 @@ enum URLResponseError: Error {
     case requestError(error: Error)
     case statusCode(urlResponseObject: URLResponseObject)
     
+    func getError() -> Error {
+        
+        switch self {
+        case .decodeError(let error):
+            return error
+        case .otherError(let error):
+            return error
+        case .requestError(let error):
+            return error
+        case .statusCode(let responseObject):
+            return NSError.errorWithDescription(description: "Response failed due to httpStatusCode: \(String(describing: responseObject.httpStatusCode))")
+        }
+    }
+    
     func getErrorMessage() -> String {
         
         switch self {

--- a/godtools/App/Share/Data/URLResponseObject.swift
+++ b/godtools/App/Share/Data/URLResponseObject.swift
@@ -25,10 +25,10 @@ class URLResponseObject {
     
     var isSuccessHttpStatusCode: Bool {
             
-            guard let httpStatusCode = self.httpStatusCode else {
-                return false
-            }
-            
-            return httpStatusCode >= 200 && httpStatusCode < 400
+        guard let httpStatusCode = self.httpStatusCode else {
+            return false
         }
+        
+        return httpStatusCode >= 200 && httpStatusCode < 400
+    }
 }

--- a/godtools/App/Share/Domain/UseCases/GetToolTranslationsFilesUseCase/GetToolTranslationsFilesUseCase.swift
+++ b/godtools/App/Share/Domain/UseCases/GetToolTranslationsFilesUseCase/GetToolTranslationsFilesUseCase.swift
@@ -70,9 +70,6 @@ class GetToolTranslationsFilesUseCase {
                         return self.translationsRepository.getTranslationManifestsFromRemote(translations: translations, manifestParserType: manifestParserType)
                             .eraseToAnyPublisher()
                     })
-                    .mapError { error in
-                        return URLResponseError.otherError(error: error)
-                    }
                     .eraseToAnyPublisher()
             })
             .receive(on: DispatchQueue.main) // NOTE: Need to switch to main queue and parse manifests again because Manifests can't be passed across threads at this time. ~Levi

--- a/godtools/App/Share/Extensions/Error+NetworkError.swift
+++ b/godtools/App/Share/Extensions/Error+NetworkError.swift
@@ -1,0 +1,24 @@
+//
+//  Error+NetworkError.swift
+//  godtools
+//
+//  Created by Levi Eggert on 8/23/22.
+//  Copyright © 2022 Cru. All rights reserved.
+//
+
+import Foundation
+
+extension Error {
+    
+    var requestErrorCode: Int {
+        return (self as NSError).code
+    }
+    
+    var requestCancelled: Bool {
+        return requestErrorCode == Int(CFNetworkErrors.cfurlErrorCancelled.rawValue)
+    }
+    
+    var notConnectedToInternet: Bool {
+        return requestErrorCode == Int(CFNetworkErrors.cfurlErrorNotConnectedToInternet.rawValue)
+    }
+}

--- a/godtools/App/Share/Views/AlertMessageView/Models/ResponseErrorAlertMessage.swift
+++ b/godtools/App/Share/Views/AlertMessageView/Models/ResponseErrorAlertMessage.swift
@@ -9,6 +9,7 @@
 import Foundation
 import RequestOperation
 
+@available(*, deprecated) // TODO: RequestOperation won't be needed as we move to Combine Publishers.  Flow+NetworkErrorAlert can be used for presenting URLResponseError's. ~Levi
 struct ResponseErrorAlertMessage: AlertMessageType {
     
     let title: String


### PR DESCRIPTION
This PR fixes 2 issues.
1. Tapping the close button from the downloading tool progress modal wasn't dismissing the download progress modal.
2. An alert wasn't being presented when downloading a tool failed due to no network connection.

Both of these issues are related and resolved by ensuring the download tool progress modal is dismissed when the combine publisher fails.  This line here -> (https://github.com/CruGlobal/godtools-swift/blob/GT-1769-fix-downloading-tool-alert/godtools/App/Flows/DownloadToolTranslations/DownloadToolTranslationsFlow.swift#L46)

Some other changes include:
- Adding Flow+NetworkErrorAlert extension for presenting URLResponseErrors.
- Deprecating ResponseErrorAlertMessage.
- Removed the didCloseClosure in DownloadToolViewModel in place of using a FlowStep.


