### PR TITLE
G-1861 Use analytics constants from GodToolsShared

### DIFF
--- a/godtools/App/Features/Menu/Presentation/Account/AccountViewModel.swift
+++ b/godtools/App/Features/Menu/Presentation/Account/AccountViewModel.swift
@@ -9,6 +9,7 @@
 import Foundation
 import Combine
 import SwiftUI
+import GodToolsToolParser
 
 class AccountViewModel: ObservableObject {
     
@@ -78,10 +79,10 @@ class AccountViewModel: ObservableObject {
             .store(in: &cancellables)
     }
     
-    private func trackSectionViewedAnalytics(sectionName: String) {
-        
+    private func trackSectionViewedAnalytics(screenName: String) {
+                        
         let trackScreen = TrackScreenModel(
-            screenName: sectionName,
+            screenName: screenName,
             siteSection: "account",
             siteSubSection: "",
             contentLanguage: getSettingsPrimaryLanguageUseCase.getPrimaryLanguage()?.analyticsContentLanguage,
@@ -100,15 +101,14 @@ extension AccountViewModel {
         flowDelegate?.navigate(step: .backTappedFromMyAccount)
     }
     
-    func activityTapped() {
+    func activityViewed() {
         
-        // TODO: Ensure this is the correct page name for when Activity section is viewed. GT-1861 ~Levi
-        trackSectionViewedAnalytics(sectionName: "Activity")
+        trackSectionViewedAnalytics(screenName: AnalyticsScreenNames.shared.ACCOUNT_ACTIVITY)
     }
     
-    func globalActivityTapped() {
+    func globalActivityViewed() {
         
-        trackSectionViewedAnalytics(sectionName: "Global Dashboard")
+        trackSectionViewedAnalytics(screenName: AnalyticsScreenNames.shared.ACCOUNT_GLOBAL_ACTIVITY)
     }
     
     func getGlobalActivityAnalyticsItem(index: Int) -> AccountGlobalActivityAnalyticsItemViewModel {

--- a/godtools/App/Features/Menu/Presentation/Account/Subviews/AccountSections/AccountSectionsView.swift
+++ b/godtools/App/Features/Menu/Presentation/Account/Subviews/AccountSections/AccountSectionsView.swift
@@ -45,9 +45,9 @@ struct AccountSectionsView: View {
                     
                     switch sections[selectedSegmentIndex] {
                     case .activity:
-                        viewModel.activityTapped()
+                        viewModel.activityViewed()
                     case .globalActivity:
-                        viewModel.globalActivityTapped()
+                        viewModel.globalActivityViewed()
                     }
                 })
             }
@@ -78,6 +78,14 @@ struct AccountSectionsView: View {
             }
             .frame(width: sectionFrameWidth, alignment: .leading)
             .padding(EdgeInsets(top: 20, leading: sectionHorizontalPadding, bottom: 20, trailing: sectionHorizontalPadding))
+            .onAppear {
+                switch sections[selectedSegmentIndex] {
+                case .activity:
+                    viewModel.activityViewed()
+                case .globalActivity:
+                    viewModel.globalActivityViewed()
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
This PR updates AccountViewModel to use analytics screen names from ```GodToolsShared``` for the account activity and account global activity screen tracking.

Also updated the view to send analytics screen tracking when account section is first viewed.