### PR TITLE
Fix Firebase crash in languages sync

### DIFF
--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -8691,7 +8691,7 @@
 					"@executable_path/Frameworks",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
-				MARKETING_VERSION = 6.0.3;
+				MARKETING_VERSION = 6.0.4;
 				OTHER_SWIFT_FLAGS = "$(inherited) -D COCOAPODS -DDEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = org.cru.godtools;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -8873,7 +8873,7 @@
 					"@executable_path/Frameworks",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
-				MARKETING_VERSION = 6.0.3;
+				MARKETING_VERSION = 6.0.4;
 				OTHER_SWIFT_FLAGS = "$(inherited) -D COCOAPODS -DDEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = org.cru.godtools.beta;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -9054,7 +9054,7 @@
 					"@executable_path/Frameworks",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
-				MARKETING_VERSION = 6.0.3;
+				MARKETING_VERSION = 6.0.4;
 				OTHER_SWIFT_FLAGS = "$(inherited) -D COCOAPODS -DDEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = org.cru.godtools.beta;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -9236,7 +9236,7 @@
 					"@executable_path/Frameworks",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
-				MARKETING_VERSION = 6.0.3;
+				MARKETING_VERSION = 6.0.4;
 				OTHER_SWIFT_FLAGS = "$(inherited) -D COCOAPODS -DDEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = org.cru.godtools;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -9446,7 +9446,7 @@
 					"@executable_path/Frameworks",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
-				MARKETING_VERSION = 6.0.3;
+				MARKETING_VERSION = 6.0.4;
 				OTHER_SWIFT_FLAGS = "$(inherited) -D COCOAPODS -DRELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = org.cru.godtools;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/godtools/App/Share/Data/LanguagesRepository/Cache/Sync/RealmLanguagesCacheSync.swift
+++ b/godtools/App/Share/Data/LanguagesRepository/Cache/Sync/RealmLanguagesCacheSync.swift
@@ -41,6 +41,8 @@ class RealmLanguagesCacheSync {
                     }
                 }
                                                 
+                let languagesRemoved: [LanguageModel] = existingLanguagesMinusNewlyAddedLanguages.map({LanguageModel(model: $0)})
+                                                
                 do {
                     
                     try realm.write {
@@ -49,7 +51,7 @@ class RealmLanguagesCacheSync {
                     }
                     
                     let result = RealmLanguagesCacheSyncResult(
-                        languagesRemoved: existingLanguagesMinusNewlyAddedLanguages.map({LanguageModel(model: $0)})
+                        languagesRemoved: languagesRemoved
                     )
                     
                     promise(.success(result))


### PR DESCRIPTION
This PR fixes a high rate crash in Firebase.  The languages sync logic was accessing realm language objects that had already been deleted from the Realm Database leading to a crash.

https://console.firebase.google.com/u/0/project/godtools-b2f82/crashlytics/app/ios:org.cru.godtools/issues/903f6aa72ea166d4ccdcdb05d040c13d?time=last-seven-days&sessionEventKey=9c4efb4fdbbe42b8b7ef9b27c41dd945_1730589182804246939 