### PR TITLE
GT-1806 fix duplicate back button on all favorites

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -41,7 +41,7 @@ SPEC CHECKSUMS:
   FBSDKCoreKit: 4afd6ff53d8133a433dbcda44451c9498f8c6ce4
   FMDB: 2ce00b547f966261cd18927a3ddb07cb6f3db82a
   Fuzi: 4c10d6449c0b49a85cd75b13844c559c0fc71220
-  GodtoolsToolParser: b8fcbc0f75cb006cb0c5eddcaa6dbf482e1a12c9
+  GodtoolsToolParser: b742939b157a7c504d3a07291c127fa9d7f43ff1
   GoogleConversionTracking: ca8c89abda2bd28bb6472b316eeb4ece9264e279
   SnowplowTracker: c393b26c456142ad5a78f4e4d771c71cb194f06c
   SSZipArchive: fe6a26b2a54d5a0890f2567b5cc6de5caa600aef

--- a/godtools/App/Features/Tools/SwiftUI/Favorites/AllFavoriteToolsView/AllFavoriteToolsView.swift
+++ b/godtools/App/Features/Tools/SwiftUI/Favorites/AllFavoriteToolsView/AllFavoriteToolsView.swift
@@ -36,6 +36,7 @@ struct AllFavoriteToolsView: View {
                 .listRowInsets(EdgeInsets())
             } refreshHandler: {}
         }
+        .navigationBarBackButtonHidden(true)
         .onAppear {
             viewModel.pageViewed()
         }


### PR DESCRIPTION
In iOS 16 the system navigation back button will automatically appear when using SwiftUI.  For now we will have to hide those on the SwiftUI View.