### PR TITLE
GT-Moved LanguageSupportable on ResourceModel into separate file extension

### DIFF
--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -895,6 +895,7 @@
 		45E8FAAD2883040B00D7D569 /* FileCache+SSZipArchive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E8FAAC2883040B00D7D569 /* FileCache+SSZipArchive.swift */; };
 		45E998D623FD7B090088DD0C /* SF-Pro-Text-Semibold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 45E998D523FD7B090088DD0C /* SF-Pro-Text-Semibold.otf */; };
 		45EC429B272C87430052F2AA /* PassthroughValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45EC429A272C87430052F2AA /* PassthroughValue.swift */; };
+		45EC5CF228CA2A4A0000AA2E /* ResourceModel+LanguageSupportable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45EC5CF128CA2A4A0000AA2E /* ResourceModel+LanguageSupportable.swift */; };
 		45EDBCF027359CD70099495B /* Realm in Frameworks */ = {isa = PBXBuildFile; productRef = 45EDBCEF27359CD70099495B /* Realm */; };
 		45EDBCF227359CD70099495B /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 45EDBCF127359CD70099495B /* RealmSwift */; };
 		45F267A128907F5D006679F2 /* RealmResourcesCacheSync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45F267A028907F5D006679F2 /* RealmResourcesCacheSync.swift */; };
@@ -1991,6 +1992,7 @@
 		45E8FAAC2883040B00D7D569 /* FileCache+SSZipArchive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileCache+SSZipArchive.swift"; sourceTree = "<group>"; };
 		45E998D523FD7B090088DD0C /* SF-Pro-Text-Semibold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SF-Pro-Text-Semibold.otf"; sourceTree = "<group>"; };
 		45EC429A272C87430052F2AA /* PassthroughValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassthroughValue.swift; sourceTree = "<group>"; };
+		45EC5CF128CA2A4A0000AA2E /* ResourceModel+LanguageSupportable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ResourceModel+LanguageSupportable.swift"; sourceTree = "<group>"; };
 		45F267A028907F5D006679F2 /* RealmResourcesCacheSync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealmResourcesCacheSync.swift; sourceTree = "<group>"; };
 		45F267A228907F67006679F2 /* RealmResourcesCacheSyncResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealmResourcesCacheSyncResult.swift; sourceTree = "<group>"; };
 		45F5A047268A72200081C507 /* IncomingDeepLinkUrl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IncomingDeepLinkUrl.swift; sourceTree = "<group>"; };
@@ -6005,6 +6007,7 @@
 			isa = PBXGroup;
 			children = (
 				45D63E9A288F77D4009B4610 /* ResourceModel.swift */,
+				45EC5CF128CA2A4A0000AA2E /* ResourceModel+LanguageSupportable.swift */,
 				45D63E95288F77D4009B4610 /* ResourceModelDefaultVariantData.swift */,
 				45D63E98288F77D4009B4610 /* ResourceModelMetatoolData.swift */,
 				45D63E97288F77D4009B4610 /* ResourceModelType.swift */,
@@ -7485,6 +7488,7 @@
 				45D63EA5288F77D4009B4610 /* ResourceModel.swift in Sources */,
 				D45922BF2864EBD400904B87 /* AllFavoriteToolsHostingView.swift in Sources */,
 				45D63E9E288F77D4009B4610 /* RealmResource.swift in Sources */,
+				45EC5CF228CA2A4A0000AA2E /* ResourceModel+LanguageSupportable.swift in Sources */,
 				455583C4269F2DA500C3FF14 /* MobileContentPageViewFactoryType.swift in Sources */,
 				45D63E56288F67F8009B4610 /* IgnoreCacheSession.swift in Sources */,
 				459C56D225FF954F00F15967 /* (null) in Sources */,

--- a/godtools/App/Share/Data/ResourcesRepository/Api/Models/ResourceModel+LanguageSupportable.swift
+++ b/godtools/App/Share/Data/ResourcesRepository/Api/Models/ResourceModel+LanguageSupportable.swift
@@ -1,0 +1,19 @@
+//
+//  ResourceModel+LanguageSupportable.swift
+//  godtools
+//
+//  Created by Levi Eggert on 9/8/22.
+//  Copyright © 2022 Cru. All rights reserved.
+//
+
+import Foundation
+
+extension ResourceModel: LanguageSupportable {
+    
+    func supportsLanguage(languageId: String) -> Bool {
+        if !languageId.isEmpty {
+            return languageIds.contains(languageId)
+        }
+        return false
+    }
+}

--- a/godtools/App/Share/Data/ResourcesRepository/Api/Models/ResourceModel.swift
+++ b/godtools/App/Share/Data/ResourcesRepository/Api/Models/ResourceModel.swift
@@ -217,13 +217,3 @@ extension ResourceModel {
         return languageIds
     }
 }
-
-extension ResourceModel: LanguageSupportable {
-    
-    func supportsLanguage(languageId: String) -> Bool {
-        if !languageId.isEmpty {
-            return languageIds.contains(languageId)
-        }
-        return false
-    }
-}


### PR DESCRIPTION
Moved LanguageSupportable logic from ResourceModel into its own file that way ResourceModel.swift is free from the LanguageSupportable.swift dependency.  
The build phase script for downloading initial resources is dependent on ResourceModel.swift and didn't want to add the additional LanguageSupportable.swift to that since it isn't needed by that build phase script.