### PR TITLE
GT-1798 Fix bug where lesson would sometimes open in the parallel language (Spanish)

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -41,7 +41,7 @@ SPEC CHECKSUMS:
   FBSDKCoreKit: 4afd6ff53d8133a433dbcda44451c9498f8c6ce4
   FMDB: 2ce00b547f966261cd18927a3ddb07cb6f3db82a
   Fuzi: 4c10d6449c0b49a85cd75b13844c559c0fc71220
-  GodtoolsToolParser: b8fcbc0f75cb006cb0c5eddcaa6dbf482e1a12c9
+  GodtoolsToolParser: b742939b157a7c504d3a07291c127fa9d7f43ff1
   GoogleConversionTracking: ca8c89abda2bd28bb6472b316eeb4ece9264e279
   SnowplowTracker: c393b26c456142ad5a78f4e4d771c71cb194f06c
   SSZipArchive: fe6a26b2a54d5a0890f2567b5cc6de5caa600aef

--- a/godtools/App/Share/Data/TranslationsRepository/TranslationsRepository.swift
+++ b/godtools/App/Share/Data/TranslationsRepository/TranslationsRepository.swift
@@ -93,6 +93,21 @@ extension TranslationsRepository {
         
         return Publishers.MergeMany(requests)
             .collect()
+            .map({ downloadedTranslationManifestFileDataModels in
+                
+                var maintainTranslationDownloadOrder: [TranslationManifestFileDataModel] = Array()
+                
+                for translation in translations {
+                    
+                    guard let translationManifest = downloadedTranslationManifestFileDataModels.first(where: {$0.translation.id == translation.id}) else {
+                        continue
+                    }
+                    
+                    maintainTranslationDownloadOrder.append(translationManifest)
+                }
+                
+                return maintainTranslationDownloadOrder
+            })
             .eraseToAnyPublisher()
     }
     


### PR DESCRIPTION
With settings primary language English and parallel language Spanish, sometimes a lesson would open in Spanish.

The issue was downloading the translations is concurrent and could finish in any order.  Updated both the UseCase and Data Layer to maintain the downloaded order of translations. 