### PR TITLE
GT-1682 Fix shareable image sizing

### DIFF
--- a/godtools/App/Features/ToolSettings/ToolSettings/Subviews/ToolSettingsShareables/ToolSettingsShareableItemView.swift
+++ b/godtools/App/Features/ToolSettings/ToolSettings/Subviews/ToolSettingsShareables/ToolSettingsShareableItemView.swift
@@ -9,13 +9,19 @@ import SwiftUI
 
 struct ToolSettingsShareableItemView: View {
     
+    private let itemSize: CGSize = CGSize(width: 112, height: 112)
+    
     @ObservedObject var viewModel: ToolSettingsShareableItemViewModel
     
     var body: some View {
+        
         GeometryReader { geometry in
+            
             viewModel.image
                 .resizable()
+                .frame(width: itemSize.width, height: itemSize.height)
                 .aspectRatio(contentMode: .fit)
+            
             VStack(alignment: .center, spacing: 0) {
                 Spacer()
                 Text(viewModel.title)
@@ -24,7 +30,7 @@ struct ToolSettingsShareableItemView: View {
             }
             .padding(EdgeInsets(top: 0, leading: 0, bottom: 15, trailing: 0))
         }
-        .frame(width: 112, height: 112)
-        .background(Color.white)
+        .frame(width: itemSize.width, height: itemSize.height)
+        .background(ColorPalette.gtLightestGrey.color)
     }
 }


### PR DESCRIPTION
- Set the shareable image size to match the containing view
- Set the background color of the containing view in the event the image is cropped due to aspectFit ratio and if the image is transparent