### PR TITLE
GT-1782 send correct content language on exit link events

### DIFF
--- a/godtools/App/Features/ToolDetails/ToolDetailsViewModel.swift
+++ b/godtools/App/Features/ToolDetails/ToolDetailsViewModel.swift
@@ -274,6 +274,8 @@ extension ToolDetailsViewModel {
             screenName: analyticsScreenName,
             siteSection: siteSection,
             siteSubSection: siteSubSection,
+            contentLanguage: getSettingsPrimaryLanguageUseCase.getPrimaryLanguage()?.analyticsContentLanguage ?? "",
+            secondaryContentLanguage: nil,
             url: url.absoluteString
         )
         

--- a/godtools/App/Features/ToolTraining/ToolTrainingViewModel.swift
+++ b/godtools/App/Features/ToolTraining/ToolTrainingViewModel.swift
@@ -156,6 +156,8 @@ class ToolTrainingViewModel: NSObject, ToolTrainingViewModelType {
             screenName: getExitAnalyticsScreenName(),
             siteSection: analyticsSiteSection,
             siteSubSection: analyticsSiteSubSection,
+            contentLanguage: renderedPageContext.language.code,
+            secondaryContentLanguage: nil,
             url: url
         )
         

--- a/godtools/App/Services/Analytics/AnalyticsTracking/ExitLinkAnalytics.swift
+++ b/godtools/App/Services/Analytics/AnalyticsTracking/ExitLinkAnalytics.swift
@@ -22,6 +22,8 @@ class ExitLinkAnalytics {
             screenName: exitLink.screenName,
             siteSection: exitLink.siteSection,
             siteSubSection: exitLink.siteSubSection,
+            contentLanguage: exitLink.contentLanguage,
+            secondaryContentLanguage: exitLink.secondaryContentLanguage,
             url: exitLink.url
         )        
     }

--- a/godtools/App/Services/Analytics/AnalyticsTracking/Models/ExitLinkModel.swift
+++ b/godtools/App/Services/Analytics/AnalyticsTracking/Models/ExitLinkModel.swift
@@ -13,5 +13,7 @@ struct ExitLinkModel {
     let screenName: String
     let siteSection: String
     let siteSubSection: String
+    let contentLanguage: String
+    let secondaryContentLanguage: String?
     let url: String
 }

--- a/godtools/App/Services/Analytics/Firebase/FirebaseAnalytics.swift
+++ b/godtools/App/Services/Analytics/Firebase/FirebaseAnalytics.swift
@@ -66,12 +66,14 @@ class FirebaseAnalytics: NSObject {
         log(method: "configure()", label: nil, labelValue: nil, data: nil)
     }
     
