### PR TITLE
GT-1805 missing headers

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -41,7 +41,7 @@ SPEC CHECKSUMS:
   FBSDKCoreKit: 4afd6ff53d8133a433dbcda44451c9498f8c6ce4
   FMDB: 2ce00b547f966261cd18927a3ddb07cb6f3db82a
   Fuzi: 4c10d6449c0b49a85cd75b13844c559c0fc71220
-  GodtoolsToolParser: b742939b157a7c504d3a07291c127fa9d7f43ff1
+  GodtoolsToolParser: b8fcbc0f75cb006cb0c5eddcaa6dbf482e1a12c9
   GoogleConversionTracking: ca8c89abda2bd28bb6472b316eeb4ece9264e279
   SnowplowTracker: c393b26c456142ad5a78f4e4d771c71cb194f06c
   SSZipArchive: fe6a26b2a54d5a0890f2567b5cc6de5caa600aef

--- a/godtools/App/Features/Lessons/Lessons/LessonsView/LessonsViewModel.swift
+++ b/godtools/App/Features/Lessons/Lessons/LessonsView/LessonsViewModel.swift
@@ -95,12 +95,9 @@ extension LessonsViewModel {
     }
     
     private func setupTitle(with language: LanguageDomainModel?) {
-        guard let language = language,
-              let languageBundle = localizationServices.bundleLoader.bundleForResource(resourceName: language.localeIdentifier)
-        else { return }
         
-        sectionTitle = localizationServices.stringForBundle(bundle: languageBundle, key: "lessons.pageTitle")
-        subtitle = localizationServices.stringForBundle(bundle: languageBundle, key: "lessons.pageSubtitle")
+        sectionTitle = localizationServices.stringForLocaleElseSystem(localeIdentifier: language?.localeIdentifier, key: "lessons.pageTitle")
+        subtitle = localizationServices.stringForLocaleElseSystem(localeIdentifier: language?.localeIdentifier, key: "lessons.pageSubtitle")
     }
 }
 

