### PR TITLE
GT-1642 Create 2 phrases for "About" text

### DIFF
--- a/godtools/App/Features/Menu/About/AboutViewModel.swift
+++ b/godtools/App/Features/Menu/About/AboutViewModel.swift
@@ -21,7 +21,7 @@ class AboutViewModel: AboutViewModelType {
         self.aboutTextProvider = aboutTextProvider
         self.analytics = analytics
         
-        navTitle.accept(value: localizationServices.stringForMainBundle(key: "about"))
+        navTitle.accept(value: localizationServices.stringForMainBundle(key: "aboutApp.navTitle"))
         
         aboutTexts.accept(value: aboutTextProvider.aboutTexts)
     }

--- a/godtools/App/Features/Menu/Menu/MenuViewModel.swift
+++ b/godtools/App/Features/Menu/Menu/MenuViewModel.swift
@@ -291,7 +291,7 @@ extension MenuViewModel {
             localizedKey = "language_settings"
             
         case .about:
-            localizedKey = "about"
+            localizedKey = "aboutApp.navTitle"
             
         case .help:
             localizedKey = "help"

--- a/godtools/App/Features/ToolDetails/Presentation/ToolDetails/ToolDetailsViewModel.swift
+++ b/godtools/App/Features/ToolDetails/Presentation/ToolDetails/ToolDetailsViewModel.swift
@@ -136,7 +136,7 @@ class ToolDetailsViewModel: ObservableObject {
         segments = segmentTypes.map({
             switch $0 {
             case .about:
-                return localizationServices.stringForBundle(bundle: languageBundle, key: "about")
+                return localizationServices.stringForBundle(bundle: languageBundle, key: "toolDetails.about.title")
             case .versions:
                 return localizationServices.stringForBundle(bundle: languageBundle, key: "toolDetails.versions.title")
             }

--- a/godtools/Base.lproj/Localizable.strings
+++ b/godtools/Base.lproj/Localizable.strings
@@ -25,6 +25,7 @@
 "toolSettings.languagesList.deleteLanguage.title" = "None";
 
 "toolSettings.chooseLanguage.toggleMessage" = "Toggle between the two different languages in this tool.";
+"toolDetails.about.title" = "About";
 "toolDetails.versions.title" = "Versions";
 "toolDetails.learnToShareToolButton.title" = "Learn to share this tool";
 "toolSettings.title" = "Tool Options";
@@ -212,7 +213,6 @@ If you don't receive this message until later, the link may not still work. We c
 "account_login" = "Account Login";
 
 // Tool Detail
-"about" = "About";
 "help" = "Frequently Asked Questions";
 "contact_us" = "Contact Us";
 "preview_mode_translators_only" = "Preview Mode (Translators Only)";
@@ -278,7 +278,8 @@ The app can be downloaded from https://godtoolsapp.com";
 
 "onboardingTutorial.getStartedButton.title" = "Get Started";
 
-// About
+// About App
+"aboutApp.navTitle" = "About";
 "general_about_1" = "GodTools helps you share your faith in an easy and clear way.";
 // Tutorial
 "tutorial.tutorialItem.0.title" = "Watch";


### PR DESCRIPTION
Currently localized text for "About" was being shared in 3 places of the app.
1. Tool Details screen, the about section title.
2. In the menu there is a menu option with About title.
3. Tapping the menu About option would open a screen with navigation title About.

There are now 2 phrases for the "About" text and the "about" phrase has been removed.

aboutApp.navTitle
toolDetails.about.title