-    func trackScreenView(screenName: String, siteSection: String, siteSubSection: String) {
+    func trackScreenView(screenName: String, siteSection: String, siteSubSection: String, contentLanguage: String? = nil, secondaryContentLanguage: String? = nil) {
         
         internalTrackEvent(
             screenName: screenName,
             siteSection: siteSection,
             siteSubSection: siteSubSection,
+            contentLanguage: contentLanguage,
+            secondaryContentLanguage: secondaryContentLanguage,
             previousScreenName: previousTrackedScreenName,
             eventName: AnalyticsEventScreenView,
             data: nil
@@ -79,24 +81,28 @@ class FirebaseAnalytics: NSObject {
         previousTrackedScreenName = screenName
     }
     
-    func trackAction(screenName: String, siteSection: String, siteSubSection: String, actionName: String, data: [String : Any]?) {
+    func trackAction(screenName: String, siteSection: String, siteSubSection: String, contentLanguage: String? = nil, secondaryContentLanguage: String? = nil, actionName: String, data: [String : Any]?) {
         
         internalTrackEvent(
             screenName: screenName,
             siteSection: siteSection,
             siteSubSection: siteSubSection,
+            contentLanguage: contentLanguage,
+            secondaryContentLanguage: secondaryContentLanguage,
             previousScreenName: previousTrackedScreenName,
             eventName: actionName,
             data: data
         )
     }
     
-    func trackExitLink(screenName: String, siteSection: String, siteSubSection: String, url: String) {
+    func trackExitLink(screenName: String, siteSection: String, siteSubSection: String, contentLanguage: String, secondaryContentLanguage: String?, url: String) {
         
         internalTrackEvent(
             screenName: screenName,
             siteSection: siteSection,
             siteSubSection: siteSubSection,
+            contentLanguage: contentLanguage,
+            secondaryContentLanguage: secondaryContentLanguage,
             previousScreenName: previousTrackedScreenName,
             eventName: AnalyticsConstants.Values.exitLink,
             data: [
@@ -111,7 +117,7 @@ class FirebaseAnalytics: NSObject {
         }
     }
     
-    private func internalTrackEvent(screenName: String?, siteSection: String?, siteSubSection: String?, previousScreenName: String, eventName: String, data: [String: Any]?) {
+    private func internalTrackEvent(screenName: String?, siteSection: String?, siteSubSection: String?, contentLanguage: String?, secondaryContentLanguage: String?, previousScreenName: String, eventName: String, data: [String: Any]?) {
         
         assertFailureIfNotConfigured()
         
@@ -125,6 +131,8 @@ class FirebaseAnalytics: NSObject {
                 screenName: screenName,
                 siteSection: siteSection,
                 siteSubSection: siteSubSection,
+                contentLanguage: contentLanguage,
+                secondaryContentLanguage: secondaryContentLanguage,
                 previousScreenName: previousScreenName
             )
             
@@ -188,14 +196,14 @@ class FirebaseAnalytics: NSObject {
         )
     }
     
-    private func createBaseProperties(screenName: String?, siteSection: String?, siteSubSection: String?, previousScreenName: String?) -> [String: String] {
+    private func createBaseProperties(screenName: String?, siteSection: String?, siteSubSection: String?, contentLanguage: String?, secondaryContentLanguage: String?, previousScreenName: String?) -> [String: String] {
         assertFailureIfNotConfigured()
         
         var properties: [String: String] = [:]
                 
         properties[AnalyticsConstants.Keys.appName] = AnalyticsConstants.Values.godTools
-        properties[AnalyticsConstants.Keys.contentLanguage] = languageSettingsService.primaryLanguage.value?.code
-        properties[AnalyticsConstants.Keys.contentLanguageSecondary] = languageSettingsService.parallelLanguage.value?.code
+        properties[AnalyticsConstants.Keys.contentLanguage] = contentLanguage ?? languageSettingsService.primaryLanguage.value?.code
+        properties[AnalyticsConstants.Keys.contentLanguageSecondary] = secondaryContentLanguage ?? languageSettingsService.parallelLanguage.value?.code
         properties[AnalyticsConstants.Keys.previousScreenName] = previousScreenName
         properties[AnalyticsConstants.Keys.screenNameFirebase] = screenName
         properties[AnalyticsConstants.Keys.siteSection] = siteSection

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/Page/MobileContentPageViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/Page/MobileContentPageViewModel.swift
@@ -94,6 +94,8 @@ class MobileContentPageViewModel: MobileContentPageViewModelType {
             screenName: analyticsScreenName,
             siteSection: analyticsSiteSection,
             siteSubSection: analyticsSiteSubSection,
+            contentLanguage: renderedPageContext.language.code,
+            secondaryContentLanguage: nil,
             url: url
         )
                         

--- a/godtools/App/Share/Domain/UseCases/GetLanguageUseCase/GetLanguageUseCase.swift
+++ b/godtools/App/Share/Domain/UseCases/GetLanguageUseCase/GetLanguageUseCase.swift
@@ -45,6 +45,7 @@ class GetLanguageUseCase {
     func getLanguage(language: LanguageModel) -> LanguageDomainModel {
                         
         return LanguageDomainModel(
+            analyticsContentLanguage: language.code,
             dataModelId: language.id,
             direction: language.direction == "rtl" ? .rightToLeft : .leftToRight,
             localeIdentifier: language.code,

--- a/godtools/App/Share/Domain/UseCases/GetLanguageUseCase/LanguageDomainModel.swift
+++ b/godtools/App/Share/Domain/UseCases/GetLanguageUseCase/LanguageDomainModel.swift
@@ -9,7 +9,8 @@
 import Foundation
 
 struct LanguageDomainModel {
-    
+
+    let analyticsContentLanguage: String
     let dataModelId: String
     let direction: LanguageDirectionDomainModel
     let localeIdentifier: String


### PR DESCRIPTION
This PR is the beginning work for Epic Analytics Content Language.  The focus of this epic is to fix the contentlanguage and contentlanguagesecondary being sent to Firebase analytics.  Currently those parameters are hardcoded to the language settings primary and parallel languages which isn't desired in all situations.

The following work for this PR includes:

Update the following method signatures in FirebaseAnalytics.swift to accept a contentLanguage and secondaryContentLanguage.  
- trackScreenView
- trackAction
- trackExitLink

Require contentLanguage and secondaryContentLanguage on trackExitLink method and update places in the app to send the correct contentLanguage and secondaryContentLanguage for ExitLink analytics.

Future:

Require contentLanguage and secondaryContentLanguage on trackScreenView and trackAction methods.

