### PR TITLE
GT-1884 Fix UIWindow warning

### DIFF
--- a/godtools/App/AppDelegate.swift
+++ b/godtools/App/AppDelegate.swift
@@ -12,9 +12,7 @@ import FBSDKCoreKit
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
-    
-    private let appWindow: UIWindow = UIWindow(frame: UIScreen.main.bounds)
-        
+            
     private lazy var appBuild: AppBuild = {
        AppBuild(infoPlist: infoPlist)
     }()
@@ -40,13 +38,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }()
     
     private lazy var appFlow: AppFlow = {
-        AppFlow(appDiContainer: appDiContainer, window: appWindow, appDeepLinkingService: appDeepLinkingService)
+        AppFlow(appDiContainer: appDiContainer, appDeepLinkingService: appDeepLinkingService)
     }()
     
     var window: UIWindow?
     
+    static func getWindow() -> UIWindow? {
+        return (UIApplication.shared.delegate as? AppDelegate)?.window
+    }
+    
     static func setWindowBackgroundColorForStatusBarColor(color: UIColor) {
-        (UIApplication.shared.delegate as? AppDelegate)?.window?.backgroundColor = color
+        AppDelegate.getWindow()?.backgroundColor = color
     }
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
@@ -76,7 +78,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         ApplicationDelegate.shared.application(application, didFinishLaunchingWithOptions: launchOptions)
         
         // window
-        let window: UIWindow = appWindow
+        let window: UIWindow = UIWindow(frame: UIScreen.main.bounds)
         window.backgroundColor = UIColor.white
         window.rootViewController = appFlow.rootController
         window.makeKeyAndVisible()

--- a/godtools/App/Flows/App/AppFlow.swift
+++ b/godtools/App/Flows/App/AppFlow.swift
@@ -15,7 +15,6 @@ class AppFlow: NSObject, ToolNavigationFlow, Flow {
     
     private static let defaultStartingDashboardTab: DashboardTabTypeDomainModel = .favorites
     
-    private let window: UIWindow
     private let dataDownloader: InitialDataDownloader
     private let followUpsService: FollowUpsService
     private let viewsService: ViewsService
@@ -45,10 +44,9 @@ class AppFlow: NSObject, ToolNavigationFlow, Flow {
     var tractFlow: TractFlow?
     var downloadToolTranslationFlow: DownloadToolTranslationsFlow?
             
-    init(appDiContainer: AppDiContainer, window: UIWindow, appDeepLinkingService: DeepLinkingService) {
+    init(appDiContainer: AppDiContainer, appDeepLinkingService: DeepLinkingService) {
         
         self.appDiContainer = appDiContainer
-        self.window = window
         self.navigationController = UINavigationController()
         self.dataDownloader = appDiContainer.initialDataDownloader
         self.followUpsService = appDiContainer.dataLayer.getFollowUpsService()
@@ -136,7 +134,7 @@ class AppFlow: NSObject, ToolNavigationFlow, Flow {
                 loadingView.addSubview(loadingImage)
                 loadingImage.image = ImageCatalog.launchImage.uiImage
                 loadingView.backgroundColor = .white
-                window.addSubview(loadingView)
+                AppDelegate.getWindow()?.addSubview(loadingView)
                 
                 navigateToDashboard()
                                 


### PR DESCRIPTION
This PR removes UIWindow allocation from AppDelegate init() and moves to didFinishLaunching() in order to fix the following warning that was in the Xcode console.
```UIWindows were created prior to initial application activation. This may result in incorrect visual appearance```