### PR TITLE
GT-1742 finish mapping resource model

### DIFF
--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -1079,6 +1079,7 @@
 		D471CFC828B4199C00DCE61C /* GetSpotlightToolsUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = D471CFC728B4199C00DCE61C /* GetSpotlightToolsUseCase.swift */; };
 		D471CFCC28B66E8100DCE61C /* GetAllToolsUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = D471CFCB28B66E8100DCE61C /* GetAllToolsUseCase.swift */; };
 		D471CFD028B80B9800DCE61C /* GetToolUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = D471CFCF28B80B9800DCE61C /* GetToolUseCase.swift */; };
+		D471CFD328B9532100DCE61C /* LanguageSupportable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D471CFD228B9532100DCE61C /* LanguageSupportable.swift */; };
 		D47C49D8280EF0B10084F4DE /* AllToolsList.swift in Sources */ = {isa = PBXBuildFile; fileRef = D47C49D7280EF0B10084F4DE /* AllToolsList.swift */; };
 		D47C49DA28104E0B0084F4DE /* OptionalImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D47C49D928104E0B0084F4DE /* OptionalImage.swift */; };
 		D47C49E02816EEBD0084F4DE /* MockFlowDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D47C49DF2816EEBD0084F4DE /* MockFlowDelegate.swift */; };
@@ -2236,6 +2237,7 @@
 		D471CFC728B4199C00DCE61C /* GetSpotlightToolsUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetSpotlightToolsUseCase.swift; sourceTree = "<group>"; };
 		D471CFCB28B66E8100DCE61C /* GetAllToolsUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetAllToolsUseCase.swift; sourceTree = "<group>"; };
 		D471CFCF28B80B9800DCE61C /* GetToolUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetToolUseCase.swift; sourceTree = "<group>"; };
+		D471CFD228B9532100DCE61C /* LanguageSupportable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageSupportable.swift; sourceTree = "<group>"; };
 		D47C49D7280EF0B10084F4DE /* AllToolsList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllToolsList.swift; sourceTree = "<group>"; };
 		D47C49D928104E0B0084F4DE /* OptionalImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionalImage.swift; sourceTree = "<group>"; };
 		D47C49DF2816EEBD0084F4DE /* MockFlowDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFlowDelegate.swift; sourceTree = "<group>"; };
@@ -4819,6 +4821,7 @@
 			isa = PBXGroup;
 			children = (
 				45AD18D925938A4E00A096A0 /* CustomViewBuilderType.swift */,
+				D471CFD228B9532100DCE61C /* LanguageSupportable.swift */,
 				45AD18D825938A4E00A096A0 /* NibBased.swift */,
 			);
 			path = Protocols;
@@ -8029,6 +8032,7 @@
 				45828BD1279CCBD200F6B5F3 /* MobileContentFlowView.swift in Sources */,
 				455583D1269F2DA500C3FF14 /* MobileContentFormInputModel.swift in Sources */,
 				45A93C76286DE4BA00090E01 /* ToolDetailsPrimaryButtonsView.swift in Sources */,
+				D471CFD328B9532100DCE61C /* LanguageSupportable.swift in Sources */,
 				45AD209625938C4900A096A0 /* GlobalActivityAnalyticsUserDefaultsCache.swift in Sources */,
 				45677894287DC6D40044AEB2 /* ChooseLanguageViewModelType.swift in Sources */,
 				45F7E7602701F1AA00CC9FB9 /* MobileContentViewVisibilityState.swift in Sources */,

--- a/godtools.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/godtools.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleDataTransport.git",
       "state" : {
-        "revision" : "5056b15c5acbb90cd214fe4d6138bdf5a740e5a8",
-        "version" : "9.2.0"
+        "revision" : "b905c49326b72211531ed9d7baa02d724828a8dc",
+        "version" : "9.1.4"
       }
     },
     {
@@ -176,8 +176,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "fa0fcd43f272a260e7f734f23e6dc55e16fcae0a",
-        "version" : "1.19.1"
+        "revision" : "e1499bc69b9040b29184f7f2996f7bab467c1639",
+        "version" : "1.19.0"
       }
     }
   ],

