### PR TITLE
GT-1494 Fix closing lesson to lessons list from deep link

### DIFF
--- a/godtools/App/Features/Tools/ToolsMenu/ToolsMenuView.swift
+++ b/godtools/App/Features/Tools/ToolsMenu/ToolsMenuView.swift
@@ -175,7 +175,7 @@ class ToolsMenuView: UIViewController {
         toolbarView.setSelectedToolbarItem(pageType: pageType)
     }
     
-    private func navigateToPage(pageType: ToolsMenuPageType, animated: Bool) {
+    func navigateToPage(pageType: ToolsMenuPageType, animated: Bool) {
         
         guard toolsListsScrollView != nil else {
             return

--- a/godtools/App/Flows/App/AppFlow.swift
+++ b/godtools/App/Flows/App/AppFlow.swift
@@ -231,7 +231,16 @@ class AppFlow: NSObject, ToolNavigationFlow, Flow {
                 return
             }
             
-            navigateToToolsMenu(startingPage: .lessons, animatePopToToolsMenu: true, animateDismissingPresentedView: true, didCompleteDismissingPresentedView: nil)
+            if let toolsMenu = getToolsMenuInNavigationStack() {
+                
+                toolsMenu.navigateToPage(pageType: .lessons, animated: false)
+                
+                navigationController.popToViewController(toolsMenu, animated: true)
+            }
+            else {
+                
+                navigateToToolsMenu(startingPage: .lessons, animatePopToToolsMenu: true, animateDismissingPresentedView: true, didCompleteDismissingPresentedView: nil)
+            }
                         
             lessonFlow = nil
             


### PR DESCRIPTION
This PR deals with navigation to the lessons list which can happen from 2 situations:
1. User opens lesson from the lessons list and then closes the lesson.
2. User deep links into a lesson and then closes a lesson.

In this change a check is made if the ToolsMenu already exists in the navigation stack, if it does we manually tab to the lessons list and then pop back to the lessons list rather than creating a new instance every time a lesson is closed.