### PR TITLE
GT-1547 Send firebase event iam_tools

### DIFF
--- a/godtools/App/Features/Tools/SwiftUI/AllTools/AllToolsContentViewModel.swift
+++ b/godtools/App/Features/Tools/SwiftUI/AllTools/AllToolsContentViewModel.swift
@@ -189,6 +189,8 @@ extension AllToolsContentViewModel {
     func pageViewed() {
         
         analytics.pageViewedAnalytics.trackPageView(trackScreen: TrackScreenModel(screenName: analyticsScreenName, siteSection: analyticsSiteSection, siteSubSection: analyticsSiteSubSection))
+        
+        analytics.trackActionAnalytics.trackAction(trackAction: TrackActionModel(screenName: analyticsScreenName, actionName: AnalyticsConstants.ActionNames.viewedToolsAction, siteSection: analyticsSiteSection, siteSubSection: analyticsSiteSubSection, url: nil, data: nil))
     }
             
     private func trackToolTappedAnalytics(for tool: ResourceModel, isSpotlight: Bool) {


### PR DESCRIPTION
When landing on AllTools we need to send a firebase event iam_tools which is used for triggering firebase messages.