### PR TITLE
GT-1810 always persist downloaded translation

### DIFF
--- a/godtools/App/DependencyContainer/AppDataLayerDependencies.swift
+++ b/godtools/App/DependencyContainer/AppDataLayerDependencies.swift
@@ -176,7 +176,7 @@ class AppDataLayerDependencies {
         
         let sync = RealmResourcesCacheSync(
             realmDatabase: sharedRealmDatabase,
-            translationsRepository: getTranslationsRepository()
+            trackDownloadedTranslationsRepository: getTrackDownloadedTranslationsRepository()
         )
         
         let api = MobileContentResourcesApi(

--- a/godtools/App/Share/Data/ResourcesRepository/Cache/Sync/RealmResourcesCacheSync.swift
+++ b/godtools/App/Share/Data/ResourcesRepository/Cache/Sync/RealmResourcesCacheSync.swift
@@ -17,12 +17,12 @@ class RealmResourcesCacheSync {
     typealias TranslationId = String
     
     private let realmDatabase: RealmDatabase
-    private let translationsRepository: TranslationsRepository
+    private let trackDownloadedTranslationsRepository: TrackDownloadedTranslationsRepository
     
-    required init(realmDatabase: RealmDatabase, translationsRepository: TranslationsRepository) {
+    required init(realmDatabase: RealmDatabase, trackDownloadedTranslationsRepository: TrackDownloadedTranslationsRepository) {
         
         self.realmDatabase = realmDatabase
-        self.translationsRepository = translationsRepository
+        self.trackDownloadedTranslationsRepository = trackDownloadedTranslationsRepository
     }
     
     func syncResources(languagesSyncResult: RealmLanguagesCacheSyncResult, resourcesPlusLatestTranslationsAndAttachments: ResourcesPlusLatestTranslationsAndAttachmentsModel) -> AnyPublisher<RealmResourcesCacheSyncResult, Error> {
@@ -171,9 +171,9 @@ class RealmResourcesCacheSync {
                         return true
                     }
                     
-                    let latestDownloadedTranslation: TranslationModel? = self.translationsRepository.getLatestDownloadedTranslation(resourceId: resourceId, languageId: languageId)
+                    let latestTrackedDownloadedTranslation: DownloadedTranslationDataModel? = self.trackDownloadedTranslationsRepository.getLatestDownloadedTranslation(resourceId: resourceId, languageId: languageId)
                     
-                    let translationIsLatestDownloadedTranslation: Bool = latestDownloadedTranslation?.id == $0.id
+                    let translationIsLatestDownloadedTranslation: Bool = latestTrackedDownloadedTranslation?.translationId == $0.id
                     
                     if translationIsLatestDownloadedTranslation {
                         

--- a/godtools/App/Share/Data/TrackDownloadedTranslationsRepository/Cache/Models/RealmDownloadedTranslation.swift
+++ b/godtools/App/Share/Data/TrackDownloadedTranslationsRepository/Cache/Models/RealmDownloadedTranslation.swift
@@ -11,8 +11,11 @@ import RealmSwift
 
 class RealmDownloadedTranslation: Object, DownloadedTranslationDataModelType {
     
+    @objc dynamic var languageId: String = ""
     @objc dynamic var manifestAndRelatedFilesPersistedToDevice: Bool = false
+    @objc dynamic var resourceId: String = ""
     @objc dynamic var translationId: String = ""
+    @objc dynamic var version: Int = -1
     
     override static func primaryKey() -> String? {
         return "translationId"
@@ -20,7 +23,10 @@ class RealmDownloadedTranslation: Object, DownloadedTranslationDataModelType {
     
     func mapFrom(model: DownloadedTranslationDataModel) {
         
+        languageId = model.languageId
         manifestAndRelatedFilesPersistedToDevice = model.manifestAndRelatedFilesPersistedToDevice
+        resourceId = model.resourceId
         translationId = model.translationId
+        version = model.version
     }
 }

--- a/godtools/App/Share/Data/TrackDownloadedTranslationsRepository/DownloadedTranslationDataModel.swift
+++ b/godtools/App/Share/Data/TrackDownloadedTranslationsRepository/DownloadedTranslationDataModel.swift
@@ -10,12 +10,18 @@ import Foundation
 
 struct DownloadedTranslationDataModel: DownloadedTranslationDataModelType {
     
+    let languageId: String
     let manifestAndRelatedFilesPersistedToDevice: Bool
+    let resourceId: String
     let translationId: String
+    let version: Int
     
     init(model: DownloadedTranslationDataModelType) {
         
+        languageId = model.languageId
         manifestAndRelatedFilesPersistedToDevice = model.manifestAndRelatedFilesPersistedToDevice
+        resourceId = model.resourceId
         translationId = model.translationId
+        version = model.version
     }
 }

--- a/godtools/App/Share/Data/TrackDownloadedTranslationsRepository/DownloadedTranslationDataModelType.swift
+++ b/godtools/App/Share/Data/TrackDownloadedTranslationsRepository/DownloadedTranslationDataModelType.swift
@@ -10,6 +10,9 @@ import Foundation
 
 protocol DownloadedTranslationDataModelType {
     
+    var languageId: String { get }
     var manifestAndRelatedFilesPersistedToDevice: Bool { get }
+    var resourceId: String { get }
     var translationId: String { get }
+    var version: Int { get }
 }

--- a/godtools/App/Share/Data/TrackDownloadedTranslationsRepository/TrackDownloadedTranslationsRepository.swift
+++ b/godtools/App/Share/Data/TrackDownloadedTranslationsRepository/TrackDownloadedTranslationsRepository.swift
@@ -18,11 +18,11 @@ class TrackDownloadedTranslationsRepository {
         self.cache = cache
     }
     
-    func getDownloadedTranslation(translationId: String) -> DownloadedTranslationDataModel? {
-        return cache.getDownloadedTranslation(translationId: translationId)
+    func getLatestDownloadedTranslation(resourceId: String, languageId: String) -> DownloadedTranslationDataModel? {
+        return cache.getLatestDownloadedTranslation(resourceId: resourceId, languageId: languageId)
     }
     
-    func trackTranslationDownloaded(translationId: String) -> AnyPublisher<String, Error> {
-        return cache.trackTranslationDownloaded(translationId: translationId)
+    func trackTranslationDownloaded(translation: TranslationModel) -> AnyPublisher<DownloadedTranslationDataModel, Error> {
+        return cache.trackTranslationDownloaded(translation: translation)
     }
 }

--- a/godtools/App/Share/Data/TranslationsRepository/Cache/Models/RealmTranslation.swift
+++ b/godtools/App/Share/Data/TranslationsRepository/Cache/Models/RealmTranslation.swift
@@ -27,7 +27,7 @@ class RealmTranslation: Object, TranslationModelType {
         return "id"
     }
     
-    func mapFrom(model: TranslationModel) {
+    func mapFrom(model: TranslationModelType) {
         
         id = model.id
         isPublished = model.isPublished


### PR DESCRIPTION
This PR fixes logic for falling back to already downloaded translations if a new translation download fails.  

If a new Translation download fails, we take the resourceId and languageId and use that to query against RealmDownloadedTranslation objects.  Any matching RealmDownloadedTranslation are then sorted by version and the latest version is used as the fallback. 
The Sync will also keep Translation objects in the database that match any existing RealmDownloadedTranslation objects by (resourceId, languageId and latest version).

Attributes resourceId, languageId, and version were introduced to RealmDownloadedTranslation objects in this PR that map from the downloaded Translation object.

