### PR TITLE
GT-1580 Add arguments for contentLanguage and secondaryContentLanguage in FirebaseAnalytics

### DIFF
--- a/godtools/App/AppDelegate.swift
+++ b/godtools/App/AppDelegate.swift
@@ -160,9 +160,23 @@ extension AppDelegate {
             
         case .tool:
             
-            appDiContainer.analytics.trackActionAnalytics.trackAction(trackAction: TrackActionModel(screenName: "", actionName: AnalyticsConstants.ActionNames.toolOpenedShortcut, siteSection: "", siteSubSection: "", url: nil, data: [
-                AnalyticsConstants.Keys.toolOpenedShortcutCountKey: 1
-            ]))
+            let getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase = appDiContainer.domainLayer.getSettingsPrimaryLanguageUseCase()
+            let getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase = appDiContainer.domainLayer.getSettingsParallelLanguageUseCase()
+            
+            let trackAction = TrackActionModel(
+                screenName: "",
+                actionName: AnalyticsConstants.ActionNames.toolOpenedShortcut,
+                siteSection: "",
+                siteSubSection: "",
+                contentLanguage: getSettingsPrimaryLanguageUseCase.getPrimaryLanguage()?.analyticsContentLanguage,
+                secondaryContentLanguage: getSettingsParallelLanguageUseCase.getParallelLanguage()?.analyticsContentLanguage,
+                url: nil,
+                data: [
+                    AnalyticsConstants.Keys.toolOpenedShortcutCountKey: 1
+                ]
+            )
+            
+            appDiContainer.analytics.trackActionAnalytics.trackAction(trackAction: trackAction)
             
             if let tractUrl = ToolShortcutItem.getTractUrl(shortcutItem: shortcutItem) {
                 successfullyHandledQuickAction = appDeepLinkingService.parseDeepLinkAndNotify(incomingDeepLink: .url(incomingUrl: IncomingDeepLinkUrl(url: tractUrl)))

--- a/godtools/App/AppDiContainer.swift
+++ b/godtools/App/AppDiContainer.swift
@@ -72,7 +72,7 @@ class AppDiContainer {
         let analyticsLoggingEnabled: Bool = appBuild.configuration == .analyticsLogging
         analytics = AnalyticsContainer(
             appsFlyerAnalytics: AppsFlyerAnalytics(appsFlyer: dataLayer.getSharedAppsFlyer(), loggingEnabled: analyticsLoggingEnabled),
-            firebaseAnalytics: FirebaseAnalytics(appBuild: appBuild, oktaUserAuthentication: oktaUserAuthentication, languageSettingsService: languageSettingsService, loggingEnabled: analyticsLoggingEnabled),
+            firebaseAnalytics: FirebaseAnalytics(appBuild: appBuild, oktaUserAuthentication: oktaUserAuthentication, loggingEnabled: analyticsLoggingEnabled),
             snowplowAnalytics: SnowplowAnalytics(config: appConfig, oktaUserAuthentication: oktaUserAuthentication, loggingEnabled: analyticsLoggingEnabled)
         )
                                                                                              
@@ -186,6 +186,8 @@ class AppDiContainer {
     func getOnboardingTutorialCustomViewBuilder(flowDelegate: FlowDelegate) -> CustomViewBuilderType {
         return OnboardingTutorialCustomViewBuilder(
             flowDelegate: flowDelegate,
+            getSettingsPrimaryLanguageUseCase: domainLayer.getSettingsPrimaryLanguageUseCase(),
+            getSettingsParallelLanguageUseCase: domainLayer.getSettingsParallelLanguageUseCase(),
             localizationServices: localizationServices,
             tutorialVideoAnalytics: getTutorialVideoAnalytics(),
             analyticsScreenName: "onboarding"

--- a/godtools/App/Features/Articles/ArticleCategories/ArticleCategoriesViewModel.swift
+++ b/godtools/App/Features/Articles/ArticleCategories/ArticleCategoriesViewModel.swift
@@ -18,6 +18,8 @@ class ArticleCategoriesViewModel: NSObject, ArticleCategoriesViewModelType {
     private let articleManifestAemRepository: ArticleManifestAemRepository
     private let localizationServices: LocalizationServices
     private let manifestResourcesCache: ManifestResourcesCache
+    private let getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase
+    private let getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase
     private let analytics: AnalyticsContainer
     
     private var categories: [GodToolsToolParser.Category] = Array()
@@ -28,7 +30,7 @@ class ArticleCategoriesViewModel: NSObject, ArticleCategoriesViewModelType {
     let numberOfCategories: ObservableValue<Int> = ObservableValue(value: 0)
     let isLoading: ObservableValue<Bool> = ObservableValue(value: false)
         
-    required init(flowDelegate: FlowDelegate, resource: ResourceModel, language: LanguageModel, manifest: Manifest, articleManifestAemRepository: ArticleManifestAemRepository, manifestResourcesCache: ManifestResourcesCache, localizationServices: LocalizationServices, analytics: AnalyticsContainer) {
+    init(flowDelegate: FlowDelegate, resource: ResourceModel, language: LanguageModel, manifest: Manifest, articleManifestAemRepository: ArticleManifestAemRepository, manifestResourcesCache: ManifestResourcesCache, localizationServices: LocalizationServices, getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase, getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase, analytics: AnalyticsContainer) {
         
         self.flowDelegate = flowDelegate
         self.resource = resource
@@ -37,6 +39,8 @@ class ArticleCategoriesViewModel: NSObject, ArticleCategoriesViewModelType {
         self.articleManifestAemRepository = articleManifestAemRepository
         self.manifestResourcesCache = manifestResourcesCache
         self.localizationServices = localizationServices
+        self.getSettingsPrimaryLanguageUseCase = getSettingsPrimaryLanguageUseCase
+        self.getSettingsParallelLanguageUseCase = getSettingsParallelLanguageUseCase
         self.analytics = analytics
         
         super.init()
@@ -89,7 +93,15 @@ class ArticleCategoriesViewModel: NSObject, ArticleCategoriesViewModelType {
 
     func pageViewed() {
         
-        analytics.pageViewedAnalytics.trackPageView(trackScreen: TrackScreenModel(screenName: analyticsScreenName, siteSection: analyticsSiteSection, siteSubSection: analyticsSiteSubSection))
+        let trackScreen = TrackScreenModel(
+            screenName: analyticsScreenName,
+            siteSection: analyticsSiteSection,
+            siteSubSection: analyticsSiteSubSection,
+            contentLanguage: getSettingsPrimaryLanguageUseCase.getPrimaryLanguage()?.analyticsContentLanguage,
+            secondaryContentLanguage: getSettingsParallelLanguageUseCase.getParallelLanguage()?.analyticsContentLanguage
+        )
+        
+        analytics.pageViewedAnalytics.trackPageView(trackScreen: trackScreen)
         analytics.appsFlyerAnalytics.trackAction(actionName: analyticsScreenName, data: nil)
     }
     

--- a/godtools/App/Features/Articles/Articles/ArticlesViewModel.swift
+++ b/godtools/App/Features/Articles/Articles/ArticlesViewModel.swift
@@ -19,6 +19,8 @@ class ArticlesViewModel: NSObject, ArticlesViewModelType {
     private let manifest: Manifest
     private let articleManifestAemRepository: ArticleManifestAemRepository
     private let localizationServices: LocalizationServices
+    private let getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase
+    private let getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase
     private let analytics: AnalyticsContainer
         
     private var articles: [AemUri] = Array()
@@ -32,7 +34,7 @@ class ArticlesViewModel: NSObject, ArticlesViewModelType {
     let isLoading: ObservableValue<Bool> = ObservableValue(value: false)
     let errorMessage: ObservableValue<ArticlesErrorMessageViewModel?> = ObservableValue(value: nil)
         
-    required init(flowDelegate: FlowDelegate, resource: ResourceModel, language: LanguageModel, category: GodToolsToolParser.Category, manifest: Manifest, articleManifestAemRepository: ArticleManifestAemRepository, localizationServices: LocalizationServices, analytics: AnalyticsContainer, currentArticleDownloadReceipt: ArticleManifestDownloadArticlesReceipt?) {
+    init(flowDelegate: FlowDelegate, resource: ResourceModel, language: LanguageModel, category: GodToolsToolParser.Category, manifest: Manifest, articleManifestAemRepository: ArticleManifestAemRepository, localizationServices: LocalizationServices, getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase, getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase, analytics: AnalyticsContainer, currentArticleDownloadReceipt: ArticleManifestDownloadArticlesReceipt?) {
         
         self.flowDelegate = flowDelegate
         self.resource = resource
@@ -41,6 +43,8 @@ class ArticlesViewModel: NSObject, ArticlesViewModelType {
         self.manifest = manifest
         self.articleManifestAemRepository = articleManifestAemRepository
         self.localizationServices = localizationServices
+        self.getSettingsPrimaryLanguageUseCase = getSettingsPrimaryLanguageUseCase
+        self.getSettingsParallelLanguageUseCase = getSettingsParallelLanguageUseCase
         self.analytics = analytics
         self.continueArticleDownloadReceipt = currentArticleDownloadReceipt
         
@@ -185,7 +189,15 @@ class ArticlesViewModel: NSObject, ArticlesViewModelType {
     
     func pageViewed() {
         
-        analytics.pageViewedAnalytics.trackPageView(trackScreen: TrackScreenModel(screenName: analyticsScreenName, siteSection: analyticsSiteSection, siteSubSection: analyticsSiteSubSection))
+        let trackScreen = TrackScreenModel(
+            screenName: analyticsScreenName,
+            siteSection: analyticsSiteSection,
+            siteSubSection: analyticsSiteSubSection,
+            contentLanguage: getSettingsPrimaryLanguageUseCase.getPrimaryLanguage()?.analyticsContentLanguage,
+            secondaryContentLanguage: getSettingsParallelLanguageUseCase.getParallelLanguage()?.analyticsContentLanguage
+        )
+        
+        analytics.pageViewedAnalytics.trackPageView(trackScreen: trackScreen)
     }
     
     func articleTapped(index: Int) {

--- a/godtools/App/Features/Articles/ArticlesWeb/ArticleWebViewModel.swift
+++ b/godtools/App/Features/Articles/ArticlesWeb/ArticleWebViewModel.swift
@@ -12,6 +12,8 @@ import WebKit
 class ArticleWebViewModel: NSObject, ArticleWebViewModelType {
     
     private let aemCacheObject: ArticleAemCacheObject
+    private let getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase
+    private let getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase
     private let analytics: AnalyticsContainer
     private let flowType: ArticleWebViewModelFlowType
     
@@ -21,10 +23,12 @@ class ArticleWebViewModel: NSObject, ArticleWebViewModelType {
     let hidesShareButton: ObservableValue<Bool> = ObservableValue(value: false)
     let isLoading: ObservableValue<Bool> = ObservableValue(value: false)
     
-    required init(flowDelegate: FlowDelegate, aemCacheObject: ArticleAemCacheObject, analytics: AnalyticsContainer, flowType: ArticleWebViewModelFlowType) {
+    init(flowDelegate: FlowDelegate, aemCacheObject: ArticleAemCacheObject, getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase, getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase, analytics: AnalyticsContainer, flowType: ArticleWebViewModelFlowType) {
         
         self.flowDelegate = flowDelegate
         self.aemCacheObject = aemCacheObject
+        self.getSettingsPrimaryLanguageUseCase = getSettingsPrimaryLanguageUseCase
+        self.getSettingsParallelLanguageUseCase = getSettingsParallelLanguageUseCase
         self.analytics = analytics
         self.flowType = flowType
         
@@ -59,8 +63,16 @@ class ArticleWebViewModel: NSObject, ArticleWebViewModelType {
     }
 
     func pageViewed() {
+        
+        let trackScreen = TrackScreenModel(
+            screenName: analyticsScreenName,
+            siteSection: analyticsSiteSection,
+            siteSubSection: analyticsSiteSubSection,
+            contentLanguage: getSettingsPrimaryLanguageUseCase.getPrimaryLanguage()?.analyticsContentLanguage,
+            secondaryContentLanguage: getSettingsParallelLanguageUseCase.getParallelLanguage()?.analyticsContentLanguage
+        )
                 
-        analytics.pageViewedAnalytics.trackPageView(trackScreen: TrackScreenModel(screenName: analyticsScreenName, siteSection: analyticsSiteSection, siteSubSection: analyticsSiteSubSection))
+        analytics.pageViewedAnalytics.trackPageView(trackScreen: trackScreen)
     }
     
     func sharedTapped() {

--- a/godtools/App/Features/Articles/ShareArticle/ShareArticleViewModel.swift
+++ b/godtools/App/Features/Articles/ShareArticle/ShareArticleViewModel.swift
@@ -10,13 +10,17 @@ import Foundation
 
 class ShareArticleViewModel: ShareArticleViewModelType {
     
+    private let getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase
+    private let getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase
     private let analytics: AnalyticsContainer
     private let articleAemData: ArticleAemData
     
     let shareMessage: String
     
-    required init(articleAemData: ArticleAemData, analytics: AnalyticsContainer) {
+    init(articleAemData: ArticleAemData, getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase, getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase, analytics: AnalyticsContainer) {
         
+        self.getSettingsPrimaryLanguageUseCase = getSettingsPrimaryLanguageUseCase
+        self.getSettingsParallelLanguageUseCase = getSettingsParallelLanguageUseCase
         self.analytics = analytics
         self.articleAemData = articleAemData
         
@@ -48,11 +52,30 @@ class ShareArticleViewModel: ShareArticleViewModelType {
     
     func pageViewed() {
         
-        analytics.pageViewedAnalytics.trackPageView(trackScreen: TrackScreenModel(screenName: analyticsScreenName, siteSection: analyticsSiteSection, siteSubSection: analyticsSiteSubSection))
+        let trackScreen = TrackScreenModel(
+            screenName: analyticsScreenName,
+            siteSection: analyticsSiteSection,
+            siteSubSection: analyticsSiteSubSection,
+            contentLanguage: getSettingsPrimaryLanguageUseCase.getPrimaryLanguage()?.analyticsContentLanguage,
+            secondaryContentLanguage: getSettingsParallelLanguageUseCase.getParallelLanguage()?.analyticsContentLanguage
+        )
+        
+        analytics.pageViewedAnalytics.trackPageView(trackScreen: trackScreen)
     }
     
     func articleShared() {
                 
-        analytics.trackActionAnalytics.trackAction(trackAction: TrackActionModel(screenName: analyticsScreenName, actionName: AnalyticsConstants.ActionNames.shareIconEngaged, siteSection: analyticsSiteSection, siteSubSection: analyticsSiteSubSection, url: nil, data: [AnalyticsConstants.Keys.shareAction: 1]))
+        let trackAction = TrackActionModel(
+            screenName: analyticsScreenName,
+            actionName: AnalyticsConstants.ActionNames.shareIconEngaged,
+            siteSection: analyticsSiteSection,
+            siteSubSection: analyticsSiteSubSection,
+            contentLanguage: getSettingsPrimaryLanguageUseCase.getPrimaryLanguage()?.analyticsContentLanguage,
+            secondaryContentLanguage: getSettingsParallelLanguageUseCase.getParallelLanguage()?.analyticsContentLanguage,
+            url: nil,
+            data: [AnalyticsConstants.Keys.shareAction: 1]
+        )
+        
+        analytics.trackActionAnalytics.trackAction(trackAction: trackAction)
     }
 }

--- a/godtools/App/Features/ChooseYourOwnAdventure/ChooseYourOwnAdventureViewModel.swift
+++ b/godtools/App/Features/ChooseYourOwnAdventure/ChooseYourOwnAdventureViewModel.swift
@@ -58,10 +58,6 @@ class ChooseYourOwnAdventureViewModel: MobileContentPagesViewModel, ChooseYourOw
         
         super.init(renderer: renderer, page: page, resourcesRepository: resourcesRepository, translationsRepository: translationsRepository, mobileContentEventAnalytics: mobileContentEventAnalytics, initialPageRenderingType: .chooseYourOwnAdventure, trainingTipsEnabled: trainingTipsEnabled)
     }
-
-    required init(renderer: MobileContentRenderer, page: Int?, resourcesRepository: ResourcesRepository, translationsRepository: TranslationsRepository, mobileContentEventAnalytics: MobileContentEventAnalyticsTracking, initialPageRenderingType: MobileContentPagesInitialPageRenderingType, trainingTipsEnabled: Bool) {
-        fatalError("init(renderer:page:resourcesRepository:translationsRepository:mobileContentEventAnalytics:initialPageRenderingType:trainingTipsEnabled:) has not been implemented")
-    }
     
     override func pageDidAppear(page: Int) {
         super.pageDidAppear(page: page)

--- a/godtools/App/Features/LanguageSettings/Presentation/ChooseLanguage/ChooseLanguageViewModel.swift
+++ b/godtools/App/Features/LanguageSettings/Presentation/ChooseLanguage/ChooseLanguageViewModel.swift
@@ -43,7 +43,7 @@ class ChooseLanguageViewModel: ChooseLanguageViewModelType {
     let numberOfLanguages: ObservableValue<Int> = ObservableValue(value: 0)
     let selectedLanguageIndex: ObservableValue<Int?> = ObservableValue(value: nil)
     
-    required init(flowDelegate: FlowDelegate, getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase, getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase,  userDidSetSettingsPrimaryLanguageUseCase: UserDidSetSettingsPrimaryLanguageUseCase, userDidSetSettingsParallelLanguageUseCase: UserDidSetSettingsParallelLanguageUseCase, userDidDeleteSettingsParallelLanguageUseCase: UserDidDeleteSettingsParallelLanguageUseCase, getSettingsLanguagesUseCase: GetSettingsLanguagesUseCase, localizationServices: LocalizationServices, analytics: AnalyticsContainer, chooseLanguageType: ChooseLanguageType) {
+    init(flowDelegate: FlowDelegate, getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase, getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase,  userDidSetSettingsPrimaryLanguageUseCase: UserDidSetSettingsPrimaryLanguageUseCase, userDidSetSettingsParallelLanguageUseCase: UserDidSetSettingsParallelLanguageUseCase, userDidDeleteSettingsParallelLanguageUseCase: UserDidDeleteSettingsParallelLanguageUseCase, getSettingsLanguagesUseCase: GetSettingsLanguagesUseCase, localizationServices: LocalizationServices, analytics: AnalyticsContainer, chooseLanguageType: ChooseLanguageType) {
         
         self.flowDelegate = flowDelegate
         self.getSettingsPrimaryLanguageUseCase = getSettingsPrimaryLanguageUseCase
@@ -141,7 +141,15 @@ class ChooseLanguageViewModel: ChooseLanguageViewModelType {
     
     func pageViewed() {
         
-        analytics.pageViewedAnalytics.trackPageView(trackScreen: TrackScreenModel(screenName: analyticsScreenName, siteSection: analyticsSiteSection, siteSubSection: analyticsSiteSubSection))
+        let trackScreen = TrackScreenModel(
+            screenName: analyticsScreenName,
+            siteSection: analyticsSiteSection,
+            siteSubSection: analyticsSiteSubSection,
+            contentLanguage: getSettingsPrimaryLanguageUseCase.getPrimaryLanguage()?.analyticsContentLanguage,
+            secondaryContentLanguage: getSettingsParallelLanguageUseCase.getParallelLanguage()?.analyticsContentLanguage
+        )
+        
+        analytics.pageViewedAnalytics.trackPageView(trackScreen: trackScreen)
     }
     
     func deleteLanguageTapped() {

--- a/godtools/App/Features/LanguageSettings/Presentation/LanguageSettings/LanguageSettingsViewModel.swift
+++ b/godtools/App/Features/LanguageSettings/Presentation/LanguageSettings/LanguageSettingsViewModel.swift
@@ -28,7 +28,7 @@ class LanguageSettingsViewModel: LanguageSettingsViewModelType {
     let shareGodToolsInNativeLanguage: String
     let languageAvailability: String
     
-    required init(flowDelegate: FlowDelegate, getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase, getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase, localizationServices: LocalizationServices, analytics: AnalyticsContainer) {
+    init(flowDelegate: FlowDelegate, getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase, getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase, localizationServices: LocalizationServices, analytics: AnalyticsContainer) {
         
         self.flowDelegate = flowDelegate
         self.getSettingsPrimaryLanguageUseCase = getSettingsPrimaryLanguageUseCase
@@ -82,7 +82,16 @@ class LanguageSettingsViewModel: LanguageSettingsViewModelType {
 extension LanguageSettingsViewModel {
     
     func pageViewed() {
-        analytics.pageViewedAnalytics.trackPageView(trackScreen: TrackScreenModel(screenName: analyticsScreenName, siteSection: analyticsSiteSection, siteSubSection: analyticsSiteSubSection))
+        
+        let trackScreen = TrackScreenModel(
+            screenName: analyticsScreenName,
+            siteSection: analyticsSiteSection,
+            siteSubSection: analyticsSiteSubSection,
+            contentLanguage: getSettingsPrimaryLanguageUseCase.getPrimaryLanguage()?.analyticsContentLanguage,
+            secondaryContentLanguage: getSettingsParallelLanguageUseCase.getParallelLanguage()?.analyticsContentLanguage
+        )
+        
+        analytics.pageViewedAnalytics.trackPageView(trackScreen: trackScreen)
     }
     
     func choosePrimaryLanguageTapped() {

--- a/godtools/App/Features/Lessons/Lesson/LessonViewModel.swift
+++ b/godtools/App/Features/Lessons/Lesson/LessonViewModel.swift
@@ -21,10 +21,6 @@ class LessonViewModel: MobileContentPagesViewModel, LessonViewModelType {
         super.init(renderer: renderer, page: page, resourcesRepository: resourcesRepository, translationsRepository: translationsRepository, mobileContentEventAnalytics: mobileContentEventAnalytics, initialPageRenderingType: .visiblePages, trainingTipsEnabled: trainingTipsEnabled)
     }
 
-    required init(renderer: MobileContentRenderer, page: Int?, resourcesRepository: ResourcesRepository, translationsRepository: TranslationsRepository, mobileContentEventAnalytics: MobileContentEventAnalyticsTracking, initialPageRenderingType: MobileContentPagesInitialPageRenderingType, trainingTipsEnabled: Bool) {
-        fatalError("init(renderer:page:resourcesRepository:translationsRepository:mobileContentEventAnalytics:initialPageRenderingType:trainingTipsEnabled:) has not been implemented")
-    }
-    
     override func handleDismissToolEvent() {
         super.handleDismissToolEvent()
         

--- a/godtools/App/Features/Lessons/Lessons/LessonsView/LessonsViewModel.swift
+++ b/godtools/App/Features/Lessons/Lessons/LessonsView/LessonsViewModel.swift
@@ -129,23 +129,45 @@ extension LessonsViewModel {
     
     func pageViewed() {
         
-        analytics.pageViewedAnalytics.trackPageView(trackScreen: TrackScreenModel(screenName: analyticsScreenName, siteSection: analyticsSiteSection, siteSubSection: analyticsSiteSubSection))
+        let trackScreen = TrackScreenModel(
+            screenName: analyticsScreenName,
+            siteSection: analyticsSiteSection,
+            siteSubSection: analyticsSiteSubSection,
+            contentLanguage: getSettingsPrimaryLanguageUseCase.getPrimaryLanguage()?.analyticsContentLanguage,
+            secondaryContentLanguage: getSettingsParallelLanguageUseCase.getParallelLanguage()?.analyticsContentLanguage
+        )
+        
+        analytics.pageViewedAnalytics.trackPageView(trackScreen: trackScreen)
+        
         analytics.appsFlyerAnalytics.trackAction(actionName: analyticsScreenName, data:  nil)
-        analytics.firebaseAnalytics.trackAction(screenName: "", siteSection: "", siteSubSection: "", actionName: AnalyticsConstants.ActionNames.viewedLessonsAction, data: nil)
+        
+        analytics.firebaseAnalytics.trackAction(
+            screenName: "",
+            siteSection: "",
+            siteSubSection: "",
+            contentLanguage: getSettingsPrimaryLanguageUseCase.getPrimaryLanguage()?.analyticsContentLanguage,
+            secondaryContentLanguage: getSettingsParallelLanguageUseCase.getParallelLanguage()?.analyticsContentLanguage,
+            actionName: AnalyticsConstants.ActionNames.viewedLessonsAction,
+            data: nil
+        )
     }
     
     private func trackLessonTappedAnalytics(for lesson: LessonDomainModel) {
         
-        analytics.trackActionAnalytics.trackAction(trackAction: TrackActionModel(
+        let trackAction = TrackActionModel(
             screenName: analyticsScreenName,
             actionName: AnalyticsConstants.ActionNames.lessonOpenTapped,
             siteSection: "",
             siteSubSection: "",
+            contentLanguage: getSettingsPrimaryLanguageUseCase.getPrimaryLanguage()?.analyticsContentLanguage,
+            secondaryContentLanguage: getSettingsParallelLanguageUseCase.getParallelLanguage()?.analyticsContentLanguage,
             url: nil,
             data: [
                 AnalyticsConstants.Keys.source: AnalyticsConstants.Sources.lessons,
                 AnalyticsConstants.Keys.tool: lesson.abbreviation
             ]
-        ))
+        )
+        
+        analytics.trackActionAnalytics.trackAction(trackAction: trackAction)
     }
 }

--- a/godtools/App/Features/Menu/About/AboutViewModel.swift
+++ b/godtools/App/Features/Menu/About/AboutViewModel.swift
@@ -11,14 +11,18 @@ import Foundation
 class AboutViewModel: AboutViewModelType {
     
     private let aboutTextProvider: AboutTextProviderType
+    private let getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase
+    private let getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase
     private let analytics: AnalyticsContainer
     
     let navTitle: ObservableValue<String> = ObservableValue(value: "")
     let aboutTexts: ObservableValue<[AboutTextModel]> = ObservableValue(value: [])
     
-    required init(aboutTextProvider: AboutTextProviderType, localizationServices: LocalizationServices, analytics: AnalyticsContainer) {
+    init(aboutTextProvider: AboutTextProviderType, localizationServices: LocalizationServices, getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase, getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase, analytics: AnalyticsContainer) {
         
         self.aboutTextProvider = aboutTextProvider
+        self.getSettingsPrimaryLanguageUseCase = getSettingsPrimaryLanguageUseCase
+        self.getSettingsParallelLanguageUseCase = getSettingsParallelLanguageUseCase
         self.analytics = analytics
         
         navTitle.accept(value: localizationServices.stringForMainBundle(key: "aboutApp.navTitle"))
@@ -39,6 +43,15 @@ class AboutViewModel: AboutViewModelType {
     }
     
     func pageViewed() {
-        analytics.pageViewedAnalytics.trackPageView(trackScreen: TrackScreenModel(screenName: analyticsScreenName, siteSection: analyticsSiteSection, siteSubSection: analyticsSiteSubSection))
+        
+        let trackScreen = TrackScreenModel(
+            screenName: analyticsScreenName,
+            siteSection: analyticsSiteSection,
+            siteSubSection: analyticsSiteSubSection,
+            contentLanguage: getSettingsPrimaryLanguageUseCase.getPrimaryLanguage()?.analyticsContentLanguage,
+            secondaryContentLanguage: getSettingsParallelLanguageUseCase.getParallelLanguage()?.analyticsContentLanguage
+        )
+        
+        analytics.pageViewedAnalytics.trackPageView(trackScreen: trackScreen)
     }
 }

--- a/godtools/App/Features/Menu/Account/AccountViewModel.swift
+++ b/godtools/App/Features/Menu/Account/AccountViewModel.swift
@@ -11,6 +11,8 @@ import Foundation
 class AccountViewModel: AccountViewModelType {
     
     private let oktaUserAuthentication: OktaUserAuthentication
+    private let getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase
+    private let getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase
     private let analytics: AnalyticsContainer
         
     let globalAnalyticsService: GlobalAnalyticsService
@@ -21,11 +23,13 @@ class AccountViewModel: AccountViewModelType {
     let accountItems: ObservableValue<[AccountItem]> = ObservableValue(value: [])
     let currentAccountItemIndex: ObservableValue<Int> = ObservableValue(value: 0)
     
-    required init(oktaUserAuthentication: OktaUserAuthentication, globalAnalyticsService: GlobalAnalyticsService, localizationServices: LocalizationServices, analytics: AnalyticsContainer) {
+    init(oktaUserAuthentication: OktaUserAuthentication, globalAnalyticsService: GlobalAnalyticsService, localizationServices: LocalizationServices, getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase, getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase, analytics: AnalyticsContainer) {
         
         self.oktaUserAuthentication = oktaUserAuthentication
         self.globalAnalyticsService = globalAnalyticsService
         self.localizationServices = localizationServices
+        self.getSettingsPrimaryLanguageUseCase = getSettingsPrimaryLanguageUseCase
+        self.getSettingsParallelLanguageUseCase = getSettingsParallelLanguageUseCase
         self.analytics = analytics
         
         navTitle = localizationServices.stringForMainBundle(key: "account.navTitle")
@@ -93,6 +97,14 @@ class AccountViewModel: AccountViewModelType {
 
     func accountPageDidAppear(page: Int) {
         
-        analytics.pageViewedAnalytics.trackPageView(trackScreen: TrackScreenModel(screenName: getAnalyticsScreenName(page: page), siteSection: analyticsSiteSection, siteSubSection: analyticsSiteSubSection))
+        let trackScreen = TrackScreenModel(
+            screenName: getAnalyticsScreenName(page: page),
+            siteSection: analyticsSiteSection,
+            siteSubSection: analyticsSiteSubSection,
+            contentLanguage: getSettingsPrimaryLanguageUseCase.getPrimaryLanguage()?.analyticsContentLanguage,
+            secondaryContentLanguage: getSettingsParallelLanguageUseCase.getParallelLanguage()?.analyticsContentLanguage
+        )
+        
+        analytics.pageViewedAnalytics.trackPageView(trackScreen: trackScreen)
     }
 }

--- a/godtools/App/Features/Menu/Menu/MenuViewModel.swift
+++ b/godtools/App/Features/Menu/Menu/MenuViewModel.swift
@@ -14,6 +14,8 @@ class MenuViewModel: NSObject, MenuViewModelType {
     private let supportedLanguageCodesForAccountCreation: [String] = ["en"]
     private let oktaUserAuthentication: OktaUserAuthentication
     private let localizationServices: LocalizationServices
+    private let getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase
+    private let getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase
     private let analytics: AnalyticsContainer
     private let getOptInOnboardingTutorialAvailableUseCase: GetOptInOnboardingTutorialAvailableUseCase
     private let disableOptInOnboardingBannerUseCase: DisableOptInOnboardingBannerUseCase
@@ -24,12 +26,14 @@ class MenuViewModel: NSObject, MenuViewModelType {
     let navDoneButtonTitle: String
     let menuDataSource: ObservableValue<MenuDataSource> = ObservableValue(value: MenuDataSource.createEmptyDataSource())
     
-    required init(flowDelegate: FlowDelegate, infoPlist: InfoPlist, oktaUserAuthentication: OktaUserAuthentication, localizationServices: LocalizationServices, analytics: AnalyticsContainer, getOptInOnboardingTutorialAvailableUseCase: GetOptInOnboardingTutorialAvailableUseCase, disableOptInOnboardingBannerUseCase: DisableOptInOnboardingBannerUseCase) {
+    init(flowDelegate: FlowDelegate, infoPlist: InfoPlist, oktaUserAuthentication: OktaUserAuthentication, localizationServices: LocalizationServices, getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase, getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase, analytics: AnalyticsContainer, getOptInOnboardingTutorialAvailableUseCase: GetOptInOnboardingTutorialAvailableUseCase, disableOptInOnboardingBannerUseCase: DisableOptInOnboardingBannerUseCase) {
         
         self.flowDelegate = flowDelegate
         self.infoPlist = infoPlist
         self.oktaUserAuthentication = oktaUserAuthentication
         self.localizationServices = localizationServices
+        self.getSettingsPrimaryLanguageUseCase = getSettingsPrimaryLanguageUseCase
+        self.getSettingsParallelLanguageUseCase = getSettingsParallelLanguageUseCase
         self.analytics = analytics
         self.getOptInOnboardingTutorialAvailableUseCase = getOptInOnboardingTutorialAvailableUseCase
         self.disableOptInOnboardingBannerUseCase = disableOptInOnboardingBannerUseCase
@@ -172,7 +176,16 @@ class MenuViewModel: NSObject, MenuViewModelType {
     }
     
     func pageViewed() {
-        analytics.pageViewedAnalytics.trackPageView(trackScreen: TrackScreenModel(screenName: getMenuAnalyticsScreenName(), siteSection: analyticsSiteSection, siteSubSection: analyticsSiteSubSection))
+        
+        let trackScreen = TrackScreenModel(
+            screenName: getMenuAnalyticsScreenName(),
+            siteSection: analyticsSiteSection,
+            siteSubSection: analyticsSiteSubSection,
+            contentLanguage: getSettingsPrimaryLanguageUseCase.getPrimaryLanguage()?.analyticsContentLanguage,
+            secondaryContentLanguage: getSettingsParallelLanguageUseCase.getParallelLanguage()?.analyticsContentLanguage
+        )
+        
+        analytics.pageViewedAnalytics.trackPageView(trackScreen: trackScreen)
     }
     
     func doneTapped() {
@@ -225,16 +238,43 @@ extension MenuViewModel {
         
         flowDelegate?.navigate(step: .shareGodToolsTappedFromMenu)
         
-        analytics.trackActionAnalytics.trackAction(trackAction: TrackActionModel(screenName: getShareAppAnalyticsScreenName(), actionName: AnalyticsConstants.ActionNames.shareIconEngaged, siteSection: analyticsSiteSection, siteSubSection: analyticsSiteSubSection, url: nil, data: [AnalyticsConstants.Keys.shareAction: 1]))
+        let trackAction = TrackActionModel(
+            screenName: getShareAppAnalyticsScreenName(),
+            actionName: AnalyticsConstants.ActionNames.shareIconEngaged,
+            siteSection: analyticsSiteSection,
+            siteSubSection: analyticsSiteSubSection,
+            contentLanguage: getSettingsPrimaryLanguageUseCase.getPrimaryLanguage()?.analyticsContentLanguage,
+            secondaryContentLanguage: getSettingsParallelLanguageUseCase.getParallelLanguage()?.analyticsContentLanguage,
+            url: nil,
+            data: [AnalyticsConstants.Keys.shareAction: 1]
+        )
         
-        analytics.pageViewedAnalytics.trackPageView(trackScreen: TrackScreenModel(screenName: getShareAppAnalyticsScreenName(), siteSection: analyticsSiteSection, siteSubSection: analyticsSiteSubSection))
+        analytics.trackActionAnalytics.trackAction(trackAction: trackAction)
+        
+        let trackScreen = TrackScreenModel(
+            screenName: getShareAppAnalyticsScreenName(),
+            siteSection: analyticsSiteSection,
+            siteSubSection: analyticsSiteSubSection,
+            contentLanguage: getSettingsPrimaryLanguageUseCase.getPrimaryLanguage()?.analyticsContentLanguage,
+            secondaryContentLanguage: getSettingsParallelLanguageUseCase.getParallelLanguage()?.analyticsContentLanguage
+        )
+        
+        analytics.pageViewedAnalytics.trackPageView(trackScreen: trackScreen)
     }
     
     func shareAStoryWithUsTapped() {
         
         flowDelegate?.navigate(step: .shareAStoryWithUsTappedFromMenu)
         
-        analytics.pageViewedAnalytics.trackPageView(trackScreen: TrackScreenModel(screenName: getShareStoryAnalyticsScreenName(), siteSection: analyticsSiteSection, siteSubSection: analyticsSiteSubSection))
+        let trackScreen = TrackScreenModel(
+            screenName: getShareStoryAnalyticsScreenName(),
+            siteSection: analyticsSiteSection,
+            siteSubSection: analyticsSiteSubSection,
+            contentLanguage: getSettingsPrimaryLanguageUseCase.getPrimaryLanguage()?.analyticsContentLanguage,
+            secondaryContentLanguage: getSettingsParallelLanguageUseCase.getParallelLanguage()?.analyticsContentLanguage
+        )
+        
+        analytics.pageViewedAnalytics.trackPageView(trackScreen: trackScreen)
     }
     
     func termsOfUseTapped() {

--- a/godtools/App/Features/Menu/WebContent/WebContentViewModel.swift
+++ b/godtools/App/Features/Menu/WebContent/WebContentViewModel.swift
@@ -10,14 +10,18 @@ import Foundation
 
 class WebContentViewModel: WebContentViewModelType {
     
+    private let getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase
+    private let getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase
     private let analytics: AnalyticsContainer
     private let webContent: WebContentType
     
     let navTitle: ObservableValue<String> = ObservableValue(value: "")
     let url: ObservableValue<URL?> = ObservableValue(value: nil)
     
-    required init(analytics: AnalyticsContainer, webContent: WebContentType) {
+    init(getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase, getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase, analytics: AnalyticsContainer, webContent: WebContentType) {
         
+        self.getSettingsPrimaryLanguageUseCase = getSettingsPrimaryLanguageUseCase
+        self.getSettingsParallelLanguageUseCase = getSettingsParallelLanguageUseCase
         self.analytics = analytics
         self.webContent = webContent
         
@@ -39,6 +43,14 @@ class WebContentViewModel: WebContentViewModelType {
     
     func pageViewed() {
         
-        analytics.pageViewedAnalytics.trackPageView(trackScreen: TrackScreenModel(screenName: analyticsScreenName, siteSection: analyticsSiteSection, siteSubSection: analyticsSiteSubSection))
+        let trackScreen = TrackScreenModel(
+            screenName: analyticsScreenName,
+            siteSection: analyticsSiteSection,
+            siteSubSection: analyticsSiteSubSection,
+            contentLanguage: getSettingsPrimaryLanguageUseCase.getPrimaryLanguage()?.analyticsContentLanguage,
+            secondaryContentLanguage: getSettingsParallelLanguageUseCase.getParallelLanguage()?.analyticsContentLanguage
+        )
+        
+        analytics.pageViewedAnalytics.trackPageView(trackScreen: trackScreen)
     }
 }

--- a/godtools/App/Features/Onboarding/Models/OnboardingTutorialCustomViewBuilder.swift
+++ b/godtools/App/Features/Onboarding/Models/OnboardingTutorialCustomViewBuilder.swift
@@ -10,17 +10,20 @@ import UIKit
 
 class OnboardingTutorialCustomViewBuilder: CustomViewBuilderType {
 
-    
-    private weak var flowDelegate: FlowDelegate?
-    
+    private let getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase
+    private let getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase
     private let localizationServices: LocalizationServices
     private let tutorialVideoAnalytics: TutorialVideoAnalytics
     private let analyticsScreenName: String
     
-    required init(flowDelegate: FlowDelegate, localizationServices: LocalizationServices, tutorialVideoAnalytics: TutorialVideoAnalytics, analyticsScreenName: String) {
+    private weak var flowDelegate: FlowDelegate?
+    
+    init(flowDelegate: FlowDelegate, getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase, getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase, localizationServices: LocalizationServices, tutorialVideoAnalytics: TutorialVideoAnalytics, analyticsScreenName: String) {
         
         self.flowDelegate = flowDelegate
 
+        self.getSettingsPrimaryLanguageUseCase = getSettingsPrimaryLanguageUseCase
+        self.getSettingsParallelLanguageUseCase = getSettingsParallelLanguageUseCase
         self.localizationServices = localizationServices
         self.tutorialVideoAnalytics = tutorialVideoAnalytics
         self.analyticsScreenName = analyticsScreenName
@@ -29,7 +32,15 @@ class OnboardingTutorialCustomViewBuilder: CustomViewBuilderType {
     func buildCustomView(customViewId: String) -> UIView? {
 
         if let onboardingFlowDelegate = flowDelegate, customViewId == "onboarding-0" {
-            let viewModel = OnboardingTutorialIntroViewModel(flowDelegate: onboardingFlowDelegate, localizationServices: localizationServices, tutorialVideoAnalytics: tutorialVideoAnalytics, analyticsScreenName: analyticsScreenName)
+            
+            let viewModel = OnboardingTutorialIntroViewModel(
+                flowDelegate: onboardingFlowDelegate,
+                getSettingsPrimaryLanguageUseCase: getSettingsPrimaryLanguageUseCase,
+                getSettingsParallelLanguageUseCase: getSettingsParallelLanguageUseCase,
+                localizationServices: localizationServices,
+                tutorialVideoAnalytics: tutorialVideoAnalytics,
+                analyticsScreenName: analyticsScreenName
+            )
 
             let view = OnboardingTutorialIntroView()
 

--- a/godtools/App/Features/Onboarding/OnboardingQuickStartViewModel.swift
+++ b/godtools/App/Features/Onboarding/OnboardingQuickStartViewModel.swift
@@ -10,18 +10,19 @@ import Foundation
 
 class OnboardingQuickStartViewModel: OnboardingQuickStartViewModelType {
     
+    private let quickStartItems: [OnboardingQuickStartItem]
+    private let getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase
+    private let getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase
+    private let trackActionAnalytics: TrackActionAnalytics
+    
+    private weak var flowDelegate: FlowDelegate?
+    
     let title: String
     let skipButtonTitle: String
     let endTutorialButtonTitle: String
     let quickStartItemCount: Int
     
-    private let quickStartItems: [OnboardingQuickStartItem]
-    
-    private let trackActionAnalytics: TrackActionAnalytics
-    
-    private weak var flowDelegate: FlowDelegate?
-    
-    required init(flowDelegate: FlowDelegate, localizationServices: LocalizationServices, trackActionAnalytics: TrackActionAnalytics) {
+    init(flowDelegate: FlowDelegate, localizationServices: LocalizationServices, getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase, getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase, trackActionAnalytics: TrackActionAnalytics) {
         
         title = localizationServices.stringForMainBundle(key: "onboardingQuickStart.title")
         skipButtonTitle = localizationServices.stringForMainBundle(key: "navigationBar.navigationItem.skip")
@@ -29,6 +30,8 @@ class OnboardingQuickStartViewModel: OnboardingQuickStartViewModelType {
         
         self.flowDelegate = flowDelegate
         
+        self.getSettingsPrimaryLanguageUseCase = getSettingsPrimaryLanguageUseCase
+        self.getSettingsParallelLanguageUseCase = getSettingsParallelLanguageUseCase
         self.trackActionAnalytics = trackActionAnalytics
         
         quickStartItems = [
@@ -67,7 +70,18 @@ class OnboardingQuickStartViewModel: OnboardingQuickStartViewModelType {
     func quickStartCellTapped(index: Int) {
         let item = quickStartItems[index]
         
-        trackActionAnalytics.trackAction(trackAction: TrackActionModel(screenName: analyticsScreenName, actionName: item.linkButtonAnalyticsAction, siteSection: "", siteSubSection: "", url: nil, data: nil))
+        let trackAction = TrackActionModel(
+            screenName: analyticsScreenName,
+            actionName: item.linkButtonAnalyticsAction,
+            siteSection: "",
+            siteSubSection: "",
+            contentLanguage: getSettingsPrimaryLanguageUseCase.getPrimaryLanguage()?.analyticsContentLanguage,
+            secondaryContentLanguage: getSettingsParallelLanguageUseCase.getParallelLanguage()?.analyticsContentLanguage,
+            url: nil,
+            data: nil
+        )
+        
+        trackActionAnalytics.trackAction(trackAction: trackAction)
         
         flowDelegate?.navigate(step: item.linkButtonFlowStep)
     }

--- a/godtools/App/Features/Onboarding/OnboardingTutorialViewModel.swift
+++ b/godtools/App/Features/Onboarding/OnboardingTutorialViewModel.swift
@@ -13,20 +13,16 @@ class OnboardingTutorialViewModel: TutorialPagerViewModel {
     private let viewBuilder: CustomViewBuilderType
     private let localizationServices: LocalizationServices
         
-    required init(flowDelegate: FlowDelegate, analyticsContainer: AnalyticsContainer, tutorialVideoAnalytics: TutorialVideoAnalytics, onboardingTutorialItemsRepository: OnboardingTutorialItemsRepositoryType, onboardingTutorialAvailability: OnboardingTutorialAvailabilityType, customViewBuilder: CustomViewBuilderType, localizationServices: LocalizationServices) {
+    required init(flowDelegate: FlowDelegate, getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase, getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase, analyticsContainer: AnalyticsContainer, tutorialVideoAnalytics: TutorialVideoAnalytics, onboardingTutorialItemsRepository: OnboardingTutorialItemsRepositoryType, onboardingTutorialAvailability: OnboardingTutorialAvailabilityType, customViewBuilder: CustomViewBuilderType, localizationServices: LocalizationServices) {
         
         self.viewBuilder = customViewBuilder
         self.localizationServices = localizationServices
         
         let tutorialPagerAnalyticsModel = TutorialPagerAnalytics(screenName: "onboarding", siteSection: "onboarding", siteSubsection: "", continueButtonTappedActionName: "Onboarding Start", continueButtonTappedData: [AnalyticsConstants.Keys.onboardingStart: 1], screenTrackIndexOffset: 2)
         
-        super.init(flowDelegate: flowDelegate, analyticsContainer: analyticsContainer, tutorialVideoAnalytics: tutorialVideoAnalytics,  tutorialItems: onboardingTutorialItemsRepository.tutorialItems, tutorialPagerAnalyticsModel: tutorialPagerAnalyticsModel, skipButtonTitle: localizationServices.stringForMainBundle(key: "navigationBar.navigationItem.skip"))
+        super.init(flowDelegate: flowDelegate, getSettingsPrimaryLanguageUseCase: getSettingsPrimaryLanguageUseCase, getSettingsParallelLanguageUseCase: getSettingsParallelLanguageUseCase, analyticsContainer: analyticsContainer, tutorialVideoAnalytics: tutorialVideoAnalytics,  tutorialItems: onboardingTutorialItemsRepository.tutorialItems, tutorialPagerAnalyticsModel: tutorialPagerAnalyticsModel, skipButtonTitle: localizationServices.stringForMainBundle(key: "navigationBar.navigationItem.skip"))
         
         onboardingTutorialAvailability.markOnboardingTutorialViewed()
-    }
-    
-    required init(flowDelegate: FlowDelegate, analyticsContainer: AnalyticsContainer, tutorialVideoAnalytics: TutorialVideoAnalytics, tutorialItems: [TutorialItemType], tutorialPagerAnalyticsModel: TutorialPagerAnalytics, skipButtonTitle: String) {
-        fatalError("init(analyticsContainer:localizationServices:tutorialItems:) has not been implemented")
     }
     
     override var customViewBuilder: CustomViewBuilderType? {

--- a/godtools/App/Features/Onboarding/Views/OnboardingTutorialIntroViewModel.swift
+++ b/godtools/App/Features/Onboarding/Views/OnboardingTutorialIntroViewModel.swift
@@ -10,20 +10,24 @@ import UIKit
 
 class OnboardingTutorialIntroViewModel: OnboardingTutorialIntroViewModelType {
 
-    private weak var flowDelegate: FlowDelegate?
-    
+    private let getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase
+    private let getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase
     private let tutorialVideoAnalytics: TutorialVideoAnalytics
     private let analyticsScreenName: String
     private let youtubeVideoId: String
+    
+    private weak var flowDelegate: FlowDelegate?
     
     let logoImage: UIImage?
     let title: String
     let videoLinkLabel: String
     
-    required init(flowDelegate: FlowDelegate, localizationServices: LocalizationServices, tutorialVideoAnalytics: TutorialVideoAnalytics, analyticsScreenName: String) {
+    init(flowDelegate: FlowDelegate, getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase, getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase, localizationServices: LocalizationServices, tutorialVideoAnalytics: TutorialVideoAnalytics, analyticsScreenName: String) {
         
         self.flowDelegate = flowDelegate
         
+        self.getSettingsPrimaryLanguageUseCase = getSettingsPrimaryLanguageUseCase
+        self.getSettingsParallelLanguageUseCase = getSettingsParallelLanguageUseCase
         self.tutorialVideoAnalytics = tutorialVideoAnalytics
         self.analyticsScreenName = analyticsScreenName
                 
@@ -40,6 +44,11 @@ class OnboardingTutorialIntroViewModel: OnboardingTutorialIntroViewModelType {
         
         flowDelegate?.navigate(step: .videoButtonTappedFromOnboardingTutorial(youtubeVideoId: youtubeVideoId))
         
-        tutorialVideoAnalytics.trackVideoPlayed(videoId: youtubeVideoId, screenName: analyticsScreenName)
+        tutorialVideoAnalytics.trackVideoPlayed(
+            videoId: youtubeVideoId,
+            screenName: analyticsScreenName,
+            contentLanguage: getSettingsPrimaryLanguageUseCase.getPrimaryLanguage()?.analyticsContentLanguage,
+            secondaryContentLanguage: getSettingsParallelLanguageUseCase.getParallelLanguage()?.analyticsContentLanguage
+        )
     }
 }

--- a/godtools/App/Features/Tool/ToolViewModel.swift
+++ b/godtools/App/Features/Tool/ToolViewModel.swift
@@ -50,10 +50,6 @@ class ToolViewModel: MobileContentPagesViewModel, ToolViewModelType {
         setupBinding()
     }
     
-    required init(renderer: MobileContentRenderer, page: Int?, resourcesRepository: ResourcesRepository, translationsRepository: TranslationsRepository, mobileContentEventAnalytics: MobileContentEventAnalyticsTracking, initialPageRenderingType: MobileContentPagesInitialPageRenderingType, trainingTipsEnabled: Bool) {
-        fatalError("init(renderer:page:resourcesRepository:translationsRepository:mobileContentEventAnalytics:initialPageRenderingType:trainingTipsEnabled:) has not been implemented")
-    }
-    
     deinit {
                 
         tractRemoteSharePublisher.didCreateNewSubscriberChannelIdForPublish.removeObserver(self)
@@ -160,9 +156,20 @@ extension ToolViewModel {
     
     private func trackShareScreenOpened() {
         
-        analytics.trackActionAnalytics.trackAction(trackAction: TrackActionModel(screenName: analyticsScreenName, actionName: AnalyticsConstants.ActionNames.shareScreenOpened, siteSection: analyticsSiteSection, siteSubSection: "", url: nil, data: [
-            AnalyticsConstants.Keys.shareScreenOpenedCountKey: 1
-        ]))
+        let trackAction = TrackActionModel(
+            screenName: analyticsScreenName,
+            actionName: AnalyticsConstants.ActionNames.shareScreenOpened,
+            siteSection: analyticsSiteSection,
+            siteSubSection: "",
+            contentLanguage: nil,
+            secondaryContentLanguage: nil,
+            url: nil,
+            data: [
+                AnalyticsConstants.Keys.shareScreenOpenedCountKey: 1
+            ]
+        )
+        
+        analytics.trackActionAnalytics.trackAction(trackAction: trackAction)
     }
     
     private func subscribeToLiveShareStreamIfNeeded() {

--- a/godtools/App/Features/Tool/Views/ToolNavBar/ToolNavBarViewModel.swift
+++ b/godtools/App/Features/Tool/Views/ToolNavBar/ToolNavBarViewModel.swift
@@ -28,7 +28,7 @@ class ToolNavBarViewModel: NSObject, ToolNavBarViewModelType {
     let remoteShareIsActive: ObservableValue<Bool> = ObservableValue(value: false)
     let selectedLanguage: ObservableValue<Int>
     
-    required init(backButtonImageType: ToolBackButtonImageType, resource: ResourceModel, manifest: Manifest, languages: [LanguageModel], tractRemoteSharePublisher: TractRemoteSharePublisher, tractRemoteShareSubscriber: TractRemoteShareSubscriber, getTranslatedLanguageUseCase: GetTranslatedLanguageUseCase, fontService: FontService, analytics: AnalyticsContainer, selectedLanguageValue: Int?) {
+    init(backButtonImageType: ToolBackButtonImageType, resource: ResourceModel, manifest: Manifest, languages: [LanguageModel], tractRemoteSharePublisher: TractRemoteSharePublisher, tractRemoteShareSubscriber: TractRemoteShareSubscriber, getTranslatedLanguageUseCase: GetTranslatedLanguageUseCase, fontService: FontService, analytics: AnalyticsContainer, selectedLanguageValue: Int?) {
         
         self.backButtonImageType = backButtonImageType
         self.resource = resource
@@ -126,7 +126,17 @@ class ToolNavBarViewModel: NSObject, ToolNavBarViewModelType {
             AnalyticsConstants.Keys.contentLanguageSecondary: language.code,
         ]
         
-        analytics.trackActionAnalytics.trackAction(trackAction: TrackActionModel(screenName: analyticsScreenName, actionName: AnalyticsConstants.ActionNames.parallelLanguageToggled, siteSection: analyticsSiteSection, siteSubSection: "", url: nil, data: data)
+        let trackAction = TrackActionModel(
+            screenName: analyticsScreenName,
+            actionName: AnalyticsConstants.ActionNames.parallelLanguageToggled,
+            siteSection: analyticsSiteSection,
+            siteSubSection: "",
+            contentLanguage: language.code,
+            secondaryContentLanguage: nil,
+            url: nil,
+            data: data
         )
+        
+        analytics.trackActionAnalytics.trackAction(trackAction: trackAction)
     }
 }

--- a/godtools/App/Features/ToolDetails/Presentation/ToolDetails/ToolDetailsView.swift
+++ b/godtools/App/Features/ToolDetails/Presentation/ToolDetails/ToolDetailsView.swift
@@ -122,6 +122,7 @@ struct ToolDetailsView_Preview: PreviewProvider {
             removeToolFromFavoritesUseCase: appDiContainer.domainLayer.getRemoveToolFromFavoritesUseCase(),
             getToolIsFavoritedUseCase: appDiContainer.domainLayer.getToolIsFavoritedUseCase(),
             getSettingsPrimaryLanguageUseCase: appDiContainer.domainLayer.getSettingsPrimaryLanguageUseCase(),
+            getSettingsParallelLanguageUseCase: appDiContainer.domainLayer.getSettingsParallelLanguageUseCase(),
             getToolLanguagesUseCase: appDiContainer.domainLayer.getToolLanguagesUseCase(),
             localizationServices: appDiContainer.localizationServices,
             analytics: appDiContainer.analytics,

--- a/godtools/App/Features/ToolDetails/Presentation/ToolDetails/ToolDetailsViewModel.swift
+++ b/godtools/App/Features/ToolDetails/Presentation/ToolDetails/ToolDetailsViewModel.swift
@@ -19,6 +19,7 @@ class ToolDetailsViewModel: ObservableObject {
     private let removeToolFromFavoritesUseCase: RemoveToolFromFavoritesUseCase
     private let getToolIsFavoritedUseCase: GetToolIsFavoritedUseCase
     private let getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase
+    private let getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase
     private let getToolLanguagesUseCase: GetToolLanguagesUseCase
     private let localizationServices: LocalizationServices
     private let analytics: AnalyticsContainer
@@ -58,7 +59,7 @@ class ToolDetailsViewModel: ObservableObject {
     @Published var toolVersions: [ToolVersionDomainModel] = Array()
     @Published var selectedToolVersion: ToolVersionDomainModel?
     
-    init(flowDelegate: FlowDelegate, resource: ResourceModel, resourcesRepository: ResourcesRepository, translationsRepository: TranslationsRepository, getToolDetailsMediaUseCase: GetToolDetailsMediaUseCase, addToolToFavoritesUseCase: AddToolToFavoritesUseCase, removeToolFromFavoritesUseCase: RemoveToolFromFavoritesUseCase, getToolIsFavoritedUseCase: GetToolIsFavoritedUseCase, getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase, getToolLanguagesUseCase: GetToolLanguagesUseCase, localizationServices: LocalizationServices, analytics: AnalyticsContainer, getToolTranslationsFilesUseCase: GetToolTranslationsFilesUseCase, getToolVersionsUseCase: GetToolVersionsUseCase, getBannerImageUseCase: GetBannerImageUseCase) {
+    init(flowDelegate: FlowDelegate, resource: ResourceModel, resourcesRepository: ResourcesRepository, translationsRepository: TranslationsRepository, getToolDetailsMediaUseCase: GetToolDetailsMediaUseCase, addToolToFavoritesUseCase: AddToolToFavoritesUseCase, removeToolFromFavoritesUseCase: RemoveToolFromFavoritesUseCase, getToolIsFavoritedUseCase: GetToolIsFavoritedUseCase, getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase, getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase, getToolLanguagesUseCase: GetToolLanguagesUseCase, localizationServices: LocalizationServices, analytics: AnalyticsContainer, getToolTranslationsFilesUseCase: GetToolTranslationsFilesUseCase, getToolVersionsUseCase: GetToolVersionsUseCase, getBannerImageUseCase: GetBannerImageUseCase) {
         
         self.flowDelegate = flowDelegate
         self.resource = resource
@@ -69,6 +70,7 @@ class ToolDetailsViewModel: ObservableObject {
         self.removeToolFromFavoritesUseCase = removeToolFromFavoritesUseCase
         self.getToolIsFavoritedUseCase = getToolIsFavoritedUseCase
         self.getSettingsPrimaryLanguageUseCase = getSettingsPrimaryLanguageUseCase
+        self.getSettingsParallelLanguageUseCase = getSettingsParallelLanguageUseCase
         self.getToolLanguagesUseCase = getToolLanguagesUseCase
         self.localizationServices = localizationServices
         self.analytics = analytics
@@ -209,17 +211,21 @@ class ToolDetailsViewModel: ObservableObject {
     
     private func trackToolVersionTappedAnalytics(for tool: ResourceModel) {
         
-        analytics.trackActionAnalytics.trackAction(trackAction: TrackActionModel(
+        let trackAction = TrackActionModel(
             screenName: analyticsScreenName,
             actionName: AnalyticsConstants.ActionNames.openDetails,
             siteSection: "",
             siteSubSection: "",
+            contentLanguage: getSettingsPrimaryLanguageUseCase.getPrimaryLanguage()?.analyticsContentLanguage,
+            secondaryContentLanguage: getSettingsParallelLanguageUseCase.getParallelLanguage()?.analyticsContentLanguage,
             url: nil,
             data: [
                 AnalyticsConstants.Keys.source: AnalyticsConstants.Sources.versions,
                 AnalyticsConstants.Keys.tool: tool.abbreviation
             ]
-        ))
+        )
+        
+        analytics.trackActionAnalytics.trackAction(trackAction: trackAction)
     }
 }
 
@@ -229,22 +235,34 @@ extension ToolDetailsViewModel {
     
     func pageViewed() {
         
-        analytics.pageViewedAnalytics.trackPageView(trackScreen: TrackScreenModel(screenName: analyticsScreenName, siteSection: siteSection, siteSubSection: siteSubSection))
+        let trackScreen = TrackScreenModel(
+            screenName: analyticsScreenName,
+            siteSection: siteSection,
+            siteSubSection: siteSubSection,
+            contentLanguage: getSettingsPrimaryLanguageUseCase.getPrimaryLanguage()?.analyticsContentLanguage,
+            secondaryContentLanguage: getSettingsParallelLanguageUseCase.getParallelLanguage()?.analyticsContentLanguage
+        )
+        
+        analytics.pageViewedAnalytics.trackPageView(trackScreen: trackScreen)
     }
     
     func openToolTapped() {
         
-        analytics.trackActionAnalytics.trackAction(trackAction: TrackActionModel(
+        let trackAction = TrackActionModel(
             screenName: analyticsScreenName,
             actionName: AnalyticsConstants.ActionNames.toolOpened,
             siteSection: siteSection,
             siteSubSection: siteSubSection,
+            contentLanguage: getSettingsPrimaryLanguageUseCase.getPrimaryLanguage()?.analyticsContentLanguage,
+            secondaryContentLanguage: getSettingsParallelLanguageUseCase.getParallelLanguage()?.analyticsContentLanguage,
             url: nil,
             data: [
                 AnalyticsConstants.Keys.source: AnalyticsConstants.Sources.toolDetails,
                 AnalyticsConstants.Keys.tool: resource.abbreviation
-            ])
+            ]
         )
+        
+        analytics.trackActionAnalytics.trackAction(trackAction: trackAction)
 
         flowDelegate?.navigate(step: .openToolTappedFromToolDetails(resource: resource))
     }

--- a/godtools/App/Features/ToolSettings/ReviewShareShareable/ReviewShareShareableView.swift
+++ b/godtools/App/Features/ToolSettings/ReviewShareShareable/ReviewShareShareableView.swift
@@ -74,6 +74,8 @@ struct ReviewShareShareableViewPreview: PreviewProvider {
                 
         return ReviewShareShareableViewModel(
             flowDelegate: MockFlowDelegate(),
+            getSettingsPrimaryLanguageUseCase: appDiContainer.domainLayer.getSettingsPrimaryLanguageUseCase(),
+            getSettingsParallelLanguageUseCase: appDiContainer.domainLayer.getSettingsParallelLanguageUseCase(),
             analytics: appDiContainer.analytics,
             shareableImageDomainModel: ShareableImageDomainModel(image: UIImage(), imageId: nil, toolAbbreviation: nil),
             localizationServices: appDiContainer.localizationServices

--- a/godtools/App/Features/ToolSettings/ReviewShareShareable/ReviewShareShareableViewModel.swift
+++ b/godtools/App/Features/ToolSettings/ReviewShareShareable/ReviewShareShareableViewModel.swift
@@ -12,17 +12,21 @@ import SwiftUI
 class ReviewShareShareableViewModel: ObservableObject {
     
     private let imageToShare: UIImage
+    private let getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase
+    private let getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase
+    private let analytics: AnalyticsContainer
+    private let shareableImageDomainModel: ShareableImageDomainModel
     
     private weak var flowDelegate: FlowDelegate?
-    private let analytics: AnalyticsContainer
     
-    private let shareableImageDomainModel: ShareableImageDomainModel
     let imagePreview: Image
     let shareImageButtonTitle: String
     
-    init(flowDelegate: FlowDelegate, analytics: AnalyticsContainer, shareableImageDomainModel: ShareableImageDomainModel, localizationServices: LocalizationServices) {
+    init(flowDelegate: FlowDelegate, getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase, getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase, analytics: AnalyticsContainer, shareableImageDomainModel: ShareableImageDomainModel, localizationServices: LocalizationServices) {
         
         self.flowDelegate = flowDelegate
+        self.getSettingsPrimaryLanguageUseCase = getSettingsPrimaryLanguageUseCase
+        self.getSettingsParallelLanguageUseCase = getSettingsParallelLanguageUseCase
         self.analytics = analytics
         self.shareableImageDomainModel = shareableImageDomainModel
         self.imageToShare = shareableImageDomainModel.image
@@ -42,13 +46,18 @@ class ReviewShareShareableViewModel: ObservableObject {
     }
     
     private func trackShareImageTappedAnalytics() {
-        analytics.trackActionAnalytics.trackAction(trackAction: TrackActionModel(
+        
+        let trackAction = TrackActionModel(
             screenName: "",
             actionName: AnalyticsConstants.ActionNames.shareShareable,
             siteSection: shareableImageDomainModel.toolAbbreviation ?? "",
             siteSubSection: "",
+            contentLanguage: getSettingsPrimaryLanguageUseCase.getPrimaryLanguage()?.analyticsContentLanguage,
+            secondaryContentLanguage: getSettingsParallelLanguageUseCase.getParallelLanguage()?.analyticsContentLanguage,
             url: nil,
             data: [AnalyticsConstants.Keys.shareableId: shareableImageDomainModel.imageId ?? ""]
-        ))
+        )
+        
+        analytics.trackActionAnalytics.trackAction(trackAction: trackAction)
     }
 }

--- a/godtools/App/Features/ToolSettings/ShareTool/ShareToolViewModel.swift
+++ b/godtools/App/Features/ToolSettings/ShareTool/ShareToolViewModel.swift
@@ -11,14 +11,18 @@ import Foundation
 class ShareToolViewModel: ShareToolViewModelType {
         
     private let resource: ResourceModel
+    private let getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase
+    private let getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase
     private let analytics: AnalyticsContainer
     private let pageNumber: Int
     
     let shareMessage: String
     
-    required init(resource: ResourceModel, language: LanguageModel, pageNumber: Int, localizationServices: LocalizationServices, analytics: AnalyticsContainer) {
+    init(resource: ResourceModel, language: LanguageModel, pageNumber: Int, localizationServices: LocalizationServices, getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase, getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase, analytics: AnalyticsContainer) {
                 
         self.resource = resource
+        self.getSettingsPrimaryLanguageUseCase = getSettingsPrimaryLanguageUseCase
+        self.getSettingsParallelLanguageUseCase = getSettingsParallelLanguageUseCase
         self.analytics = analytics
         self.pageNumber = pageNumber
         
@@ -50,10 +54,29 @@ class ShareToolViewModel: ShareToolViewModelType {
     
     func pageViewed() {
         
-        analytics.pageViewedAnalytics.trackPageView(trackScreen: TrackScreenModel(screenName: analyticsScreenName, siteSection: analyticsSiteSection, siteSubSection: analyticsSiteSubSection))
+        let trackScreen = TrackScreenModel(
+            screenName: analyticsScreenName,
+            siteSection: analyticsSiteSection,
+            siteSubSection: analyticsSiteSubSection,
+            contentLanguage: getSettingsPrimaryLanguageUseCase.getPrimaryLanguage()?.analyticsContentLanguage,
+            secondaryContentLanguage: getSettingsParallelLanguageUseCase.getParallelLanguage()?.analyticsContentLanguage
+        )
+        
+        analytics.pageViewedAnalytics.trackPageView(trackScreen: trackScreen)
+        
+        let trackAction = TrackActionModel(
+            screenName: analyticsScreenName,
+            actionName: AnalyticsConstants.ActionNames.shareIconEngaged,
+            siteSection: analyticsSiteSection,
+            siteSubSection: analyticsSiteSubSection,
+            contentLanguage: getSettingsPrimaryLanguageUseCase.getPrimaryLanguage()?.analyticsContentLanguage,
+            secondaryContentLanguage: getSettingsParallelLanguageUseCase.getParallelLanguage()?.analyticsContentLanguage,
+            url: nil,
+            data: [
+                AnalyticsConstants.Keys.shareAction: 1
+            ]
+        )
                 
-        analytics.trackActionAnalytics.trackAction(trackAction: TrackActionModel(screenName: analyticsScreenName, actionName: AnalyticsConstants.ActionNames.shareIconEngaged, siteSection: analyticsSiteSection, siteSubSection: analyticsSiteSubSection, url: nil, data: [
-            AnalyticsConstants.Keys.shareAction: 1
-        ]))
+        analytics.trackActionAnalytics.trackAction(trackAction: trackAction)
     }
 }

--- a/godtools/App/Features/ToolSettings/ShareToolRemoteSessionURL/ShareToolRemoteSessionURLViewModel.swift
+++ b/godtools/App/Features/ToolSettings/ShareToolRemoteSessionURL/ShareToolRemoteSessionURLViewModel.swift
@@ -10,12 +10,16 @@ import Foundation
 
 class ShareToolRemoteSessionURLViewModel: ShareToolRemoteSessionURLViewModelType {
         
+    private let getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase
+    private let getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase
     private let analytics: AnalyticsContainer
     
     let shareMessage: String
     
-    required init(toolRemoteShareUrl: String, localizationServices: LocalizationServices, analytics: AnalyticsContainer) {
+    required init(toolRemoteShareUrl: String, localizationServices: LocalizationServices, getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase, getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase, analytics: AnalyticsContainer) {
               
+        self.getSettingsPrimaryLanguageUseCase = getSettingsPrimaryLanguageUseCase
+        self.getSettingsParallelLanguageUseCase = getSettingsParallelLanguageUseCase
         self.analytics = analytics
         
         shareMessage = String.localizedStringWithFormat(
@@ -26,8 +30,19 @@ class ShareToolRemoteSessionURLViewModel: ShareToolRemoteSessionURLViewModelType
     
     func pageViewed() {
         
-        analytics.trackActionAnalytics.trackAction(trackAction: TrackActionModel(screenName: "", actionName: AnalyticsConstants.ActionNames.shareScreenEngaged, siteSection: "", siteSubSection: "", url: nil, data: [
-            AnalyticsConstants.Keys.shareScreenEngagedCountKey: 1
-        ]))
+        let trackAction = TrackActionModel(
+            screenName: "",
+            actionName: AnalyticsConstants.ActionNames.shareScreenEngaged,
+            siteSection: "",
+            siteSubSection: "",
+            contentLanguage: getSettingsPrimaryLanguageUseCase.getPrimaryLanguage()?.analyticsContentLanguage,
+            secondaryContentLanguage: getSettingsParallelLanguageUseCase.getParallelLanguage()?.analyticsContentLanguage,
+            url: nil,
+            data: [
+                AnalyticsConstants.Keys.shareScreenEngagedCountKey: 1
+            ]
+        )
+        
+        analytics.trackActionAnalytics.trackAction(trackAction: trackAction)
     }
 }

--- a/godtools/App/Features/ToolSettings/ShareToolScreenTutorial/ShareToolScreenTutorialViewModel.swift
+++ b/godtools/App/Features/ToolSettings/ShareToolScreenTutorial/ShareToolScreenTutorialViewModel.swift
@@ -15,6 +15,8 @@ class ShareToolScreenTutorialViewModel: ShareToolScreenTutorialViewModelType {
     private let tutorialItemsProvider: ShareToolScreenTutorialItemProvider
     private let shareToolScreenTutorialNumberOfViewsCache: ShareToolScreenTutorialNumberOfViewsCache
     private let resource: ResourceModel
+    private let getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase
+    private let getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase
     private let analyticsContainer: AnalyticsContainer
     private let tutorialVideoAnalytics: TutorialVideoAnalytics
     
@@ -26,13 +28,15 @@ class ShareToolScreenTutorialViewModel: ShareToolScreenTutorialViewModelType {
     let continueTitle: String
     let shareLinkTitle: String
     
-    required init(flowDelegate: FlowDelegate, localizationServices: LocalizationServices, tutorialItemsProvider: ShareToolScreenTutorialItemProvider, shareToolScreenTutorialNumberOfViewsCache: ShareToolScreenTutorialNumberOfViewsCache, resource: ResourceModel, analyticsContainer: AnalyticsContainer, tutorialVideoAnalytics: TutorialVideoAnalytics) {
+    init(flowDelegate: FlowDelegate, localizationServices: LocalizationServices, tutorialItemsProvider: ShareToolScreenTutorialItemProvider, shareToolScreenTutorialNumberOfViewsCache: ShareToolScreenTutorialNumberOfViewsCache, resource: ResourceModel, getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase, getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase, analyticsContainer: AnalyticsContainer, tutorialVideoAnalytics: TutorialVideoAnalytics) {
         
         self.flowDelegate = flowDelegate
         self.localizationServices = localizationServices
         self.tutorialItemsProvider = tutorialItemsProvider
         self.shareToolScreenTutorialNumberOfViewsCache = shareToolScreenTutorialNumberOfViewsCache
         self.resource = resource
+        self.getSettingsPrimaryLanguageUseCase = getSettingsPrimaryLanguageUseCase
+        self.getSettingsParallelLanguageUseCase = getSettingsParallelLanguageUseCase
         self.analyticsContainer = analyticsContainer
         self.tutorialVideoAnalytics = tutorialVideoAnalytics
         self.customViewBuilder = ShareToolScreenCustomTutorialViewBuilder()
@@ -49,7 +53,14 @@ class ShareToolScreenTutorialViewModel: ShareToolScreenTutorialViewModelType {
     
     func tutorialItemWillAppear(index: Int) -> TutorialCellViewModelType {
                 
-        return TutorialCellViewModel(item: tutorialItems.value[index], customViewBuilder: customViewBuilder, tutorialVideoAnalytics: tutorialVideoAnalytics, analyticsScreenName: analyticsScreenName)
+        return TutorialCellViewModel(
+            item: tutorialItems.value[index],
+            customViewBuilder: customViewBuilder,
+            tutorialVideoAnalytics: tutorialVideoAnalytics,
+            analyticsScreenName: analyticsScreenName,
+            getSettingsPrimaryLanguageUseCase: getSettingsPrimaryLanguageUseCase,
+            getSettingsParallelLanguageUseCase: getSettingsParallelLanguageUseCase
+        )
     }
     
     func closeTapped() {

--- a/godtools/App/Features/ToolTraining/ToolTrainingViewModel.swift
+++ b/godtools/App/Features/ToolTraining/ToolTrainingViewModel.swift
@@ -15,6 +15,8 @@ class ToolTrainingViewModel: NSObject, ToolTrainingViewModelType {
     private let renderedPageContext: MobileContentRenderedPageContext
     private let trainingTipId: String
     private let tipModel: Tip
+    private let getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase
+    private let getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase
     private let analytics: AnalyticsContainer
     private let localizationServices: LocalizationServices
     private let viewedTrainingTips: ViewedTrainingTipsService
@@ -29,12 +31,14 @@ class ToolTrainingViewModel: NSObject, ToolTrainingViewModelType {
     let continueButtonTitle: ObservableValue<String> = ObservableValue(value: "")
     let numberOfTipPages: ObservableValue<Int> = ObservableValue(value: 0)
     
-    required init(pageRenderer: MobileContentPageRenderer, renderedPageContext: MobileContentRenderedPageContext, trainingTipId: String, tipModel: Tip, analytics: AnalyticsContainer, localizationServices: LocalizationServices, viewedTrainingTips: ViewedTrainingTipsService, closeTappedClosure: @escaping (() -> Void)) {
+    init(pageRenderer: MobileContentPageRenderer, renderedPageContext: MobileContentRenderedPageContext, trainingTipId: String, tipModel: Tip, getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase, getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase, analytics: AnalyticsContainer, localizationServices: LocalizationServices, viewedTrainingTips: ViewedTrainingTipsService, closeTappedClosure: @escaping (() -> Void)) {
         
         self.renderedPageContext = renderedPageContext
         self.pageRenderer = pageRenderer
         self.trainingTipId = trainingTipId
         self.tipModel = tipModel
+        self.getSettingsPrimaryLanguageUseCase = getSettingsPrimaryLanguageUseCase
+        self.getSettingsParallelLanguageUseCase = getSettingsParallelLanguageUseCase
         self.analytics = analytics
         self.localizationServices = localizationServices
         self.viewedTrainingTips = viewedTrainingTips
@@ -188,8 +192,17 @@ class ToolTrainingViewModel: NSObject, ToolTrainingViewModelType {
     }
     
     func tipPageDidAppear(page: Int) {
+       
         setPage(page: page, animated: true)
         
-        analytics.pageViewedAnalytics.trackPageView(trackScreen: TrackScreenModel(screenName: getTipPageAnalyticsScreenName(tipPage: page), siteSection: analyticsSiteSection, siteSubSection: analyticsSiteSubSection))
+        let trackScreen = TrackScreenModel(
+            screenName: getTipPageAnalyticsScreenName(tipPage: page),
+            siteSection: analyticsSiteSection,
+            siteSubSection: analyticsSiteSubSection,
+            contentLanguage: getSettingsPrimaryLanguageUseCase.getPrimaryLanguage()?.analyticsContentLanguage,
+            secondaryContentLanguage: getSettingsParallelLanguageUseCase.getParallelLanguage()?.analyticsContentLanguage
+        )
+        
+        analytics.pageViewedAnalytics.trackPageView(trackScreen: trackScreen)
     }
 }

--- a/godtools/App/Features/Tools/SwiftUI/AllTools/AllToolsContentViewModel.swift
+++ b/godtools/App/Features/Tools/SwiftUI/AllTools/AllToolsContentViewModel.swift
@@ -18,13 +18,13 @@ class AllToolsContentViewModel: NSObject, ObservableObject {
     private let languageSettingsService: LanguageSettingsService
     private let localizationServices: LocalizationServices
     private let favoritingToolMessageCache: FavoritingToolMessageCache
+    private let getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase
+    private let getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase
     private let analytics: AnalyticsContainer
     
     private let getAllToolsUseCase: GetAllToolsUseCase
     private let getBannerImageUseCase: GetBannerImageUseCase
     private let getLanguageAvailabilityUseCase: GetLanguageAvailabilityUseCase
-    private let getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase
-    private let getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase
     private let getSpotlightToolsUseCase: GetSpotlightToolsUseCase
     private let getToolCategoriesUseCase: GetToolCategoriesUseCase
     private let getToolIsFavoritedUseCase: GetToolIsFavoritedUseCase
@@ -192,23 +192,46 @@ extension AllToolsContentViewModel {
     
     func pageViewed() {
         
-        analytics.pageViewedAnalytics.trackPageView(trackScreen: TrackScreenModel(screenName: analyticsScreenName, siteSection: analyticsSiteSection, siteSubSection: analyticsSiteSubSection))
+        let trackScreen = TrackScreenModel(
+            screenName: analyticsScreenName,
+            siteSection: analyticsSiteSection,
+            siteSubSection: analyticsSiteSubSection,
+            contentLanguage: getSettingsPrimaryLanguageUseCase.getPrimaryLanguage()?.analyticsContentLanguage,
+            secondaryContentLanguage: getSettingsParallelLanguageUseCase.getParallelLanguage()?.analyticsContentLanguage
+        )
         
-        analytics.trackActionAnalytics.trackAction(trackAction: TrackActionModel(screenName: analyticsScreenName, actionName: AnalyticsConstants.ActionNames.viewedToolsAction, siteSection: analyticsSiteSection, siteSubSection: analyticsSiteSubSection, url: nil, data: nil))
+        analytics.pageViewedAnalytics.trackPageView(trackScreen: trackScreen)
+        
+        let trackAction = TrackActionModel(
+            screenName: analyticsScreenName,
+            actionName: AnalyticsConstants.ActionNames.viewedToolsAction,
+            siteSection: analyticsSiteSection,
+            siteSubSection: analyticsSiteSubSection,
+            contentLanguage: getSettingsPrimaryLanguageUseCase.getPrimaryLanguage()?.analyticsContentLanguage,
+            secondaryContentLanguage: getSettingsParallelLanguageUseCase.getParallelLanguage()?.analyticsContentLanguage,
+            url: nil,
+            data: nil
+        )
+        
+        analytics.trackActionAnalytics.trackAction(trackAction: trackAction)
     }
             
     private func trackToolTappedAnalytics(for tool: ResourceModel, isSpotlight: Bool) {
         
-        analytics.trackActionAnalytics.trackAction(trackAction: TrackActionModel(
+        let trackAction = TrackActionModel(
             screenName: analyticsScreenName,
             actionName: AnalyticsConstants.ActionNames.openDetails,
             siteSection: "",
             siteSubSection: "",
+            contentLanguage: getSettingsPrimaryLanguageUseCase.getPrimaryLanguage()?.analyticsContentLanguage,
+            secondaryContentLanguage: getSettingsParallelLanguageUseCase.getParallelLanguage()?.analyticsContentLanguage,
             url: nil,
             data: [
                 AnalyticsConstants.Keys.source: isSpotlight ? AnalyticsConstants.Sources.spotlight : AnalyticsConstants.Sources.allTools,
                 AnalyticsConstants.Keys.tool: tool.abbreviation
             ]
-        ))
+        )
+        
+        analytics.trackActionAnalytics.trackAction(trackAction: trackAction)
     }
 }

--- a/godtools/App/Features/Tools/SwiftUI/Favorites/AllFavoriteToolsView/AllFavoriteToolsViewModel.swift
+++ b/godtools/App/Features/Tools/SwiftUI/Favorites/AllFavoriteToolsView/AllFavoriteToolsViewModel.swift
@@ -28,6 +28,7 @@ class AllFavoriteToolsViewModel: BaseFavoriteToolsViewModel {
     // MARK: - Init
     
     init(dataDownloader: InitialDataDownloader, localizationServices: LocalizationServices, getAllFavoritedToolsUseCase: GetAllFavoritedToolsUseCase, getBannerImageUseCase: GetBannerImageUseCase, getLanguageAvailabilityUseCase: GetLanguageAvailabilityUseCase, getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase, getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase, getToolIsFavoritedUseCase: GetToolIsFavoritedUseCase, removeToolFromFavoritesUseCase: RemoveToolFromFavoritesUseCase, flowDelegate: FlowDelegate?, analytics: AnalyticsContainer) {
+        
         self.flowDelegate = flowDelegate
         self.analytics = analytics
         
@@ -105,35 +106,53 @@ extension AllFavoriteToolsViewModel {
         
     func pageViewed() {
         
-        analytics.pageViewedAnalytics.trackPageView(trackScreen: TrackScreenModel(screenName: analyticsScreenName, siteSection: analyticsSiteSection, siteSubSection: analyticsSiteSubSection))
+        let trackScreen = TrackScreenModel(
+            screenName: analyticsScreenName,
+            siteSection: analyticsSiteSection,
+            siteSubSection: analyticsSiteSubSection,
+            contentLanguage: getSettingsPrimaryLanguageUseCase.getPrimaryLanguage()?.analyticsContentLanguage,
+            secondaryContentLanguage: getSettingsParallelLanguageUseCase.getParallelLanguage()?.analyticsContentLanguage
+        )
+        
+        analytics.pageViewedAnalytics.trackPageView(trackScreen: trackScreen)
     }
     
     private func trackOpenFavoritedToolButtonAnalytics(for tool: ResourceModel) {
-        analytics.trackActionAnalytics.trackAction(trackAction: TrackActionModel(
+       
+        let trackAction = TrackActionModel(
             screenName: analyticsScreenName,
             actionName: AnalyticsConstants.ActionNames.toolOpened,
             siteSection: "",
             siteSubSection: "",
+            contentLanguage: getSettingsPrimaryLanguageUseCase.getPrimaryLanguage()?.analyticsContentLanguage,
+            secondaryContentLanguage: getSettingsParallelLanguageUseCase.getParallelLanguage()?.analyticsContentLanguage,
             url: nil,
             data: [
                 AnalyticsConstants.Keys.source: AnalyticsConstants.Sources.favoriteTools,
                 AnalyticsConstants.Keys.tool: tool.abbreviation
             ]
-        ))
+        )
+        
+        analytics.trackActionAnalytics.trackAction(trackAction: trackAction)
     }
     
     private func trackFavoritedToolDetailsButtonAnalytics(for tool: ResourceModel) {
-        analytics.trackActionAnalytics.trackAction(trackAction: TrackActionModel(
+        
+        let trackAction = TrackActionModel(
             screenName: analyticsScreenName,
             actionName: AnalyticsConstants.ActionNames.openDetails,
             siteSection: "",
             siteSubSection: "",
+            contentLanguage: getSettingsPrimaryLanguageUseCase.getPrimaryLanguage()?.analyticsContentLanguage,
+            secondaryContentLanguage: getSettingsParallelLanguageUseCase.getParallelLanguage()?.analyticsContentLanguage,
             url: nil,
             data: [
                 AnalyticsConstants.Keys.source: AnalyticsConstants.Sources.favoriteTools,
                 AnalyticsConstants.Keys.tool: tool.abbreviation
             ]
-        ))
+        )
+        
+        analytics.trackActionAnalytics.trackAction(trackAction: trackAction)
     }
 }
 

--- a/godtools/App/Features/Tools/SwiftUI/Favorites/FavoritesContentViewModel.swift
+++ b/godtools/App/Features/Tools/SwiftUI/Favorites/FavoritesContentViewModel.swift
@@ -104,9 +104,12 @@ extension FavoritesContentViewModel {
     }
     
     func getTutorialBannerViewModel() -> OpenTutorialBannerViewModel {
+        
         return OpenTutorialBannerViewModel(
             flowDelegate: flowDelegate,
             localizationServices: localizationServices,
+            getSettingsPrimaryLanguageUseCase: getSettingsPrimaryLanguageUseCase,
+            getSettingsParallelLanguageUseCase: getSettingsParallelLanguageUseCase,
             analytics: analytics,
             delegate: self
         )
@@ -219,52 +222,83 @@ extension FavoritesContentViewModel {
     
     func pageViewed() {
         
-        analytics.pageViewedAnalytics.trackPageView(trackScreen: TrackScreenModel(screenName: analyticsScreenName, siteSection: analyticsSiteSection, siteSubSection: analyticsSiteSubSection))
+        let trackScreen = TrackScreenModel(
+            screenName: analyticsScreenName,
+            siteSection: analyticsSiteSection,
+            siteSubSection: analyticsSiteSubSection,
+            contentLanguage: getSettingsPrimaryLanguageUseCase.getPrimaryLanguage()?.analyticsContentLanguage,
+            secondaryContentLanguage: getSettingsParallelLanguageUseCase.getParallelLanguage()?.analyticsContentLanguage
+        )
         
-        analytics.firebaseAnalytics.trackAction(screenName: "", siteSection: "", siteSubSection: "", actionName: AnalyticsConstants.ActionNames.viewedMyToolsAction, data: nil)
+        analytics.pageViewedAnalytics.trackPageView(trackScreen: trackScreen)
+        
+        analytics.firebaseAnalytics.trackAction(
+            screenName: "",
+            siteSection: "",
+            siteSubSection: "",
+            contentLanguage: getSettingsPrimaryLanguageUseCase.getPrimaryLanguage()?.analyticsContentLanguage,
+            secondaryContentLanguage: getSettingsParallelLanguageUseCase.getParallelLanguage()?.analyticsContentLanguage,
+            actionName: AnalyticsConstants.ActionNames.viewedMyToolsAction,
+            data: nil
+        )
         
         flowDelegate?.navigate(step: .userViewedFavoritedToolsListFromTools)
     }
     
     private func trackFeaturedLessonTappedAnalytics(for lesson: LessonDomainModel) {
-        analytics.trackActionAnalytics.trackAction(trackAction: TrackActionModel(
+       
+        let trackAction = TrackActionModel(
             screenName: analyticsScreenName,
             actionName: AnalyticsConstants.ActionNames.lessonOpenTapped,
             siteSection: "",
             siteSubSection: "",
+            contentLanguage: getSettingsPrimaryLanguageUseCase.getPrimaryLanguage()?.analyticsContentLanguage,
+            secondaryContentLanguage: getSettingsParallelLanguageUseCase.getParallelLanguage()?.analyticsContentLanguage,
             url: nil,
             data: [
-                    AnalyticsConstants.Keys.source: AnalyticsConstants.Sources.featured,
-                    AnalyticsConstants.Keys.tool: lesson.abbreviation
-                  ]
-        ))
+                AnalyticsConstants.Keys.source: AnalyticsConstants.Sources.featured,
+                AnalyticsConstants.Keys.tool: lesson.abbreviation
+              ]
+        )
+        
+        analytics.trackActionAnalytics.trackAction(trackAction: trackAction)
     }
     
     private func trackOpenFavoritedToolButtonAnalytics(for tool: ResourceModel) {
-        analytics.trackActionAnalytics.trackAction(trackAction: TrackActionModel(
+        
+        let trackAction = TrackActionModel(
             screenName: analyticsScreenName,
             actionName: AnalyticsConstants.ActionNames.toolOpened,
             siteSection: "",
             siteSubSection: "",
+            contentLanguage: getSettingsPrimaryLanguageUseCase.getPrimaryLanguage()?.analyticsContentLanguage,
+            secondaryContentLanguage: getSettingsParallelLanguageUseCase.getParallelLanguage()?.analyticsContentLanguage,
             url: nil,
             data: [
                 AnalyticsConstants.Keys.source: AnalyticsConstants.Sources.favoriteTools,
                 AnalyticsConstants.Keys.tool: tool.abbreviation
             ]
-        ))
+        )
+        
+        analytics.trackActionAnalytics.trackAction(trackAction: trackAction)
     }
     
     private func trackFavoritedToolDetailsButtonAnalytics(for tool: ResourceModel) {
-        analytics.trackActionAnalytics.trackAction(trackAction: TrackActionModel(
+       
+        let trackAction = TrackActionModel(
             screenName: analyticsScreenName,
             actionName: AnalyticsConstants.ActionNames.openDetails,
             siteSection: "",
             siteSubSection: "",
+            contentLanguage: getSettingsPrimaryLanguageUseCase.getPrimaryLanguage()?.analyticsContentLanguage,
+            secondaryContentLanguage: getSettingsParallelLanguageUseCase.getParallelLanguage()?.analyticsContentLanguage,
             url: nil,
             data: [
                 AnalyticsConstants.Keys.source: AnalyticsConstants.Sources.favoriteTools,
                 AnalyticsConstants.Keys.tool: tool.abbreviation
             ]
-        ))
+        )
+        
+        analytics.trackActionAnalytics.trackAction(trackAction: trackAction)
     }
 }

--- a/godtools/App/Features/Tools/SwiftUI/Favorites/OpenTutorialBannerView/OpenTutorialBannerView.swift
+++ b/godtools/App/Features/Tools/SwiftUI/Favorites/OpenTutorialBannerView/OpenTutorialBannerView.swift
@@ -49,6 +49,8 @@ struct OpenTutorialBannerView_Previews: PreviewProvider {
         let viewModel = OpenTutorialBannerViewModel(
             flowDelegate: MockFlowDelegate(),
             localizationServices: appDiContainer.localizationServices,
+            getSettingsPrimaryLanguageUseCase: appDiContainer.domainLayer.getSettingsPrimaryLanguageUseCase(),
+            getSettingsParallelLanguageUseCase: appDiContainer.domainLayer.getSettingsParallelLanguageUseCase(),
             analytics: appDiContainer.analytics,
             delegate: nil
         )

--- a/godtools/App/Features/Tools/SwiftUI/Favorites/OpenTutorialBannerView/OpenTutorialBannerViewModel.swift
+++ b/godtools/App/Features/Tools/SwiftUI/Favorites/OpenTutorialBannerView/OpenTutorialBannerViewModel.swift
@@ -18,7 +18,10 @@ class OpenTutorialBannerViewModel: NSObject, ObservableObject {
     // MARK: - Properties
     
     private let localizationServices: LocalizationServices
+    private let getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase
+    private let getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase
     private let analytics: AnalyticsContainer
+    
     private weak var flowDelegate: FlowDelegate?
     private weak var delegate: OpenTutorialBannerViewModelDelegate?
     
@@ -29,10 +32,12 @@ class OpenTutorialBannerViewModel: NSObject, ObservableObject {
     
     // MARK: - Init
     
-    init(flowDelegate: FlowDelegate?, localizationServices: LocalizationServices, analytics: AnalyticsContainer, delegate: OpenTutorialBannerViewModelDelegate?) {
+    init(flowDelegate: FlowDelegate?, localizationServices: LocalizationServices, getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase, getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase, analytics: AnalyticsContainer, delegate: OpenTutorialBannerViewModelDelegate?) {
         
         self.flowDelegate = flowDelegate
         self.localizationServices = localizationServices
+        self.getSettingsPrimaryLanguageUseCase = getSettingsPrimaryLanguageUseCase
+        self.getSettingsParallelLanguageUseCase = getSettingsParallelLanguageUseCase
         self.analytics = analytics
         self.delegate = delegate
         
@@ -64,6 +69,18 @@ extension OpenTutorialBannerViewModel {
     }
     
     private func trackCloseTapped() {
-        analytics.trackActionAnalytics.trackAction(trackAction: TrackActionModel(screenName: analyticsScreenName, actionName: AnalyticsConstants.ActionNames.tutorialHomeDismiss, siteSection: "", siteSubSection: "", url: nil, data: [AnalyticsConstants.Keys.tutorialDismissed: 1]))
+        
+        let trackAction = TrackActionModel(
+            screenName: analyticsScreenName,
+            actionName: AnalyticsConstants.ActionNames.tutorialHomeDismiss,
+            siteSection: "",
+            siteSubSection: "",
+            contentLanguage: getSettingsPrimaryLanguageUseCase.getPrimaryLanguage()?.analyticsContentLanguage,
+            secondaryContentLanguage: getSettingsParallelLanguageUseCase.getParallelLanguage()?.analyticsContentLanguage,
+            url: nil,
+            data: [AnalyticsConstants.Keys.tutorialDismissed: 1]
+        )
+        
+        analytics.trackActionAnalytics.trackAction(trackAction: trackAction)
     }
 }

--- a/godtools/App/Flows/App/AppFlow.swift
+++ b/godtools/App/Flows/App/AppFlow.swift
@@ -741,6 +741,7 @@ extension AppFlow {
             removeToolFromFavoritesUseCase: appDiContainer.domainLayer.getRemoveToolFromFavoritesUseCase(),
             getToolIsFavoritedUseCase: appDiContainer.domainLayer.getToolIsFavoritedUseCase(),
             getSettingsPrimaryLanguageUseCase: appDiContainer.domainLayer.getSettingsPrimaryLanguageUseCase(),
+            getSettingsParallelLanguageUseCase: appDiContainer.domainLayer.getSettingsParallelLanguageUseCase(),
             getToolLanguagesUseCase: appDiContainer.domainLayer.getToolLanguagesUseCase(),
             localizationServices: appDiContainer.localizationServices,
             analytics: appDiContainer.analytics,

--- a/godtools/App/Flows/Article/ArticleFlow.swift
+++ b/godtools/App/Flows/Article/ArticleFlow.swift
@@ -31,6 +31,8 @@ class ArticleFlow: Flow {
             articleManifestAemRepository: appDiContainer.getArticleManifestAemRepository(),
             manifestResourcesCache: appDiContainer.getManifestResourcesCache(),
             localizationServices: appDiContainer.localizationServices,
+            getSettingsPrimaryLanguageUseCase: appDiContainer.domainLayer.getSettingsPrimaryLanguageUseCase(),
+            getSettingsParallelLanguageUseCase: appDiContainer.domainLayer.getSettingsParallelLanguageUseCase(),
             analytics: appDiContainer.analytics
         )
         
@@ -60,6 +62,8 @@ class ArticleFlow: Flow {
                 manifest: manifest,
                 articleManifestAemRepository: appDiContainer.getArticleManifestAemRepository(),
                 localizationServices: appDiContainer.localizationServices,
+                getSettingsPrimaryLanguageUseCase: appDiContainer.domainLayer.getSettingsPrimaryLanguageUseCase(),
+                getSettingsParallelLanguageUseCase: appDiContainer.domainLayer.getSettingsParallelLanguageUseCase(),
                 analytics: appDiContainer.analytics,
                 currentArticleDownloadReceipt: currentArticleDownloadReceipt
             )
@@ -72,6 +76,8 @@ class ArticleFlow: Flow {
             let viewModel = ArticleWebViewModel(
                 flowDelegate: self,
                 aemCacheObject: aemCacheObject,
+                getSettingsPrimaryLanguageUseCase: appDiContainer.domainLayer.getSettingsPrimaryLanguageUseCase(),
+                getSettingsParallelLanguageUseCase: appDiContainer.domainLayer.getSettingsParallelLanguageUseCase(),
                 analytics: appDiContainer.analytics,
                 flowType: .tool(resource: resource)
             )
@@ -84,6 +90,8 @@ class ArticleFlow: Flow {
             
             let viewModel = ShareArticleViewModel(
                 articleAemData: articleAemData,
+                getSettingsPrimaryLanguageUseCase: appDiContainer.domainLayer.getSettingsPrimaryLanguageUseCase(),
+                getSettingsParallelLanguageUseCase: appDiContainer.domainLayer.getSettingsParallelLanguageUseCase(),
                 analytics: appDiContainer.analytics
             )
             

--- a/godtools/App/Flows/ArticleDeepLink/ArticleDeepLinkFlow.swift
+++ b/godtools/App/Flows/ArticleDeepLink/ArticleDeepLinkFlow.swift
@@ -82,6 +82,8 @@ class ArticleDeepLinkFlow: Flow {
         let viewModel = ArticleWebViewModel(
             flowDelegate: self,
             aemCacheObject: aemCacheObject,
+            getSettingsPrimaryLanguageUseCase: appDiContainer.domainLayer.getSettingsPrimaryLanguageUseCase(),
+            getSettingsParallelLanguageUseCase: appDiContainer.domainLayer.getSettingsParallelLanguageUseCase(),
             analytics: appDiContainer.analytics,
             flowType: .deeplink
         )

--- a/godtools/App/Flows/Menu/MenuFlow.swift
+++ b/godtools/App/Flows/Menu/MenuFlow.swift
@@ -43,6 +43,8 @@ class MenuFlow: Flow {
             infoPlist: appDiContainer.dataLayer.getInfoPlist(),
             oktaUserAuthentication: appDiContainer.oktaUserAuthentication,
             localizationServices: appDiContainer.localizationServices,
+            getSettingsPrimaryLanguageUseCase: appDiContainer.domainLayer.getSettingsPrimaryLanguageUseCase(),
+            getSettingsParallelLanguageUseCase: appDiContainer.domainLayer.getSettingsParallelLanguageUseCase(),
             analytics: appDiContainer.analytics,
             getOptInOnboardingTutorialAvailableUseCase: appDiContainer.getOptInOnboardingTutorialAvailableUseCase(),
             disableOptInOnboardingBannerUseCase: appDiContainer.getDisableOptInOnboardingBannerUseCase()
@@ -94,6 +96,8 @@ class MenuFlow: Flow {
                 oktaUserAuthentication: appDiContainer.oktaUserAuthentication,
                 globalAnalyticsService: appDiContainer.dataLayer.getGlobalAnalyticsService(),
                 localizationServices: appDiContainer.localizationServices,
+                getSettingsPrimaryLanguageUseCase: appDiContainer.domainLayer.getSettingsPrimaryLanguageUseCase(),
+                getSettingsParallelLanguageUseCase: appDiContainer.domainLayer.getSettingsParallelLanguageUseCase(),
                 analytics: appDiContainer.analytics
             )
             let view = AccountView(viewModel: viewModel)
@@ -109,6 +113,8 @@ class MenuFlow: Flow {
             let viewModel = AboutViewModel(
                 aboutTextProvider: aboutTextProvider,
                 localizationServices: appDiContainer.localizationServices,
+                getSettingsPrimaryLanguageUseCase: appDiContainer.domainLayer.getSettingsPrimaryLanguageUseCase(),
+                getSettingsParallelLanguageUseCase: appDiContainer.domainLayer.getSettingsParallelLanguageUseCase(),
                 analytics: appDiContainer.analytics
             )
             let view = AboutView(viewModel: viewModel)
@@ -235,6 +241,8 @@ class MenuFlow: Flow {
     private func navigateToWebContentView(webContent: WebContentType) {
         
         let viewModel = WebContentViewModel(
+            getSettingsPrimaryLanguageUseCase: appDiContainer.domainLayer.getSettingsPrimaryLanguageUseCase(),
+            getSettingsParallelLanguageUseCase: appDiContainer.domainLayer.getSettingsParallelLanguageUseCase(),
             analytics: appDiContainer.analytics,
             webContent: webContent
         )

--- a/godtools/App/Flows/Onboarding/OnboardingFlow.swift
+++ b/godtools/App/Flows/Onboarding/OnboardingFlow.swift
@@ -42,6 +42,8 @@ class OnboardingFlow: Flow {
         
         let viewModel = OnboardingTutorialViewModel(
             flowDelegate: self,
+            getSettingsPrimaryLanguageUseCase: appDiContainer.domainLayer.getSettingsPrimaryLanguageUseCase(),
+            getSettingsParallelLanguageUseCase: appDiContainer.domainLayer.getSettingsParallelLanguageUseCase(),
             analyticsContainer: appDiContainer.analytics,
             tutorialVideoAnalytics: appDiContainer.getTutorialVideoAnalytics(),
             onboardingTutorialItemsRepository: onboardingTutorialItemsRepository,
@@ -74,7 +76,14 @@ class OnboardingFlow: Flow {
         
         if getOnboardingQuickLinksEnabledUseCase.getQuickLinksEnabled() {
             
-            let viewModel = OnboardingQuickStartViewModel(flowDelegate: self, localizationServices: appDiContainer.localizationServices, trackActionAnalytics: appDiContainer.analytics.trackActionAnalytics)
+            let viewModel = OnboardingQuickStartViewModel(
+                flowDelegate: self,
+                localizationServices: appDiContainer.localizationServices,
+                getSettingsPrimaryLanguageUseCase: appDiContainer.domainLayer.getSettingsPrimaryLanguageUseCase(),
+                getSettingsParallelLanguageUseCase: appDiContainer.domainLayer.getSettingsParallelLanguageUseCase(),
+                trackActionAnalytics: appDiContainer.analytics.trackActionAnalytics
+            )
+            
             let view = OnboardingQuickStartView(viewModel: viewModel)
             
             navigationController.setViewControllers([view], animated: true)

--- a/godtools/App/Flows/ToolSettings/ToolSettingsFlow.swift
+++ b/godtools/App/Flows/ToolSettings/ToolSettingsFlow.swift
@@ -82,6 +82,8 @@ class ToolSettingsFlow: Flow {
                 language: language,
                 pageNumber: toolData.pageNumber,
                 localizationServices: appDiContainer.localizationServices,
+                getSettingsPrimaryLanguageUseCase: appDiContainer.domainLayer.getSettingsPrimaryLanguageUseCase(),
+                getSettingsParallelLanguageUseCase: appDiContainer.domainLayer.getSettingsParallelLanguageUseCase(),
                 analytics: appDiContainer.analytics
             )
             
@@ -157,6 +159,8 @@ class ToolSettingsFlow: Flow {
                 let viewModel = ShareToolRemoteSessionURLViewModel(
                     toolRemoteShareUrl: remoteShareUrl,
                     localizationServices: appDiContainer.localizationServices,
+                    getSettingsPrimaryLanguageUseCase: appDiContainer.domainLayer.getSettingsPrimaryLanguageUseCase(),
+                    getSettingsParallelLanguageUseCase: appDiContainer.domainLayer.getSettingsParallelLanguageUseCase(),
                     analytics: appDiContainer.analytics
                 )
                 let view = ShareToolRemoteSessionURLView(viewModel: viewModel)
@@ -212,6 +216,8 @@ class ToolSettingsFlow: Flow {
                    
             let viewModel = ReviewShareShareableViewModel(
                 flowDelegate: self,
+                getSettingsPrimaryLanguageUseCase: appDiContainer.domainLayer.getSettingsPrimaryLanguageUseCase(),
+                getSettingsParallelLanguageUseCase: appDiContainer.domainLayer.getSettingsParallelLanguageUseCase(),
                 analytics: appDiContainer.analytics,
                 shareableImageDomainModel: shareableImageDomainModel,
                 localizationServices: appDiContainer.localizationServices
@@ -257,6 +263,8 @@ class ToolSettingsFlow: Flow {
             tutorialItemsProvider: tutorialItemsProvider,
             shareToolScreenTutorialNumberOfViewsCache: appDiContainer.getShareToolScreenTutorialNumberOfViewsCache(),
             resource: toolData.renderer.value.resource,
+            getSettingsPrimaryLanguageUseCase: appDiContainer.domainLayer.getSettingsPrimaryLanguageUseCase(),
+            getSettingsParallelLanguageUseCase: appDiContainer.domainLayer.getSettingsParallelLanguageUseCase(),
             analyticsContainer: appDiContainer.analytics,
             tutorialVideoAnalytics: appDiContainer.getTutorialVideoAnalytics()
         )

--- a/godtools/App/Flows/Tutorial/TutorialFlow.swift
+++ b/godtools/App/Flows/Tutorial/TutorialFlow.swift
@@ -39,6 +39,8 @@ class TutorialFlow: Flow {
         let viewModel = TutorialViewModel(
             flowDelegate: self,
             getTutorialUseCase: appDiContainer.domainLayer.getTutorialUseCase(),
+            getSettingsPrimaryLanguageUseCase: appDiContainer.domainLayer.getSettingsPrimaryLanguageUseCase(),
+            getSettingsParallelLanguageUseCase: appDiContainer.domainLayer.getSettingsParallelLanguageUseCase(),
             analytics: appDiContainer.analytics,
             tutorialVideoAnalytics: appDiContainer.getTutorialVideoAnalytics()
         )

--- a/godtools/App/Services/Analytics/AnalyticsTracking/LessonFeedback/LessonFeedbackAnalytics.swift
+++ b/godtools/App/Services/Analytics/AnalyticsTracking/LessonFeedback/LessonFeedbackAnalytics.swift
@@ -50,6 +50,8 @@ class LessonFeedbackAnalytics {
             screenName: "",
             siteSection: siteSection,
             siteSubSection: "",
+            contentLanguage: nil,
+            secondaryContentLanguage: nil,
             actionName: LessonFeedbackAnalytics.trackLessonFeedbackActionName,
             data: data
         )

--- a/godtools/App/Services/Analytics/AnalyticsTracking/Models/TrackActionModel.swift
+++ b/godtools/App/Services/Analytics/AnalyticsTracking/Models/TrackActionModel.swift
@@ -14,6 +14,8 @@ struct TrackActionModel {
     let actionName: String
     let siteSection: String
     let siteSubSection: String
+    let contentLanguage: String?
+    let secondaryContentLanguage: String?
     let url: String?
     let data: [String: Any]?
 }

--- a/godtools/App/Services/Analytics/AnalyticsTracking/Models/TrackScreenModel.swift
+++ b/godtools/App/Services/Analytics/AnalyticsTracking/Models/TrackScreenModel.swift
@@ -13,17 +13,6 @@ struct TrackScreenModel {
     let screenName: String
     let siteSection: String
     let siteSubSection: String
-    let contentLanguage: String? // TODO: This optional should be removed in GT-1580 to wrap up Epic Analytics Content Language. ~Levi
+    let contentLanguage: String?
     let secondaryContentLanguage: String?
-    
-    init(screenName: String, siteSection: String, siteSubSection: String, contentLanguage: String? = nil, secondaryContentLanguage: String? = nil) {
-        
-        // TODO: This init should be removed in GT-1580 to wrap up Epic Analytics Content Language. ~Levi
-        
-        self.screenName = screenName
-        self.siteSection = siteSection
-        self.siteSubSection = siteSubSection
-        self.contentLanguage = contentLanguage
-        self.secondaryContentLanguage = secondaryContentLanguage
-    }
 }

--- a/godtools/App/Services/Analytics/AnalyticsTracking/TrackActionAnalytics.swift
+++ b/godtools/App/Services/Analytics/AnalyticsTracking/TrackActionAnalytics.swift
@@ -25,6 +25,8 @@ class TrackActionAnalytics {
             screenName: trackAction.screenName,
             siteSection: trackAction.siteSection,
             siteSubSection: trackAction.siteSubSection,
+            contentLanguage: trackAction.contentLanguage,
+            secondaryContentLanguage: trackAction.secondaryContentLanguage,
             actionName: trackAction.actionName,
             data: trackAction.data
         )

--- a/godtools/App/Services/Analytics/AnalyticsTracking/TutorialVideoAnalytics/TutorialVideoAnalytics.swift
+++ b/godtools/App/Services/Analytics/AnalyticsTracking/TutorialVideoAnalytics/TutorialVideoAnalytics.swift
@@ -12,22 +12,24 @@ class TutorialVideoAnalytics {
     
     private let trackActionAnalytics: TrackActionAnalytics
     
-    required init(trackActionAnalytics: TrackActionAnalytics) {
+    init(trackActionAnalytics: TrackActionAnalytics) {
         
         self.trackActionAnalytics = trackActionAnalytics
     }
     
-    func trackVideoPlayed(videoId: String, screenName: String) {
+    func trackVideoPlayed(videoId: String, screenName: String, contentLanguage: String?, secondaryContentLanguage: String?) {
             
-        trackActionAnalytics.trackAction(
-            trackAction: TrackActionModel(
-                screenName: screenName,
-                actionName: AnalyticsConstants.ActionNames.tutorialVideo,
-                siteSection: "",
-                siteSubSection: "",
-                url: nil,
-                data: [AnalyticsConstants.Keys.tutorialVideo: 1, AnalyticsConstants.Keys.tutorialVideoId: videoId]
-            )
+        let trackAction = TrackActionModel(
+            screenName: screenName,
+            actionName: AnalyticsConstants.ActionNames.tutorialVideo,
+            siteSection: "",
+            siteSubSection: "",
+            contentLanguage: contentLanguage,
+            secondaryContentLanguage: secondaryContentLanguage,
+            url: nil,
+            data: [AnalyticsConstants.Keys.tutorialVideo: 1, AnalyticsConstants.Keys.tutorialVideoId: videoId]
         )
+        
+        trackActionAnalytics.trackAction(trackAction: trackAction)
     }
 }

--- a/godtools/App/Services/Analytics/Firebase/FirebaseAnalytics+MobileContentAnalyticsSystem.swift
+++ b/godtools/App/Services/Analytics/Firebase/FirebaseAnalytics+MobileContentAnalyticsSystem.swift
@@ -11,6 +11,15 @@ import Foundation
 extension FirebaseAnalytics: MobileContentAnalyticsSystem {
     
     func trackMobileContentAction(screenName: String, siteSection: String, action: String, data: [String: Any]?) {
-        trackAction(screenName: screenName, siteSection: siteSection, siteSubSection: "", actionName: action, data: data)
+        
+        trackAction(
+            screenName: screenName,
+            siteSection: siteSection,
+            siteSubSection: "",
+            contentLanguage: nil,
+            secondaryContentLanguage: nil,
+            actionName: action,
+            data: data
+        )
     }
 }

--- a/godtools/App/Services/Analytics/Firebase/FirebaseAnalytics.swift
+++ b/godtools/App/Services/Analytics/Firebase/FirebaseAnalytics.swift
@@ -14,17 +14,15 @@ class FirebaseAnalytics: NSObject {
     
     private let appBuild: AppBuild
     private let oktaUserAuthentication: OktaUserAuthentication
-    private let languageSettingsService: LanguageSettingsService
     private let loggingEnabled: Bool
     
     private var previousTrackedScreenName: String = ""
     private var isConfigured: Bool = false
     
-    required init(appBuild: AppBuild, oktaUserAuthentication: OktaUserAuthentication, languageSettingsService: LanguageSettingsService, loggingEnabled: Bool) {
+    init(appBuild: AppBuild, oktaUserAuthentication: OktaUserAuthentication, loggingEnabled: Bool) {
         
         self.appBuild = appBuild
         self.oktaUserAuthentication = oktaUserAuthentication
-        self.languageSettingsService = languageSettingsService
         self.loggingEnabled = loggingEnabled
         
         super.init()
@@ -66,7 +64,7 @@ class FirebaseAnalytics: NSObject {
         log(method: "configure()", label: nil, labelValue: nil, data: nil)
     }
     
-    func trackScreenView(screenName: String, siteSection: String, siteSubSection: String, contentLanguage: String? = nil, secondaryContentLanguage: String? = nil) {
+    func trackScreenView(screenName: String, siteSection: String, siteSubSection: String, contentLanguage: String?, secondaryContentLanguage: String?) {
         
         internalTrackEvent(
             screenName: screenName,
@@ -81,7 +79,7 @@ class FirebaseAnalytics: NSObject {
         previousTrackedScreenName = screenName
     }
     
-    func trackAction(screenName: String, siteSection: String, siteSubSection: String, contentLanguage: String? = nil, secondaryContentLanguage: String? = nil, actionName: String, data: [String : Any]?) {
+    func trackAction(screenName: String, siteSection: String, siteSubSection: String, contentLanguage: String?, secondaryContentLanguage: String?, actionName: String, data: [String : Any]?) {
         
         internalTrackEvent(
             screenName: screenName,
@@ -95,7 +93,7 @@ class FirebaseAnalytics: NSObject {
         )
     }
     
-    func trackExitLink(screenName: String, siteSection: String, siteSubSection: String, contentLanguage: String, secondaryContentLanguage: String?, url: String) {
+    func trackExitLink(screenName: String, siteSection: String, siteSubSection: String, contentLanguage: String?, secondaryContentLanguage: String?, url: String) {
         
         internalTrackEvent(
             screenName: screenName,
@@ -202,8 +200,8 @@ class FirebaseAnalytics: NSObject {
         var properties: [String: String] = [:]
                 
         properties[AnalyticsConstants.Keys.appName] = AnalyticsConstants.Values.godTools
-        properties[AnalyticsConstants.Keys.contentLanguage] = contentLanguage ?? languageSettingsService.primaryLanguage.value?.code
-        properties[AnalyticsConstants.Keys.contentLanguageSecondary] = secondaryContentLanguage ?? languageSettingsService.parallelLanguage.value?.code
+        properties[AnalyticsConstants.Keys.contentLanguage] = contentLanguage
+        properties[AnalyticsConstants.Keys.contentLanguageSecondary] = secondaryContentLanguage
         properties[AnalyticsConstants.Keys.previousScreenName] = previousScreenName
         properties[AnalyticsConstants.Keys.screenNameFirebase] = screenName
         properties[AnalyticsConstants.Keys.siteSection] = siteSection

--- a/godtools/App/Services/Renderer/Navigation/MobileContentRendererNavigation.swift
+++ b/godtools/App/Services/Renderer/Navigation/MobileContentRendererNavigation.swift
@@ -123,6 +123,8 @@ class MobileContentRendererNavigation {
             renderedPageContext: event.renderedPageContext,
             trainingTipId: event.trainingTipId,
             tipModel: event.tipModel,
+            getSettingsPrimaryLanguageUseCase: appDiContainer.domainLayer.getSettingsPrimaryLanguageUseCase(),
+            getSettingsParallelLanguageUseCase: appDiContainer.domainLayer.getSettingsParallelLanguageUseCase(),
             analytics: appDiContainer.analytics,
             localizationServices: appDiContainer.localizationServices,
             viewedTrainingTips: appDiContainer.getViewedTrainingTipsService(),

--- a/godtools/App/Services/Renderer/Views/Lesson/Views/Page/LessonPageViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/Lesson/Views/Page/LessonPageViewModel.swift
@@ -16,7 +16,7 @@ class LessonPageViewModel: MobileContentPageViewModel, LessonPageViewModelType {
     private let analytics: AnalyticsContainer
     private let analyticsEventsObjects: [MobileContentAnalyticsEvent]
     
-    required init(pageModel: Page, renderedPageContext: MobileContentRenderedPageContext, analytics: AnalyticsContainer, mobileContentAnalytics: MobileContentAnalytics) {
+    init(pageModel: Page, renderedPageContext: MobileContentRenderedPageContext, analytics: AnalyticsContainer, mobileContentAnalytics: MobileContentAnalytics) {
             
         self.pageModel = pageModel
         self.renderedPageContext = renderedPageContext

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/CardCollectionPage/MobileContentCardCollectionPageViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/CardCollectionPage/MobileContentCardCollectionPageViewModel.swift
@@ -15,7 +15,7 @@ class MobileContentCardCollectionPageViewModel: MobileContentPageViewModel, Mobi
     private let renderedPageContext: MobileContentRenderedPageContext
     private let analytics: AnalyticsContainer
         
-    required init(cardCollectionPage: CardCollectionPage, renderedPageContext: MobileContentRenderedPageContext, analytics: AnalyticsContainer) {
+    init(cardCollectionPage: CardCollectionPage, renderedPageContext: MobileContentRenderedPageContext, analytics: AnalyticsContainer) {
         
         self.cardCollectionPage = cardCollectionPage
         self.renderedPageContext = renderedPageContext
@@ -83,11 +83,27 @@ class MobileContentCardCollectionPageViewModel: MobileContentPageViewModel, Mobi
     
     func pageDidAppear() {
         
-        analytics.pageViewedAnalytics.trackPageView(trackScreen: TrackScreenModel(screenName: getPageAnalyticsScreenName(), siteSection: analyticsSiteSection, siteSubSection: analyticsSiteSubSection, contentLanguage: renderedPageContext.language.code, secondaryContentLanguage: nil))
+        let trackScreen = TrackScreenModel(
+            screenName: getPageAnalyticsScreenName(),
+            siteSection: analyticsSiteSection,
+            siteSubSection: analyticsSiteSubSection,
+            contentLanguage: renderedPageContext.language.code,
+            secondaryContentLanguage: nil
+        )
+        
+        analytics.pageViewedAnalytics.trackPageView(trackScreen: trackScreen)
     }
     
     func cardDidAppear(card: Int) {
         
-        analytics.pageViewedAnalytics.trackPageView(trackScreen: TrackScreenModel(screenName: getCardAnalyticsScreenName(card: card), siteSection: analyticsSiteSection, siteSubSection: analyticsSiteSubSection, contentLanguage: renderedPageContext.language.code, secondaryContentLanguage: nil))
+        let trackScreen = TrackScreenModel(
+            screenName: getCardAnalyticsScreenName(card: card),
+            siteSection: analyticsSiteSection,
+            siteSubSection: analyticsSiteSubSection,
+            contentLanguage: renderedPageContext.language.code,
+            secondaryContentLanguage: nil
+        )
+        
+        analytics.pageViewedAnalytics.trackPageView(trackScreen: trackScreen)
     }
 }

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentPage/MobileContentContentPageViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentPage/MobileContentContentPageViewModel.swift
@@ -15,7 +15,7 @@ class MobileContentContentPageViewModel: MobileContentPageViewModel, MobileConte
     private let renderedPageContext: MobileContentRenderedPageContext
     private let analytics: AnalyticsContainer
     
-    required init(contentPage: Page, renderedPageContext: MobileContentRenderedPageContext, analytics: AnalyticsContainer) {
+    init(contentPage: Page, renderedPageContext: MobileContentRenderedPageContext, analytics: AnalyticsContainer) {
         
         self.contentPage = contentPage
         self.renderedPageContext = renderedPageContext
@@ -41,6 +41,14 @@ class MobileContentContentPageViewModel: MobileContentPageViewModel, MobileConte
     
     func pageDidAppear() {
         
-        analytics.pageViewedAnalytics.trackPageView(trackScreen: TrackScreenModel(screenName: getPageAnalyticsScreenName(), siteSection:analyticsSiteSection, siteSubSection: analyticsSiteSubSection, contentLanguage: renderedPageContext.language.code, secondaryContentLanguage: nil))
+        let trackScreen = TrackScreenModel(
+            screenName: getPageAnalyticsScreenName(),
+            siteSection:analyticsSiteSection,
+            siteSubSection: analyticsSiteSubSection,
+            contentLanguage: renderedPageContext.language.code,
+            secondaryContentLanguage: nil
+        )
+        
+        analytics.pageViewedAnalytics.trackPageView(trackScreen: trackScreen)
     }
 }

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/Pages/MobileContentPagesViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/Pages/MobileContentPagesViewModel.swift
@@ -36,7 +36,7 @@ class MobileContentPagesViewModel: NSObject, MobileContentPagesViewModelType {
     let pageNavigation: ObservableValue<MobileContentPagesNavigationModel?> = ObservableValue(value: nil)
     let pagesRemoved: ObservableValue<[IndexPath]> = ObservableValue(value: [])
     
-    required init(renderer: MobileContentRenderer, page: Int?, resourcesRepository: ResourcesRepository, translationsRepository: TranslationsRepository, mobileContentEventAnalytics: MobileContentEventAnalyticsTracking, initialPageRenderingType: MobileContentPagesInitialPageRenderingType, trainingTipsEnabled: Bool) {
+    init(renderer: MobileContentRenderer, page: Int?, resourcesRepository: ResourcesRepository, translationsRepository: TranslationsRepository, mobileContentEventAnalytics: MobileContentEventAnalyticsTracking, initialPageRenderingType: MobileContentPagesInitialPageRenderingType, trainingTipsEnabled: Bool) {
         
         self.renderer = CurrentValueSubject(renderer)
         self.currentPageRenderer = CurrentValueSubject(renderer.pageRenderers[0])

--- a/godtools/App/Services/Renderer/Views/Tool/Views/Card/ToolPageCardViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/Tool/Views/Card/ToolPageCardViewModel.swift
@@ -166,10 +166,16 @@ class ToolPageCardViewModel: ToolPageCardViewModelType {
         
     func cardDidAppear() {
         mobileContentDidAppear()
+                   
+        let trackScreen =  TrackScreenModel(
+            screenName: analyticsScreenName,
+            siteSection: analyticsSiteSection,
+            siteSubSection: analyticsSiteSubSection,
+            contentLanguage: renderedPageContext.language.code,
+            secondaryContentLanguage: nil
+        )
         
-        let screenName: String = analyticsScreenName
-        
-        analytics.pageViewedAnalytics.trackPageView(trackScreen: TrackScreenModel(screenName: screenName, siteSection: analyticsSiteSection, siteSubSection: analyticsSiteSubSection, contentLanguage: renderedPageContext.language.code, secondaryContentLanguage: nil))
+        analytics.pageViewedAnalytics.trackPageView(trackScreen: trackScreen)
     }
     
     func cardDidDisappear() {

--- a/godtools/App/Services/Renderer/Views/Tool/Views/Page/ToolPageViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/Tool/Views/Page/ToolPageViewModel.swift
@@ -90,7 +90,15 @@ class ToolPageViewModel: MobileContentPageViewModel, ToolPageViewModelType {
     func pageDidAppear() {
         mobileContentDidAppear()
         
-        analytics.pageViewedAnalytics.trackPageView(trackScreen: TrackScreenModel(screenName: analyticsScreenName, siteSection: analyticsSiteSection, siteSubSection: analyticsSiteSubSection, contentLanguage: renderedPageContext.language.code, secondaryContentLanguage: nil))
+        let trackScreen = TrackScreenModel(
+            screenName: analyticsScreenName,
+            siteSection: analyticsSiteSection,
+            siteSubSection: analyticsSiteSubSection,
+            contentLanguage: renderedPageContext.language.code,
+            secondaryContentLanguage: nil
+        )
+        
+        analytics.pageViewedAnalytics.trackPageView(trackScreen: trackScreen)
     }
     
     func didChangeCardPosition(cardPosition: Int?) {

--- a/godtools/App/Share/Views/TutorialCell/TutorialCellViewModel.swift
+++ b/godtools/App/Share/Views/TutorialCell/TutorialCellViewModel.swift
@@ -13,6 +13,8 @@ class TutorialCellViewModel: TutorialCellViewModelType {
     private let item: TutorialItemType
     private let tutorialVideoAnalytics: TutorialVideoAnalytics
     private let analyticsScreenName: String
+    private let getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase
+    private let getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase
     
     private var trackedAnalyticsForYouTubeVideoIds: [String] = Array()
     
@@ -20,11 +22,13 @@ class TutorialCellViewModel: TutorialCellViewModelType {
     let title: String
     let message: String
     
-    required init(item: TutorialItemType, customViewBuilder: CustomViewBuilderType?, tutorialVideoAnalytics: TutorialVideoAnalytics, analyticsScreenName: String) {
+    init(item: TutorialItemType, customViewBuilder: CustomViewBuilderType?, tutorialVideoAnalytics: TutorialVideoAnalytics, analyticsScreenName: String, getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase, getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase) {
         
         self.item = item
         self.tutorialVideoAnalytics = tutorialVideoAnalytics
         self.analyticsScreenName = analyticsScreenName
+        self.getSettingsPrimaryLanguageUseCase = getSettingsPrimaryLanguageUseCase
+        self.getSettingsParallelLanguageUseCase = getSettingsParallelLanguageUseCase
         
         if let imageName = item.imageName, !imageName.isEmpty, let image = UIImage(named: imageName) {
             
@@ -79,7 +83,12 @@ class TutorialCellViewModel: TutorialCellViewModelType {
             
             trackedAnalyticsForYouTubeVideoIds.append(videoId)
             
-            tutorialVideoAnalytics.trackVideoPlayed(videoId: videoId, screenName: analyticsScreenName)
+            tutorialVideoAnalytics.trackVideoPlayed(
+                videoId: videoId,
+                screenName: analyticsScreenName,
+                contentLanguage: getSettingsPrimaryLanguageUseCase.getPrimaryLanguage()?.analyticsContentLanguage,
+                secondaryContentLanguage: getSettingsParallelLanguageUseCase.getParallelLanguage()?.analyticsContentLanguage
+            )
         }
     }
 }

--- a/godtools/App/Share/Views/TutorialPagerView/TutorialPagerViewModel.swift
+++ b/godtools/App/Share/Views/TutorialPagerView/TutorialPagerViewModel.swift
@@ -10,6 +10,8 @@ import Foundation
 
 class TutorialPagerViewModel: TutorialPagerViewModelType {
     
+    private let getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase
+    private let getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase
     private let analyticsContainer: AnalyticsContainer
     private let tutorialVideoAnalytics: TutorialVideoAnalytics
     private let tutorialPagerAnalyticsModel: TutorialPagerAnalytics
@@ -24,9 +26,11 @@ class TutorialPagerViewModel: TutorialPagerViewModelType {
     
     private weak var flowDelegate: FlowDelegate?
     
-    required init(flowDelegate: FlowDelegate, analyticsContainer: AnalyticsContainer, tutorialVideoAnalytics: TutorialVideoAnalytics, tutorialItems: [TutorialItemType], tutorialPagerAnalyticsModel: TutorialPagerAnalytics, skipButtonTitle: String) {
+    init(flowDelegate: FlowDelegate, getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase, getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase, analyticsContainer: AnalyticsContainer, tutorialVideoAnalytics: TutorialVideoAnalytics, tutorialItems: [TutorialItemType], tutorialPagerAnalyticsModel: TutorialPagerAnalytics, skipButtonTitle: String) {
         
         self.flowDelegate = flowDelegate
+        self.getSettingsPrimaryLanguageUseCase = getSettingsPrimaryLanguageUseCase
+        self.getSettingsParallelLanguageUseCase = getSettingsParallelLanguageUseCase
         self.analyticsContainer = analyticsContainer
         self.tutorialVideoAnalytics = tutorialVideoAnalytics
         self.tutorialPagerAnalyticsModel = tutorialPagerAnalyticsModel
@@ -54,7 +58,14 @@ class TutorialPagerViewModel: TutorialPagerViewModelType {
     
     func tutorialItemWillAppear(index: Int) -> TutorialCellViewModelType {
         
-        return TutorialCellViewModel(item: tutorialItems[index], customViewBuilder: customViewBuilder, tutorialVideoAnalytics: tutorialVideoAnalytics, analyticsScreenName: tutorialPagerAnalyticsModel.analyticsScreenName(page: index))
+        return TutorialCellViewModel(
+            item: tutorialItems[index],
+            customViewBuilder: customViewBuilder,
+            tutorialVideoAnalytics: tutorialVideoAnalytics,
+            analyticsScreenName: tutorialPagerAnalyticsModel.analyticsScreenName(page: index),
+            getSettingsPrimaryLanguageUseCase: getSettingsPrimaryLanguageUseCase,
+            getSettingsParallelLanguageUseCase: getSettingsParallelLanguageUseCase
+        )
     }
     
     func skipTapped() {
@@ -92,13 +103,16 @@ class TutorialPagerViewModel: TutorialPagerViewModelType {
         let analyticsScreenName = tutorialPagerAnalyticsModel.analyticsScreenName(page: page)
         
         if !analyticsScreenName.isEmpty {
-            analyticsContainer.pageViewedAnalytics.trackPageView(
-                trackScreen: TrackScreenModel(
-                    screenName: analyticsScreenName,
-                    siteSection: tutorialPagerAnalyticsModel.siteSection,
-                    siteSubSection: tutorialPagerAnalyticsModel.siteSubsection
-                )
+            
+            let trackScreen = TrackScreenModel(
+                screenName: analyticsScreenName,
+                siteSection: tutorialPagerAnalyticsModel.siteSection,
+                siteSubSection: tutorialPagerAnalyticsModel.siteSubsection,
+                contentLanguage: getSettingsPrimaryLanguageUseCase.getPrimaryLanguage()?.analyticsContentLanguage,
+                secondaryContentLanguage: getSettingsParallelLanguageUseCase.getParallelLanguage()?.analyticsContentLanguage
             )
+            
+            analyticsContainer.pageViewedAnalytics.trackPageView(trackScreen: trackScreen)
         }
     }
     
@@ -107,16 +121,19 @@ class TutorialPagerViewModel: TutorialPagerViewModelType {
         let analyticsScreenName = tutorialPagerAnalyticsModel.analyticsScreenName(page: page)
         
         if !analyticsScreenName.isEmpty, !tutorialPagerAnalyticsModel.continueButtonTappedActionName.isEmpty {
-            analyticsContainer.trackActionAnalytics.trackAction(
-                trackAction: TrackActionModel(
-                    screenName: analyticsScreenName,
-                    actionName: tutorialPagerAnalyticsModel.continueButtonTappedActionName,
-                    siteSection: tutorialPagerAnalyticsModel.siteSection,
-                    siteSubSection: tutorialPagerAnalyticsModel.siteSubsection,
-                    url: nil,
-                    data: tutorialPagerAnalyticsModel.continueButtonTappedData
-                )
+            
+            let trackAction = TrackActionModel(
+                screenName: analyticsScreenName,
+                actionName: tutorialPagerAnalyticsModel.continueButtonTappedActionName,
+                siteSection: tutorialPagerAnalyticsModel.siteSection,
+                siteSubSection: tutorialPagerAnalyticsModel.siteSubsection,
+                contentLanguage: getSettingsPrimaryLanguageUseCase.getPrimaryLanguage()?.analyticsContentLanguage,
+                secondaryContentLanguage: getSettingsParallelLanguageUseCase.getParallelLanguage()?.analyticsContentLanguage,
+                url: nil,
+                data: tutorialPagerAnalyticsModel.continueButtonTappedData
             )
+            
+            analyticsContainer.trackActionAnalytics.trackAction(trackAction: trackAction)
         }
     }
 }


### PR DESCRIPTION
This PR removes the ```LanguageSettingsService.swift``` dependency from ```FirebaseAnalytics.swift``` in order that contentLanguage and secondaryContentLanguage can be injected into FirebaseAnalytics.   
Most cases the contentLanguage and secondaryContentLanguage will default to the settings primary and parallel language with some exceptions (example tool renderer).