--- a/godtools/App/Features/Tools/SwiftUI/AllTools/ToolCardsView/ToolCardView/ViewModels/ToolCardViewModel.swift
+++ b/godtools/App/Features/Tools/SwiftUI/AllTools/ToolCardsView/ToolCardView/ViewModels/ToolCardViewModel.swift
@@ -150,17 +150,11 @@ extension ToolCardViewModel {
     
     private func reloadParallelLanguageName(_ parallelLanguage: LanguageDomainModel?) {
         
-        if let parallelLanguage = parallelLanguage {
+        let getLanguageAvailability = getLanguageAvailabilityUseCase.getLanguageAvailability(for: tool, language: parallelLanguage)
             
-            let getLanguageAvailability = getLanguageAvailabilityUseCase.getLanguageAvailability(for: tool, language: parallelLanguage)
+        if getLanguageAvailability.isAvailable {
             
-            if getLanguageAvailability.isAvailable {
-                
-                parallelLanguageName = getLanguageAvailability.availabilityString
-                
-            } else {
-                parallelLanguageName = ""
-            }
+            parallelLanguageName = getLanguageAvailability.availabilityString
             
         } else {
             parallelLanguageName = ""

--- a/godtools/App/Features/Tools/SwiftUI/AllTools/ToolCardsView/ToolCardView/ViewModels/ToolCardViewModel.swift
+++ b/godtools/App/Features/Tools/SwiftUI/AllTools/ToolCardsView/ToolCardView/ViewModels/ToolCardViewModel.swift
@@ -149,16 +149,20 @@ extension ToolCardViewModel {
     }
     
     private func reloadParallelLanguageName(_ parallelLanguage: LanguageDomainModel?) {
-        guard let parallelLanguage = parallelLanguage else { return }
-
-        let getLanguageAvailability = getLanguageAvailabilityUseCase.getLanguageAvailability(for: tool, language: parallelLanguage)
         
-        if getLanguageAvailability.isAvailable {
+        if let parallelLanguage = parallelLanguage {
             
-            parallelLanguageName = getLanguageAvailability.availabilityString
+            let getLanguageAvailability = getLanguageAvailabilityUseCase.getLanguageAvailability(for: tool, language: parallelLanguage)
+            
+            if getLanguageAvailability.isAvailable {
+                
+                parallelLanguageName = getLanguageAvailability.availabilityString
+                
+            } else {
+                parallelLanguageName = ""
+            }
             
         } else {
-            
             parallelLanguageName = ""
         }
     }

--- a/godtools/App/Features/Tools/SwiftUI/AllTools/ToolCategoriesView/ToolCategoriesViewModel.swift
+++ b/godtools/App/Features/Tools/SwiftUI/AllTools/ToolCategoriesView/ToolCategoriesViewModel.swift
@@ -69,7 +69,7 @@ extension ToolCategoriesViewModel {
             .receiveOnMain()
             .sink { language in
                 
-                self.reloadForLanguageChange(to: language)
+                self.setTitleText(with: language)
             }
             .store(in: &cancellables)
         
@@ -93,14 +93,8 @@ extension ToolCategoriesViewModel {
         }
     }
     
-    private func setTitleText(with language: LanguageDomainModel) {
-        guard let languageBundle = localizationServices.bundleLoader.bundleForResource(resourceName: language.localeIdentifier) else { return }
-        categoryTitleText = localizationServices.stringForBundle(bundle: languageBundle, key: "allTools.categories.title")
-    }
-    
-    private func reloadForLanguageChange(to language: LanguageDomainModel?) {
-        guard let language = language else { return }
-
-        setTitleText(with: language)
+    private func setTitleText(with language: LanguageDomainModel?) {
+        
+        categoryTitleText = localizationServices.stringForLocaleElseSystem(localeIdentifier: language?.localeIdentifier, key: "allTools.categories.title")
     }
 }

--- a/godtools/App/Features/Tools/SwiftUI/Favorites/FavoriteToolsView/ViewModels/BaseFavoriteToolsViewModel.swift
+++ b/godtools/App/Features/Tools/SwiftUI/Favorites/FavoriteToolsView/ViewModels/BaseFavoriteToolsViewModel.swift
@@ -68,9 +68,9 @@ class BaseFavoriteToolsViewModel: ToolCardProvider {
     
     // MARK: - Public
     
-    func setText(for languageBundle: Bundle) {
+    func setText(for language: LanguageDomainModel?) {
         
-        sectionTitle = localizationServices.stringForBundle(bundle: languageBundle, key: "favorites.favoriteTools.title")
+        sectionTitle = localizationServices.stringForLocaleElseSystem(localeIdentifier: language?.localeIdentifier, key: "favorites.favoriteTools.title")
     }
 }
 
@@ -93,11 +93,7 @@ extension BaseFavoriteToolsViewModel {
             .receiveOnMain()
             .sink { primaryLanguage in
                 
-                guard let primaryLanguage = primaryLanguage,
-                      let languageBundle = self.localizationServices.bundleLoader.bundleForResource(resourceName: primaryLanguage.localeIdentifier)
-                else { return }
-                
-                self.setText(for: languageBundle)
+                self.setText(for: primaryLanguage)
             }
             .store(in: &cancellables)
     }

--- a/godtools/App/Features/Tools/SwiftUI/Favorites/FavoriteToolsView/ViewModels/FavoriteToolsViewModel.swift
+++ b/godtools/App/Features/Tools/SwiftUI/Favorites/FavoriteToolsView/ViewModels/FavoriteToolsViewModel.swift
@@ -42,14 +42,14 @@ class FavoriteToolsViewModel: BaseFavoriteToolsViewModel {
         maxNumberCardsToShow = maxNumberCardsShown
     }
     
-    override func setText(for languageBundle: Bundle) {
+    override func setText(for language: LanguageDomainModel?) {
         
-        viewAllButtonText = localizationServices.stringForBundle(bundle: languageBundle, key: "favorites.favoriteTools.viewAll") + " >"
-        noFavoriteToolsTitle = localizationServices.stringForBundle(bundle: languageBundle, key: "favorites.noTools.title")
-        noFavoriteToolsDescription = localizationServices.stringForBundle(bundle: languageBundle, key: "favorites.noTools.description")
-        noFavoriteToolsButtonText = localizationServices.stringForBundle(bundle: languageBundle, key: "favorites.noTools.button")
+        viewAllButtonText = localizationServices.stringForLocaleElseSystem(localeIdentifier: language?.localeIdentifier, key: "favorites.favoriteTools.viewAll") + " >"
+        noFavoriteToolsTitle = localizationServices.stringForLocaleElseSystem(localeIdentifier: language?.localeIdentifier, key: "favorites.noTools.title")
+        noFavoriteToolsDescription = localizationServices.stringForLocaleElseSystem(localeIdentifier: language?.localeIdentifier, key: "favorites.noTools.description")
+        noFavoriteToolsButtonText = localizationServices.stringForLocaleElseSystem(localeIdentifier: language?.localeIdentifier, key: "favorites.noTools.button")
         
-        super.setText(for: languageBundle)
+        super.setText(for: language)
     }
 }
 

--- a/godtools/App/Features/Tools/SwiftUI/Favorites/FavoritesContentViewModel.swift
+++ b/godtools/App/Features/Tools/SwiftUI/Favorites/FavoritesContentViewModel.swift
@@ -136,11 +136,8 @@ extension FavoritesContentViewModel {
     }
     
     private func setupTitle(with language: LanguageDomainModel?) {
-        guard let language = language,
-              let languageBundle = localizationServices.bundleLoader.bundleForResource(resourceName: language.localeIdentifier)
-        else { return }
 
-        pageTitle = localizationServices.stringForBundle(bundle: languageBundle, key: "favorites.pageTitle")
+        pageTitle = localizationServices.stringForLocaleElseSystem(localeIdentifier: language?.localeIdentifier, key: "favorites.pageTitle")
     }
 }
 

--- a/godtools/App/Features/Tools/SwiftUI/Favorites/FeaturedLessonsView/FeaturedLessonCardsViewModel.swift
+++ b/godtools/App/Features/Tools/SwiftUI/Favorites/FeaturedLessonsView/FeaturedLessonCardsViewModel.swift
@@ -91,10 +91,7 @@ extension FeaturedLessonCardsViewModel {
     }
     
     private func setupTitle(with language: LanguageDomainModel?) {
-        guard let language = language,
-              let languageBundle = localizationServices.bundleLoader.bundleForResource(resourceName: language.localeIdentifier)
-        else { return }
         
-        sectionTitle = localizationServices.stringForBundle(bundle: languageBundle, key: "favorites.favoriteLessons.title")
+        sectionTitle = localizationServices.stringForLocaleElseSystem(localeIdentifier: language?.localeIdentifier, key: "favorites.favoriteLessons.title")
     }
 }

--- a/godtools/App/Share/SwiftUI Views/LessonCardView/ViewModels/LessonCardViewModel.swift
+++ b/godtools/App/Share/SwiftUI Views/LessonCardView/ViewModels/LessonCardViewModel.swift
@@ -80,13 +80,12 @@ extension LessonCardViewModel {
     }
     
     private func reloadTitle(for primaryLanguage: LanguageDomainModel?) {
-        guard let primaryLanguage = primaryLanguage else { return }
 
         let resourcesCache: ResourcesCache = dataDownloader.resourcesCache
              
         let titleValue: String
         
-        if let primaryTranslation = resourcesCache.getResourceLanguageTranslation(resourceId: lesson.id, languageId: primaryLanguage.id) {
+        if let primaryLanguage = primaryLanguage, let primaryTranslation = resourcesCache.getResourceLanguageTranslation(resourceId: lesson.id, languageId: primaryLanguage.id) {
             
             titleValue = primaryTranslation.translatedName
         }


### PR DESCRIPTION
https://jira.cru.org/browse/GT-1805

The headers weren't showing up if you select a primary language that doesn't have translations for the headers, swipe the app out of memory, and then open it back up.  This isn't related to iOS 16, it would've happened on any device.