--- a/godtools/App/Features/ToolDetails/ToolDetailsViewModel.swift
+++ b/godtools/App/Features/ToolDetails/ToolDetailsViewModel.swift
@@ -158,7 +158,7 @@ class ToolDetailsViewModel: ObservableObject {
             .receive(on: DispatchQueue.main)
             .assign(to: \.mediaType, on: self)
         
-        toolIsFavoritedCancellable = getToolIsFavoritedUseCase.getToolIsFavoritedPublisher(tool: resource)
+        toolIsFavoritedCancellable = getToolIsFavoritedUseCase.getToolIsFavoritedPublisher(toolId: resource.id)
             .receiveOnMain()
             .assign(to: \.isFavorited, on: self)
     }

--- a/godtools/App/Features/Tools/SwiftUI/AllTools/ToolCardsView/ToolCardView/ViewModels/ToolCardViewModel.swift
+++ b/godtools/App/Features/Tools/SwiftUI/AllTools/ToolCardsView/ToolCardView/ViewModels/ToolCardViewModel.swift
@@ -157,7 +157,7 @@ extension ToolCardViewModel {
             languageBundle = bundleLoader.bundleForResource(resourceName: primaryLanguage.code) ?? Bundle.main
             languageDirection = primaryLanguage.languageDirection
         }
