### PR TITLE
GT-1810 Fixed maintaining the order of downloaded translations

### DIFF
--- a/godtools/App/Share/Data/TranslationsRepository/TranslationsRepository.swift
+++ b/godtools/App/Share/Data/TranslationsRepository/TranslationsRepository.swift
@@ -115,7 +115,19 @@ extension TranslationsRepository {
                 
                 for translation in translations {
                     
-                    guard let translationManifest = downloadedTranslationManifestFileDataModels.first(where: {$0.translation.id == translation.id}) else {
+                    let translationManifest: TranslationManifestFileDataModel?
+                    
+                    if let downloadedTranslationManifest = downloadedTranslationManifestFileDataModels.first(where: {$0.translation.id == translation.id}) {
+                        translationManifest = downloadedTranslationManifest
+                    }
+                    else if let downloadedTranslationManifest = downloadedTranslationManifestFileDataModels.first(where: {$0.translation.resource?.id == translation.resource?.id && $0.translation.language?.id == translation.language?.id}) {
+                        translationManifest = downloadedTranslationManifest
+                    }
+                    else {
+                        translationManifest = nil
+                    }
+                    
+                    guard let translationManifest = translationManifest else {
                         continue
                     }
                     

--- a/godtools/App/Share/Domain/UseCases/GetToolTranslationsFilesUseCase/GetToolTranslationsFilesUseCase.swift
+++ b/godtools/App/Share/Domain/UseCases/GetToolTranslationsFilesUseCase/GetToolTranslationsFilesUseCase.swift
@@ -79,9 +79,21 @@ class GetToolTranslationsFilesUseCase {
                 
                 var maintainTranslationDownloadOrder: [TranslationManifestFileDataModel] = Array()
                 
-                for translation in translationsToDownload {
+                for translationToDownload in translationsToDownload {
                     
-                    guard let translationManifest = downloadedTranslations.first(where: {$0.translation.id == translation.id}) else {
+                    let translationManifest: TranslationManifestFileDataModel?
+                    
+                    if let downloadedTranslationManifest = downloadedTranslations.first(where: {$0.translation.id == translationToDownload.id}) {
+                        translationManifest = downloadedTranslationManifest
+                    }
+                    else if let downloadedTranslationManifest = downloadedTranslations.first(where: {$0.translation.resource?.id == translationToDownload.resource?.id && $0.translation.language?.id == translationToDownload.language?.id}) {
+                        translationManifest = downloadedTranslationManifest
+                    }
+                    else {
+                        translationManifest = nil
+                    }
+                    
+                    guard let translationManifest = translationManifest else {
                         continue
                     }
                     


### PR DESCRIPTION
This PR adds a fix to the download translations logic where we always want to show the latest downloaded translation if downloading a new translation fails due to no network connection.

The issue here was we maintain the order of downloaded translations by sorting those on the translation id.  In the case where we use a fallback translation, the translation id will never match the translation to download because they're different translation models.  Instead we need to search on the translation resource id and language id.