### PR TITLE
GT fix to resources sync when running in debug 

### DIFF
--- a/godtools/App/Share/Data/ResourcesRepository/ResourcesRepository.swift
+++ b/godtools/App/Share/Data/ResourcesRepository/ResourcesRepository.swift
@@ -76,9 +76,20 @@ class ResourcesRepository {
     func syncLanguagesAndResourcesPlusLatestTranslationsAndLatestAttachments() -> AnyPublisher<RealmResourcesCacheSyncResult, URLResponseError> {
         
         return syncLanguagesAndResourcesPlusLatestTranslationsAndLatestAttachmentsFromJsonFileIfNeeded()
-            .mapError { error in
-                return URLResponseError.otherError(error: error)
-            }
+            .map({ result in
+                    
+                return RealmResourcesCacheSyncResult(
+                    languagesSyncResult: RealmLanguagesCacheSyncResult(languageIdsRemoved: []),
+                    resourceIdsRemoved: [],
+                    translationIdsRemoved: [],
+                    attachmentIdsRemoved: [],
+                    latestAttachmentFiles: []
+                )
+            })
+            .catch({ (error: Error) in
+                return self.syncLanguagesAndResourcesPlusLatestTranslationsAndLatestAttachmentsFromRemote()
+                    .eraseToAnyPublisher()
+            })
             .flatMap({ syncedResourcesFromFileCacheResults -> AnyPublisher<RealmResourcesCacheSyncResult, URLResponseError> in
                                 
                 return self.syncLanguagesAndResourcesPlusLatestTranslationsAndLatestAttachmentsFromRemote()


### PR DESCRIPTION
If for any reason fetching resources from the bundle fails, still ensure resources are fetched from remote.  This would occur in non release builds because at the moment assets are only pre-bundled with release builds.