-        else if let englishTranslation = resourcesCache.getResourceLanguageTranslation(resourceId: tool.resource.id, languageCode: "en") {
+        else if let englishTranslation = resourcesCache.getResourceLanguageTranslation(resourceId: tool.id, languageCode: "en") {
             
             toolName = englishTranslation.translatedName
             languageBundle = bundleLoader.englishBundle ?? Bundle.main
@@ -165,13 +165,13 @@ extension ToolCardViewModel {
         }
         else {
             
-            toolName = tool.resource.name
+            toolName = tool.name
             languageBundle = bundleLoader.englishBundle ?? Bundle.main
             languageDirection = .leftToRight
         }
         
         title = toolName
-        category = localizationServices.toolCategoryStringForBundle(bundle: languageBundle, attrCategory: tool.resource.attrCategory)
+        category = localizationServices.toolCategoryStringForBundle(bundle: languageBundle, attrCategory: tool.category)
         detailsButtonTitle = localizationServices.stringForBundle(bundle: languageBundle, key: "favorites.favoriteLessons.details")
         openButtonTitle = localizationServices.stringForBundle(bundle: languageBundle, key: "open")
         layoutDirection = LayoutDirection.from(languageDirection: languageDirection)

--- a/godtools/App/Features/Tools/SwiftUI/AllTools/ToolCardsView/ToolCardView/ViewModels/ToolCardViewModel.swift
+++ b/godtools/App/Features/Tools/SwiftUI/AllTools/ToolCardsView/ToolCardView/ViewModels/ToolCardViewModel.swift
@@ -180,7 +180,7 @@ extension ToolCardViewModel {
     private func reloadParallelLanguageName() {
         let parallelLanguage = languageSettingsService.parallelLanguage.value
         
-        let getLanguageAvailability = getLanguageAvailabilityStringUseCase.getLanguageAvailability(for: tool.resource, language: parallelLanguage)
+        let getLanguageAvailability = getLanguageAvailabilityStringUseCase.getLanguageAvailability(for: tool, language: parallelLanguage)
         
         if getLanguageAvailability.isAvailable {
             

--- a/godtools/App/Features/Tools/SwiftUI/AllTools/ToolCardsView/ToolCardView/ViewModels/ToolCardViewModel.swift
+++ b/godtools/App/Features/Tools/SwiftUI/AllTools/ToolCardsView/ToolCardView/ViewModels/ToolCardViewModel.swift
@@ -126,7 +126,7 @@ extension ToolCardViewModel {
             }
         }
         
-        getToolIsFavoritedUseCase.getToolIsFavoritedPublisher(tool: tool.resource)
+        getToolIsFavoritedUseCase.getToolIsFavoritedPublisher(toolId: tool.id)
             .receiveOnMain()
             .assign(to: \.isFavorited, on: self)
             .store(in: &cancellables)

--- a/godtools/App/Share/Data/ResourcesRepository/Api/Models/ResourceModel.swift
+++ b/godtools/App/Share/Data/ResourcesRepository/Api/Models/ResourceModel.swift
@@ -216,6 +216,9 @@ extension ResourceModel {
     func getLanguageIds() -> [String] {
         return languageIds
     }
+}
+
+extension ResourceModel: LanguageSupportable {
     
     func supportsLanguage(languageId: String) -> Bool {
         if !languageId.isEmpty {

--- a/godtools/App/Share/Domain/UseCases/GetLanguageAvailabilityStringUseCase/GetLanguageAvailablityStringUseCase.swift
+++ b/godtools/App/Share/Domain/UseCases/GetLanguageAvailabilityStringUseCase/GetLanguageAvailablityStringUseCase.swift
@@ -18,7 +18,7 @@ class GetLanguageAvailabilityStringUseCase {
         self.getTranslatedLanguageUseCase = getTranslatedLanguageUseCase
     }
     
-    func getLanguageAvailability(for resource: ResourceModel, language: LanguageModel?) -> (isAvailable: Bool, string: String) {
+    func getLanguageAvailability(for resource: LanguageSupportable, language: LanguageModel?) -> (isAvailable: Bool, string: String) {
         guard let language = language else {
             return (false, "")
         }

--- a/godtools/App/Share/Domain/UseCases/GetToolIsFavoritedUseCase/GetToolIsFavoritedUseCase.swift
+++ b/godtools/App/Share/Domain/UseCases/GetToolIsFavoritedUseCase/GetToolIsFavoritedUseCase.swift
@@ -18,20 +18,20 @@ class GetToolIsFavoritedUseCase {
         self.favoritedResourcesRepository = favoritedResourcesRepository
     }
     
-    func getToolIsFavoritedPublisher(tool: ResourceModel) -> AnyPublisher<Bool, Never>  {
+    func getToolIsFavoritedPublisher(toolId: String) -> AnyPublisher<Bool, Never>  {
         
         return favoritedResourcesRepository.getFavoritedResourcesChanged()
             .flatMap({ void -> AnyPublisher<Bool, Never> in
                 
-                return Just(self.getToolIsFavorited(tool: tool))
+                return Just(self.getToolIsFavorited(toolId: toolId))
                     .eraseToAnyPublisher()
             })
             .eraseToAnyPublisher()
     }
     
     // TODO: - change this to pass in the id instead of tool (GT-1777)
-    func getToolIsFavorited(tool: ResourceModel) -> Bool {
+    func getToolIsFavorited(toolId: String) -> Bool {
         
-        return favoritedResourcesRepository.getFavoritedResource(resourceId: tool.id) != nil
+        return favoritedResourcesRepository.getFavoritedResource(resourceId: toolId) != nil
     }
 }

--- a/godtools/App/Share/Domain/UseCases/GetToolUseCase/GetToolUseCase.swift
+++ b/godtools/App/Share/Domain/UseCases/GetToolUseCase/GetToolUseCase.swift
@@ -16,6 +16,7 @@ class GetToolUseCase {
             bannerImageId: resource.attrBanner,
             category: resource.attrCategory,
             dataModelId: resource.id,
+            languageIds: resource.languageIds,
             name: resource.name,
             resource: resource
         )

--- a/godtools/App/Share/Domain/UseCases/GetToolUseCase/GetToolUseCase.swift
+++ b/godtools/App/Share/Domain/UseCases/GetToolUseCase/GetToolUseCase.swift
@@ -14,7 +14,9 @@ class GetToolUseCase {
         
         return ToolDomainModel(
             bannerImageId: resource.attrBanner,
+            category: resource.attrCategory,
             dataModelId: resource.id,
+            name: resource.name,
             resource: resource
         )
     }

--- a/godtools/App/Share/Domain/UseCases/GetToolUseCase/ToolDomainModel.swift
+++ b/godtools/App/Share/Domain/UseCases/GetToolUseCase/ToolDomainModel.swift
@@ -14,6 +14,7 @@ struct ToolDomainModel {
     let bannerImageId: String
     let category: String
     let dataModelId: String
+    let languageIds: [String]
     let name: String
     
     // TODO: - remove this once we're done refactoring to pass ToolDomainModels around instead of ResourceModels
@@ -27,6 +28,7 @@ extension ToolDomainModel {
         bannerImageId = resource.attrBanner
         category = resource.attrCategory
         dataModelId = resource.id
+        languageIds = resource.languageIds
         name = resource.name
         
         self.resource = resource
@@ -37,5 +39,16 @@ extension ToolDomainModel: Identifiable {
     
     var id: String {
         dataModelId
+    }
+}
+
+extension ToolDomainModel: LanguageSupportable {
+    
+    func supportsLanguage(languageId: String) -> Bool {
+        if !languageId.isEmpty {
+            return languageIds.contains(languageId)
+        }
+        
+        return false
     }
 }

--- a/godtools/App/Share/Domain/UseCases/GetToolUseCase/ToolDomainModel.swift
+++ b/godtools/App/Share/Domain/UseCases/GetToolUseCase/ToolDomainModel.swift
@@ -12,7 +12,9 @@ struct ToolDomainModel {
     
     // TODO: - finish mapping necessary attributes in GT-1777
     let bannerImageId: String
+    let category: String
     let dataModelId: String
+    let name: String
     
     // TODO: - remove this once we're done refactoring to pass ToolDomainModels around instead of ResourceModels
     let resource: ResourceModel
@@ -23,7 +25,9 @@ extension ToolDomainModel {
     // TODO: - remove this once we're done refactoring.  (Should be using GetToolUseCase if we need to map from ResourceModel to ToolDomainModel)
     init(resource: ResourceModel) {
         bannerImageId = resource.attrBanner
+        category = resource.attrCategory
         dataModelId = resource.id
+        name = resource.name
         
         self.resource = resource
     }

--- a/godtools/App/Share/Domain/UseCases/ToggleToolFavoritedUseCase/ToggleToolFavoritedUseCase.swift
+++ b/godtools/App/Share/Domain/UseCases/ToggleToolFavoritedUseCase/ToggleToolFavoritedUseCase.swift
@@ -23,7 +23,7 @@ class ToggleToolFavoritedUseCase {
     
     func toggleToolFavorited(tool: ResourceModel) {
         
-        if getToolIsFavoritedUseCase.getToolIsFavorited(tool: tool) {
+        if getToolIsFavoritedUseCase.getToolIsFavorited(toolId: tool.id) {
             
             removeToolFromFavoritesUseCase.removeToolFromFavorites(resourceId: tool.id)
             

--- a/godtools/App/Share/Protocols/LanguageSupportable.swift
+++ b/godtools/App/Share/Protocols/LanguageSupportable.swift
@@ -1,0 +1,14 @@
+//
+//  LanguageSupportable.swift
+//  godtools
+//
+//  Created by Rachael Skeath on 8/26/22.
+//  Copyright © 2022 Cru. All rights reserved.
+//
+
+import Foundation
+
+protocol LanguageSupportable {
+    
+    func supportsLanguage(languageId: String) -> Bool
+}


### PR DESCRIPTION
https://jira.cru.org/browse/GT-1777

- Cleaned up the remaining `ResourceModel` dependencies inside `ToolCardViewModel`
- In `GetLanguageAvailabilityStringUseCase`, `ResourceModel` was being passed in, and in some cases it was a tool and others it was a lesson.  This brings us back to the question of whether or not we want lessons to share tool code or have duplicated code.  I tend think it makes sense to share behavior by using protocols, but still keep the domain models separate-- `ToolDomainModel` and `LessonDomainModel`.  So, I made a protocol `LanguageSupportable` so any domain model that conforms to it can use `GetLanguageAvailabilityStringUseCase` moving forward.  Thoughts?