### PR TITLE
GT-1504 Move tap event registration into base MobileContentView

### DIFF
--- a/godtools/App/Services/Renderer/Renderer/MobileContentRendererPageViewFactories.swift
+++ b/godtools/App/Services/Renderer/Renderer/MobileContentRendererPageViewFactories.swift
@@ -30,7 +30,8 @@ class MobileContentRendererPageViewFactories: MobileContentPageViewFactoryType {
         case .chooseYourOwnAdventure:
             
             let chooseYourOwnAdventureViewFactory = ChooseYourOwnAdventurePageViewFactory(
-                analytics: analytics
+                analytics: analytics,
+                mobileContentAnalytics: mobileContentAnalytics
             )
             
             pageViewFactories = [chooseYourOwnAdventureViewFactory]
@@ -53,6 +54,7 @@ class MobileContentRendererPageViewFactories: MobileContentPageViewFactoryType {
             )
             
             let trainingViewFactory: TrainingViewFactory = TrainingViewFactory(
+                mobileContentAnalytics: mobileContentAnalytics,
                 viewedTrainingTipsService: viewedTrainingTipsService
             )
             
@@ -71,6 +73,7 @@ class MobileContentRendererPageViewFactories: MobileContentPageViewFactoryType {
             )
             
             let trainingViewFactory: TrainingViewFactory = TrainingViewFactory(
+                mobileContentAnalytics: mobileContentAnalytics,
                 viewedTrainingTipsService: viewedTrainingTipsService
             )
             
@@ -79,6 +82,7 @@ class MobileContentRendererPageViewFactories: MobileContentPageViewFactoryType {
         case .trainingTip:
             
             let trainingViewFactory: TrainingViewFactory = TrainingViewFactory(
+                mobileContentAnalytics: mobileContentAnalytics,
                 viewedTrainingTipsService: viewedTrainingTipsService
             )
             

--- a/godtools/App/Services/Renderer/Views/ChooseYourOwnAdventure/ViewFactory/ChooseYourOwnAdventurePageViewFactory.swift
+++ b/godtools/App/Services/Renderer/Views/ChooseYourOwnAdventure/ViewFactory/ChooseYourOwnAdventurePageViewFactory.swift
@@ -12,10 +12,12 @@ import GodToolsToolParser
 class ChooseYourOwnAdventurePageViewFactory: MobileContentPageViewFactoryType {
     
     private let analytics: AnalyticsContainer
+    private let mobileContentAnalytics: MobileContentAnalytics
         
-    required init(analytics: AnalyticsContainer) {
+    required init(analytics: AnalyticsContainer, mobileContentAnalytics: MobileContentAnalytics) {
         
         self.analytics = analytics
+        self.mobileContentAnalytics = mobileContentAnalytics
     }
     
     func viewForRenderableModel(renderableModel: AnyObject, renderableModelParent: AnyObject?, renderedPageContext: MobileContentRenderedPageContext) -> MobileContentView? {
@@ -45,6 +47,7 @@ class ChooseYourOwnAdventurePageViewFactory: MobileContentPageViewFactoryType {
             let viewModel = MobileContentContentPageViewModel(
                 contentPage: contentPage,
                 renderedPageContext: renderedPageContext,
+                mobileContentAnalytics: mobileContentAnalytics,
                 analytics: analytics
             )
             
@@ -60,7 +63,8 @@ class ChooseYourOwnAdventurePageViewFactory: MobileContentPageViewFactoryType {
             
             let viewModel = MobileContentFlowViewModel(
                 contentFlow: contentFlow,
-                renderedPageContext: renderedPageContext
+                renderedPageContext: renderedPageContext,
+                mobileContentAnalytics: mobileContentAnalytics
             )
             
             let view = MobileContentFlowView(viewModel: viewModel)

--- a/godtools/App/Services/Renderer/Views/Lesson/Views/Page/LessonPageViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/Lesson/Views/Page/LessonPageViewModel.swift
@@ -26,7 +26,7 @@ class LessonPageViewModel: MobileContentPageViewModel {
             renderedPageContext: renderedPageContext
         )
         
-        super.init(pageModel: pageModel, renderedPageContext: renderedPageContext, hidesBackgroundImage: false)
+        super.init(pageModel: pageModel, renderedPageContext: renderedPageContext, mobileContentAnalytics: mobileContentAnalytics, hidesBackgroundImage: false)
     }
 }
 

--- a/godtools/App/Services/Renderer/Views/MobileContent/ViewFactory/MobileContentPageViewFactory.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/ViewFactory/MobileContentPageViewFactory.swift
@@ -29,7 +29,8 @@ class MobileContentPageViewFactory: MobileContentPageViewFactoryType {
         
             let viewModel = MobileContentParagraphViewModel(
                 paragraphModel: paragraphModel,
-                renderedPageContext: renderedPageContext
+                renderedPageContext: renderedPageContext,
+                mobileContentAnalytics: mobileContentAnalytics
             )
             
             let view = MobileContentParagraphView(viewModel: viewModel, contentInsets: .zero, itemSpacing: 5, scrollIsEnabled: false)
@@ -99,7 +100,8 @@ class MobileContentPageViewFactory: MobileContentPageViewFactoryType {
             
             let viewModel = MobileContentCardCollectionPageCardViewModel(
                 card: cardCollectionPageCard,
-                renderedPageContext: renderedPageContext
+                renderedPageContext: renderedPageContext,
+                mobileContentAnalytics: mobileContentAnalytics
             )
             
             let view = MobileContentCardCollectionPageCardView(viewModel: viewModel)
@@ -111,6 +113,7 @@ class MobileContentPageViewFactory: MobileContentPageViewFactoryType {
             let viewModel = MobileContentContentPageViewModel(
                 contentPage: contentPage,
                 renderedPageContext: renderedPageContext,
+                mobileContentAnalytics: mobileContentAnalytics,
                 analytics: analytics
             )
             
@@ -123,6 +126,7 @@ class MobileContentPageViewFactory: MobileContentPageViewFactoryType {
             let viewModel = MobileContentCardCollectionPageViewModel(
                 cardCollectionPage: cardCollectionPage,
                 renderedPageContext: renderedPageContext,
+                mobileContentAnalytics: mobileContentAnalytics,
                 analytics: analytics
             )
             
@@ -134,7 +138,8 @@ class MobileContentPageViewFactory: MobileContentPageViewFactoryType {
             
             let viewModel = MobileContentHeadingViewModel(
                 headingModel: headingModel.text,
-                renderedPageContext: renderedPageContext
+                renderedPageContext: renderedPageContext,
+                mobileContentAnalytics: mobileContentAnalytics
             )
             
             let view = MobileContentHeadingView(viewModel: viewModel)
@@ -143,8 +148,14 @@ class MobileContentPageViewFactory: MobileContentPageViewFactoryType {
         }
         else if let contentModel = renderableModel as? MultiplatformContent {
             
+            let viewModel = MobileContentViewModel(
+                baseModels: contentModel.content,
+                renderedPageContext: renderedPageContext,
+                mobileContentAnalytics: mobileContentAnalytics
+            )
+            
             return MobileContentStackView(
-                viewModel: MobileContentViewModel(baseModels: contentModel.content, renderedPageContext: renderedPageContext),
+                viewModel: viewModel,
                 contentInsets: contentModel.contentInsets,
                 itemSpacing: contentModel.itemSpacing,
                 scrollIsEnabled: contentModel.scrollIsEnabled
@@ -166,7 +177,8 @@ class MobileContentPageViewFactory: MobileContentPageViewFactoryType {
             
             let viewModel = MobileContentEmbeddedVideoViewModel(
                 videoModel: videoModel,
-                renderedPageContext: renderedPageContext
+                renderedPageContext: renderedPageContext,
+                mobileContentAnalytics: mobileContentAnalytics
             )
             
             let view = MobileContentEmbeddedVideoView(viewModel: viewModel)
@@ -189,7 +201,8 @@ class MobileContentPageViewFactory: MobileContentPageViewFactoryType {
 
             let viewModel = MobileContentTabsViewModel(
                 tabsModel: tabsModel,
-                renderedPageContext: renderedPageContext
+                renderedPageContext: renderedPageContext,
+                mobileContentAnalytics: mobileContentAnalytics
             )
             
             let view = MobileContentTabsView(viewModel: viewModel)
@@ -201,6 +214,7 @@ class MobileContentPageViewFactory: MobileContentPageViewFactoryType {
             let viewModel = MobileContentInputViewModel(
                 inputModel: inputModel,
                 renderedPageContext: renderedPageContext,
+                mobileContentAnalytics: mobileContentAnalytics,
                 fontService: fontService
             )
             
@@ -212,7 +226,8 @@ class MobileContentPageViewFactory: MobileContentPageViewFactoryType {
             
             let viewModel = MobileContentFormViewModel(
                 formModel: formModel,
-                renderedPageContext: renderedPageContext
+                renderedPageContext: renderedPageContext,
+                mobileContentAnalytics: mobileContentAnalytics
             )
             
             let view = MobileContentFormView(viewModel: viewModel)
@@ -223,7 +238,8 @@ class MobileContentPageViewFactory: MobileContentPageViewFactoryType {
                 
             let viewModel = MobileContentSpacerViewModel(
                 spacerModel: spacerModel,
-                renderedPageContext: renderedPageContext
+                renderedPageContext: renderedPageContext,
+                mobileContentAnalytics: mobileContentAnalytics
             )
             
             let view = MobileContentSpacerView(viewModel: viewModel)
@@ -234,7 +250,8 @@ class MobileContentPageViewFactory: MobileContentPageViewFactoryType {
             
             let viewModel = MobileContentHeaderViewModel(
                 headerModel: headerModel.text,
-                renderedPageContext: renderedPageContext
+                renderedPageContext: renderedPageContext,
+                mobileContentAnalytics: mobileContentAnalytics
             )
             
             let view = MobileContentHeaderView(viewModel: viewModel)
@@ -245,7 +262,8 @@ class MobileContentPageViewFactory: MobileContentPageViewFactoryType {
             
             let viewModel = MobileContentFlowViewModel(
                 contentFlow: contentFlow,
-                renderedPageContext: renderedPageContext
+                renderedPageContext: renderedPageContext,
+                mobileContentAnalytics: mobileContentAnalytics
             )
             
             let view = MobileContentFlowView(viewModel: viewModel)
@@ -256,7 +274,8 @@ class MobileContentPageViewFactory: MobileContentPageViewFactoryType {
             
             let viewModel = MobileContentFlowItemViewModel(
                 flowItem: contentFlowItem,
-                renderedPageContext: renderedPageContext
+                renderedPageContext: renderedPageContext,
+                mobileContentAnalytics: mobileContentAnalytics
             )
             
             let view = MobileContentFlowItemView(viewModel: viewModel)
@@ -279,7 +298,8 @@ class MobileContentPageViewFactory: MobileContentPageViewFactoryType {
             
             let viewModel = MobileContentMultiSelectViewModel(
                 multiSelectModel: multiSelectModel,
-                renderedPageContext: renderedPageContext
+                renderedPageContext: renderedPageContext,
+                mobileContentAnalytics: mobileContentAnalytics
             )
             
             let view = MobileContentMultiSelectView(viewModel: viewModel)
@@ -302,7 +322,8 @@ class MobileContentPageViewFactory: MobileContentPageViewFactoryType {
             
             let viewModel = MobileContentAccordionViewModel(
                 accordionModel: accordionModel,
-                renderedPageContext: renderedPageContext
+                renderedPageContext: renderedPageContext,
+                mobileContentAnalytics: mobileContentAnalytics
             )
             
             let view = MobileContentAccordionView(viewModel: viewModel)
@@ -318,6 +339,7 @@ class MobileContentPageViewFactory: MobileContentPageViewFactoryType {
         let viewModel = MobileContentTextViewModel(
             textModel: textModel,
             renderedPageContext: renderedPageContext,
+            mobileContentAnalytics: mobileContentAnalytics,
             fontService: fontService
         )
         

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/CardCollectionPage/MobileContentCardCollectionPageViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/CardCollectionPage/MobileContentCardCollectionPageViewModel.swift
@@ -14,12 +14,12 @@ class MobileContentCardCollectionPageViewModel: MobileContentPageViewModel {
     private let cardCollectionPage: CardCollectionPage
     private let analytics: AnalyticsContainer
         
-    init(cardCollectionPage: CardCollectionPage, renderedPageContext: MobileContentRenderedPageContext, analytics: AnalyticsContainer) {
+    init(cardCollectionPage: CardCollectionPage, renderedPageContext: MobileContentRenderedPageContext, mobileContentAnalytics: MobileContentAnalytics, analytics: AnalyticsContainer) {
         
         self.cardCollectionPage = cardCollectionPage
         self.analytics = analytics
         
-        super.init(pageModel: cardCollectionPage, renderedPageContext: renderedPageContext, hidesBackgroundImage: false)
+        super.init(pageModel: cardCollectionPage, renderedPageContext: renderedPageContext, mobileContentAnalytics: mobileContentAnalytics, hidesBackgroundImage: false)
     }
     
     private func getPageAnalyticsScreenName() -> String {

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/CardCollectionPageCard/MobileContentCardCollectionPageCardViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/CardCollectionPageCard/MobileContentCardCollectionPageCardViewModel.swift
@@ -15,11 +15,11 @@ class MobileContentCardCollectionPageCardViewModel: MobileContentViewModel {
     
     let pageNumber: String
     
-    init(card: CardCollectionPage.Card, renderedPageContext: MobileContentRenderedPageContext) {
+    init(card: CardCollectionPage.Card, renderedPageContext: MobileContentRenderedPageContext, mobileContentAnalytics: MobileContentAnalytics) {
                 
         self.cardModel = card
         pageNumber = "\(card.position + 1)/\(card.page.cards.count)"
         
-        super.init(baseModel: card, renderedPageContext: renderedPageContext)
+        super.init(baseModel: card, renderedPageContext: renderedPageContext, mobileContentAnalytics: mobileContentAnalytics)
     }
 }

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentAccordion/MobileContentAccordionViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentAccordion/MobileContentAccordionViewModel.swift
@@ -13,10 +13,10 @@ class MobileContentAccordionViewModel: MobileContentViewModel {
     
     private let accordionModel: Accordion
     
-    init(accordionModel: Accordion, renderedPageContext: MobileContentRenderedPageContext) {
+    init(accordionModel: Accordion, renderedPageContext: MobileContentRenderedPageContext, mobileContentAnalytics: MobileContentAnalytics) {
         
         self.accordionModel = accordionModel
         
-        super.init(baseModel: accordionModel, renderedPageContext: renderedPageContext)
+        super.init(baseModel: accordionModel, renderedPageContext: renderedPageContext, mobileContentAnalytics: mobileContentAnalytics)
     }
 }

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentAccordionSection/MobileContentAccordionSectionViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentAccordionSection/MobileContentAccordionSectionViewModel.swift
@@ -26,7 +26,7 @@ class MobileContentAccordionSectionViewModel: MobileContentViewModel {
             renderedPageContext: renderedPageContext
         )
         
-        super.init(baseModel: sectionModel, renderedPageContext: renderedPageContext)
+        super.init(baseModel: sectionModel, renderedPageContext: renderedPageContext, mobileContentAnalytics: mobileContentAnalytics)
     }
 }
 

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentAnimation/MobileContentAnimationView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentAnimation/MobileContentAnimationView.swift
@@ -12,7 +12,6 @@ class MobileContentAnimationView: MobileContentView {
     
     private let viewModel: MobileContentAnimationViewModel
     private let animatedView: AnimatedView = AnimatedView(frame: CGRect(x: 0, y: 0, width: 50, height: 50))
-    private let touchAreaButton: UIButton = UIButton(type: .custom)
     
     init(viewModel: MobileContentAnimationViewModel) {
         
@@ -22,8 +21,6 @@ class MobileContentAnimationView: MobileContentView {
         
         setupLayout()
         setupBinding()
-        
-        touchAreaButton.addTarget(self, action: #selector(touchAreaTapped), for: .touchUpInside)
     }
     
     required init?(coder: NSCoder) {
@@ -36,12 +33,6 @@ class MobileContentAnimationView: MobileContentView {
         addSubview(animatedView)
         animatedView.translatesAutoresizingMaskIntoConstraints = false
         animatedView.constrainEdgesToView(view: self)
-        
-        // touchAreaButton
-        addSubview(touchAreaButton)
-        touchAreaButton.translatesAutoresizingMaskIntoConstraints = false
-        touchAreaButton.constrainEdgesToView(view: self)
-        touchAreaButton.backgroundColor = .clear
     }
     
     private func setupBinding() {
@@ -50,11 +41,6 @@ class MobileContentAnimationView: MobileContentView {
             animatedView.configure(viewModel: animatedViewModel)
             animatedView.setAnimationContentMode(contentMode: .scaleAspectFill)
         }
-    }
-    
-    @objc private func touchAreaTapped() {
-        
-        super.viewTapped(mobileContentAnalytics: viewModel.mobileContentAnalytics)
     }
     
     override var heightConstraintType: MobileContentViewHeightConstraintType {

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentAnimation/MobileContentAnimationViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentAnimation/MobileContentAnimationViewModel.swift
@@ -42,6 +42,6 @@ class MobileContentAnimationViewModel: MobileContentViewModel {
             animatedViewModel = nil
         }
         
-        super.init(baseModel: animationModel, renderedPageContext: renderedPageContext)
+        super.init(baseModel: animationModel, renderedPageContext: renderedPageContext, mobileContentAnalytics: mobileContentAnalytics)
     }
 }

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentButton/MobileContentButtonView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentButton/MobileContentButtonView.swift
@@ -18,7 +18,6 @@ class MobileContentButtonView: MobileContentView {
     private let buttonTitle: UILabel = UILabel()
     private let buttonImagePaddingToButtonTitle: CGFloat = 12
     
-    private var tapGesture: UITapGestureRecognizer?
     private var buttonImageView: UIImageView?
     private var buttonViewWidthConstraint: NSLayoutConstraint?
     
@@ -30,11 +29,6 @@ class MobileContentButtonView: MobileContentView {
         
         setupLayout()
         setupBinding()
-        
-        // tapGesture
-        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(buttonTapped))
-        addGestureRecognizer(tapGesture)
-        self.tapGesture = tapGesture
     }
     
     required init?(coder: NSCoder) {
@@ -191,11 +185,6 @@ class MobileContentButtonView: MobileContentView {
         case .points(let value):
             break
         }
-    }
-    
-    @objc private func buttonTapped() {
-        
-        super.viewTapped(mobileContentAnalytics: viewModel.mobileContentAnalytics)
     }
     
     // MARK: - MobileContentView

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentButton/MobileContentButtonViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentButton/MobileContentButtonViewModel.swift
@@ -75,7 +75,7 @@ class MobileContentButtonViewModel: MobileContentViewModel {
             self.icon = nil
         }
         
-        super.init(baseModel: buttonModel, renderedPageContext: renderedPageContext)
+        super.init(baseModel: buttonModel, renderedPageContext: renderedPageContext, mobileContentAnalytics: mobileContentAnalytics)
         
         visibilityFlowWatcher = buttonModel.watchVisibility(state: renderedPageContext.rendererState, block: { [weak self] (invisible: KotlinBoolean, gone: KotlinBoolean) in
             

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentCard/MobileContentCardView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentCard/MobileContentCardView.swift
@@ -45,37 +45,4 @@ class MobileContentCardView: MobileContentStackView {
     private func setupBinding() {
         
     }
-    
-    override func finishedRenderingChildren() {
-        super.finishedRenderingChildren()
-        
-        addButtonOverlay()
-    }
-    
-    private func addButtonOverlay() {
-        
-        if let buttonOverlay = self.buttonOverlay {
-            buttonOverlay.removeTarget(self, action: #selector(cardTapped), for: .touchUpInside)
-            buttonOverlay.removeFromSuperview()
-            self.buttonOverlay = nil
-        }
-        
-        let button = UIButton(type: .custom)
-        
-        addSubview(button)
-        button.translatesAutoresizingMaskIntoConstraints = false
-        button.constrainEdgesToView(view: self)
-        
-        button.backgroundColor = .clear
-        button.setTitle(nil, for: .normal)
-        
-        button.addTarget(self, action: #selector(cardTapped), for: .touchUpInside)
-        
-        self.buttonOverlay = button
-    }
-    
-    @objc private func cardTapped() {
-        
-        super.viewTapped(mobileContentAnalytics: viewModel.mobileContentAnalytics)
-    }
 }

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentCard/MobileContentCardViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentCard/MobileContentCardViewModel.swift
@@ -20,6 +20,6 @@ class MobileContentCardViewModel: MobileContentViewModel {
         self.cardModel = cardModel
         self.mobileContentAnalytics = mobileContentAnalytics
         
-        super.init(baseModel: cardModel, renderedPageContext: renderedPageContext)
+        super.init(baseModel: cardModel, renderedPageContext: renderedPageContext, mobileContentAnalytics: mobileContentAnalytics)
     }
 }

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentEmbeddedVideo/MobileContentEmbeddedVideoViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentEmbeddedVideo/MobileContentEmbeddedVideoViewModel.swift
@@ -13,11 +13,11 @@ class MobileContentEmbeddedVideoViewModel: MobileContentViewModel {
     
     private let videoModel: Video
     
-    init(videoModel: Video, renderedPageContext: MobileContentRenderedPageContext) {
+    init(videoModel: Video, renderedPageContext: MobileContentRenderedPageContext, mobileContentAnalytics: MobileContentAnalytics) {
         
         self.videoModel = videoModel
         
-        super.init(baseModel: videoModel, renderedPageContext: renderedPageContext)
+        super.init(baseModel: videoModel, renderedPageContext: renderedPageContext, mobileContentAnalytics: mobileContentAnalytics)
     }
     
     var videoId: String {

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentFlow/MobileContentFlowViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentFlow/MobileContentFlowViewModel.swift
@@ -13,11 +13,11 @@ class MobileContentFlowViewModel: MobileContentViewModel {
     
     private let contentFlow: GodToolsToolParser.Flow
     
-    init(contentFlow: GodToolsToolParser.Flow, renderedPageContext: MobileContentRenderedPageContext) {
+    init(contentFlow: GodToolsToolParser.Flow, renderedPageContext: MobileContentRenderedPageContext, mobileContentAnalytics: MobileContentAnalytics) {
         
         self.contentFlow = contentFlow
         
-        super.init(baseModel: contentFlow, renderedPageContext: renderedPageContext)
+        super.init(baseModel: contentFlow, renderedPageContext: renderedPageContext, mobileContentAnalytics: mobileContentAnalytics)
     }
     
     var rowGravity: Gravity.Horizontal {

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentFlowItem/MobileContentFlowItemViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentFlowItem/MobileContentFlowItemViewModel.swift
@@ -17,7 +17,7 @@ class MobileContentFlowItemViewModel: MobileContentViewModel {
     
     let visibilityState: ObservableValue<MobileContentViewVisibilityState>
     
-    init(flowItem: GodToolsToolParser.Flow.Item, renderedPageContext: MobileContentRenderedPageContext) {
+    init(flowItem: GodToolsToolParser.Flow.Item, renderedPageContext: MobileContentRenderedPageContext, mobileContentAnalytics: MobileContentAnalytics) {
         
         self.flowItem = flowItem
         
@@ -35,7 +35,7 @@ class MobileContentFlowItemViewModel: MobileContentViewModel {
         
         visibilityState = ObservableValue(value: visibility)
         
-        super.init(baseModel: flowItem, renderedPageContext: renderedPageContext)
+        super.init(baseModel: flowItem, renderedPageContext: renderedPageContext, mobileContentAnalytics: mobileContentAnalytics)
         
         visibilityFlowWatcher = flowItem.watchVisibility(state: renderedPageContext.rendererState, block: { [weak self] (invisible: KotlinBoolean, gone: KotlinBoolean) in
             

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentForm/MobileContentFormViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentForm/MobileContentFormViewModel.swift
@@ -13,10 +13,10 @@ class MobileContentFormViewModel: MobileContentViewModel {
     
     private let formModel: Form
             
-    init(formModel: Form, renderedPageContext: MobileContentRenderedPageContext) {
+    init(formModel: Form, renderedPageContext: MobileContentRenderedPageContext, mobileContentAnalytics: MobileContentAnalytics) {
         
         self.formModel = formModel
         
-        super.init(baseModel: formModel, renderedPageContext: renderedPageContext)
+        super.init(baseModel: formModel, renderedPageContext: renderedPageContext, mobileContentAnalytics: mobileContentAnalytics)
     }
 }

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentHeader/MobileContentHeaderViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentHeader/MobileContentHeaderViewModel.swift
@@ -13,11 +13,11 @@ class MobileContentHeaderViewModel: MobileContentViewModel {
     
     private let headerModel: Text
     
-    init(headerModel: Text, renderedPageContext: MobileContentRenderedPageContext) {
+    init(headerModel: Text, renderedPageContext: MobileContentRenderedPageContext, mobileContentAnalytics: MobileContentAnalytics) {
         
         self.headerModel = headerModel
         
-        super.init(baseModel: headerModel, renderedPageContext: renderedPageContext)
+        super.init(baseModel: headerModel, renderedPageContext: renderedPageContext, mobileContentAnalytics: mobileContentAnalytics)
     }
     
     var fontSize: CGFloat {

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentImage/MobileContentImageView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentImage/MobileContentImageView.swift
@@ -43,11 +43,6 @@ class MobileContentImageView: MobileContentView {
         }
     }
     
-    @objc func handleImageTapped() {
-        
-        super.viewTapped(mobileContentAnalytics: viewModel.mobileContentAnalytics)
-    }
-    
     // MARK: - MobileContentView
 
     override var heightConstraintType: MobileContentViewHeightConstraintType {
@@ -92,12 +87,6 @@ extension MobileContentImageView {
         addSubview(imageView)
         imageView.translatesAutoresizingMaskIntoConstraints = false
         imageView.constrainEdgesToView(view: self)
-                
-        // add image tap gesture
-        let tapGesture: UITapGestureRecognizer = UITapGestureRecognizer()
-        tapGesture.addTarget(self, action: #selector(handleImageTapped))
-        imageView.isUserInteractionEnabled = true
-        imageView.addGestureRecognizer(tapGesture)
     }
 }
 

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentImage/MobileContentImageViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentImage/MobileContentImageViewModel.swift
@@ -31,6 +31,6 @@ class MobileContentImageViewModel: MobileContentViewModel {
             self.image = nil
         }
         
-        super.init(baseModel: imageModel, renderedPageContext: renderedPageContext)
+        super.init(baseModel: imageModel, renderedPageContext: renderedPageContext, mobileContentAnalytics: mobileContentAnalytics)
     }
 }

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentInput/MobileContentInputViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentInput/MobileContentInputViewModel.swift
@@ -19,7 +19,7 @@ class MobileContentInputViewModel: MobileContentViewModel {
     let inputLabel: String?
     let placeholder: String?
     
-    init(inputModel: Input, renderedPageContext: MobileContentRenderedPageContext, fontService: FontService) {
+    init(inputModel: Input, renderedPageContext: MobileContentRenderedPageContext, mobileContentAnalytics: MobileContentAnalytics, fontService: FontService) {
         
         self.inputModel = inputModel
         self.fontService = fontService
@@ -27,7 +27,7 @@ class MobileContentInputViewModel: MobileContentViewModel {
         inputLabel = inputModel.label?.text
         placeholder = inputModel.placeholder?.text
         
-        super.init(baseModel: inputModel, renderedPageContext: renderedPageContext)
+        super.init(baseModel: inputModel, renderedPageContext: renderedPageContext, mobileContentAnalytics: mobileContentAnalytics)
     }
     
     var isHidden: Bool {

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentLink/MobileContentLinkView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentLink/MobileContentLinkView.swift
@@ -21,8 +21,6 @@ class MobileContentLinkView: MobileContentView {
         
         setupLayout()
         setupBinding()
-        
-        linkButton.addTarget(self, action: #selector(handleLinkTapped), for: .touchUpInside)
     }
     
     required init?(coder: NSCoder) {
@@ -58,11 +56,6 @@ class MobileContentLinkView: MobileContentView {
         linkButton.titleLabel?.font = viewModel.font
         linkButton.setTitle(viewModel.title, for: .normal)
         linkButton.setTitleColor(viewModel.titleColor, for: .normal)
-    }
-    
-    @objc func handleLinkTapped() {
-        
-        super.viewTapped(mobileContentAnalytics: viewModel.mobileContentAnalytics)
     }
     
     // MARK: - MobileContentView

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentLink/MobileContentLinkViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentLink/MobileContentLinkViewModel.swift
@@ -26,7 +26,7 @@ class MobileContentLinkViewModel: MobileContentViewModel {
         self.fontService = fontService
         self.titleColor = linkModel.text.textColor
         
-        super.init(baseModel: linkModel, renderedPageContext: renderedPageContext)
+        super.init(baseModel: linkModel, renderedPageContext: renderedPageContext, mobileContentAnalytics: mobileContentAnalytics)
     }
     
     var backgroundColor: UIColor {

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentMultiSelect/MobileContentMultiSelectViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentMultiSelect/MobileContentMultiSelectViewModel.swift
@@ -13,11 +13,11 @@ class MobileContentMultiSelectViewModel: MobileContentViewModel {
     
     private let multiSelectModel: Multiselect
     
-    init(multiSelectModel: Multiselect, renderedPageContext: MobileContentRenderedPageContext) {
+    init(multiSelectModel: Multiselect, renderedPageContext: MobileContentRenderedPageContext, mobileContentAnalytics: MobileContentAnalytics) {
         
         self.multiSelectModel = multiSelectModel
         
-        super.init(baseModel: multiSelectModel, renderedPageContext: renderedPageContext)
+        super.init(baseModel: multiSelectModel, renderedPageContext: renderedPageContext, mobileContentAnalytics: mobileContentAnalytics)
     }
     
     var numberOfColumnsForOptions: Int {

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentMultiSelectOption/MobileContentMultiSelectOptionViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentMultiSelectOption/MobileContentMultiSelectOptionViewModel.swift
@@ -28,7 +28,7 @@ class MobileContentMultiSelectOptionViewModel: MobileContentViewModel {
         
         hidesShadow = multiSelectOptionModel.style == .flat
         
-        super.init(baseModel: multiSelectOptionModel, renderedPageContext: renderedPageContext)
+        super.init(baseModel: multiSelectOptionModel, renderedPageContext: renderedPageContext, mobileContentAnalytics: mobileContentAnalytics)
         
         isSelectedFlowWatcher = multiSelectOptionModel.watchIsSelected(state: renderedPageContext.rendererState) { [weak self] (isSelected: KotlinBoolean) in
 

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentPage/MobileContentContentPageViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentPage/MobileContentContentPageViewModel.swift
@@ -14,12 +14,12 @@ class MobileContentContentPageViewModel: MobileContentPageViewModel {
     private let contentPage: Page
     private let analytics: AnalyticsContainer
     
-    init(contentPage: Page, renderedPageContext: MobileContentRenderedPageContext, analytics: AnalyticsContainer) {
+    init(contentPage: Page, renderedPageContext: MobileContentRenderedPageContext, mobileContentAnalytics: MobileContentAnalytics, analytics: AnalyticsContainer) {
         
         self.contentPage = contentPage
         self.analytics = analytics
         
-        super.init(pageModel: contentPage, renderedPageContext: renderedPageContext, hidesBackgroundImage: false)
+        super.init(pageModel: contentPage, renderedPageContext: renderedPageContext, mobileContentAnalytics: mobileContentAnalytics, hidesBackgroundImage: false)
     }
     
     private func getPageAnalyticsScreenName() -> String {

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentParagraph/MobileContentParagraphViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentParagraph/MobileContentParagraphViewModel.swift
@@ -17,11 +17,11 @@ class MobileContentParagraphViewModel: MobileContentViewModel {
     
     let visibilityState: ObservableValue<MobileContentViewVisibilityState> = ObservableValue(value: .visible)
     
-    init(paragraphModel: Paragraph, renderedPageContext: MobileContentRenderedPageContext) {
+    init(paragraphModel: Paragraph, renderedPageContext: MobileContentRenderedPageContext, mobileContentAnalytics: MobileContentAnalytics) {
         
         self.paragraphModel = paragraphModel
         
-        super.init(baseModel: paragraphModel, renderedPageContext: renderedPageContext)
+        super.init(baseModel: paragraphModel, renderedPageContext: renderedPageContext, mobileContentAnalytics: mobileContentAnalytics)
                 
         visibilityFlowWatcher = paragraphModel.watchVisibility(state: renderedPageContext.rendererState) { [weak self] (invisible: KotlinBoolean, gone: KotlinBoolean) in
                 

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentTab/MobileContentTabViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentTab/MobileContentTabViewModel.swift
@@ -19,7 +19,7 @@ class MobileContentTabViewModel: MobileContentViewModel {
         self.tabModel = tabModel
         self.mobileContentAnalytics = mobileContentAnalytics
         
-        super.init(baseModel: tabModel, renderedPageContext: renderedPageContext)
+        super.init(baseModel: tabModel, renderedPageContext: renderedPageContext, mobileContentAnalytics: mobileContentAnalytics)
     }
     
     var labelText: String? {

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentTabs/MobileContentTabsViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentTabs/MobileContentTabsViewModel.swift
@@ -13,11 +13,11 @@ class MobileContentTabsViewModel: MobileContentViewModel {
     
     private let tabsModel: Tabs
         
-    init(tabsModel: Tabs, renderedPageContext: MobileContentRenderedPageContext) {
+    init(tabsModel: Tabs, renderedPageContext: MobileContentRenderedPageContext, mobileContentAnalytics: MobileContentAnalytics) {
         
         self.tabsModel = tabsModel
         
-        super.init(baseModel: tabsModel, renderedPageContext: renderedPageContext)
+        super.init(baseModel: tabsModel, renderedPageContext: renderedPageContext, mobileContentAnalytics: mobileContentAnalytics)
     }
     
     var languageDirectionSemanticContentAttribute: UISemanticContentAttribute {

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentText/MobileContentTextViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentText/MobileContentTextViewModel.swift
@@ -19,14 +19,14 @@ class MobileContentTextViewModel: MobileContentViewModel {
         
     let textColor: UIColor
     
-    init(textModel: Text, renderedPageContext: MobileContentRenderedPageContext, fontService: FontService) {
+    init(textModel: Text, renderedPageContext: MobileContentRenderedPageContext, mobileContentAnalytics: MobileContentAnalytics, fontService: FontService) {
         
         self.textModel = textModel
         self.fontService = fontService
         
         self.textColor = textModel.textColor
         
-        super.init(baseModel: textModel, renderedPageContext: renderedPageContext)
+        super.init(baseModel: textModel, renderedPageContext: renderedPageContext, mobileContentAnalytics: mobileContentAnalytics)
     }
     
     var startImage: UIImage? {

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/Heading/MobileContentHeadingViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/Heading/MobileContentHeadingViewModel.swift
@@ -13,11 +13,11 @@ class MobileContentHeadingViewModel: MobileContentViewModel {
     
     private let headingModel: Text
     
-    init(headingModel: Text, renderedPageContext: MobileContentRenderedPageContext) {
+    init(headingModel: Text, renderedPageContext: MobileContentRenderedPageContext, mobileContentAnalytics: MobileContentAnalytics) {
         
         self.headingModel = headingModel
         
-        super.init(baseModel: headingModel, renderedPageContext: renderedPageContext)
+        super.init(baseModel: headingModel, renderedPageContext: renderedPageContext, mobileContentAnalytics: mobileContentAnalytics)
     }
     
     var fontSize: CGFloat {

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/MobileContentView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/MobileContentView.swift
@@ -19,6 +19,8 @@ class MobileContentView: UIView {
     
     private let viewModel: MobileContentViewModel?
     
+    private var tapGesture: UITapGestureRecognizer?
+    
     private(set) weak var parent: MobileContentView?
     
     private(set) var children: [MobileContentView] = Array()
@@ -30,6 +32,12 @@ class MobileContentView: UIView {
         self.viewModel = viewModel
         
         super.init(frame: frame ?? UIScreen.main.bounds)
+        
+        if isClickable {
+            let tapGesture = UITapGestureRecognizer(target: self, action: #selector(tapped))
+            addGestureRecognizer(tapGesture)
+            self.tapGesture = tapGesture
+        }
     }
     
     required init?(coder: NSCoder) {
@@ -38,6 +46,10 @@ class MobileContentView: UIView {
     
     var paddingInsets: UIEdgeInsets {
         return .zero
+    }
+    
+    var isClickable: Bool {
+        return viewModel?.getIsClickable() ?? false
     }
             
     private func getRootView() -> MobileContentView {
@@ -116,13 +128,13 @@ class MobileContentView: UIView {
     
     // MARK: - View Tapped
     
-    func viewTapped(mobileContentAnalytics: MobileContentAnalytics) {
-        
+    @objc private func tapped() {
+
         guard let viewModel = self.viewModel else {
             return
         }
         
-        viewModel.viewTapped(mobileContentAnalytics: mobileContentAnalytics)
+        viewModel.viewTapped()
         
         let clickableEvents: [EventId] = viewModel.getClickableEvents()
         

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/MobileContentViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/MobileContentViewModel.swift
@@ -11,11 +11,13 @@ import GodToolsToolParser
 
 class MobileContentViewModel: NSObject {
     
+    private let mobileContentAnalytics: MobileContentAnalytics
+    
     let baseModel: BaseModel?
     let baseModels: [BaseModel]
     let renderedPageContext: MobileContentRenderedPageContext
     
-    init(baseModel: BaseModel?, renderedPageContext: MobileContentRenderedPageContext) {
+    init(baseModel: BaseModel?, renderedPageContext: MobileContentRenderedPageContext, mobileContentAnalytics: MobileContentAnalytics) {
         
         self.baseModel = baseModel
         
@@ -27,16 +29,18 @@ class MobileContentViewModel: NSObject {
         }
         
         self.renderedPageContext = renderedPageContext
+        self.mobileContentAnalytics = mobileContentAnalytics
                 
         super.init()
     }
     
-    init(baseModels: [BaseModel], renderedPageContext: MobileContentRenderedPageContext) {
+    init(baseModels: [BaseModel], renderedPageContext: MobileContentRenderedPageContext, mobileContentAnalytics: MobileContentAnalytics) {
         
         self.baseModel = baseModels.first
         self.baseModels = baseModels
         
         self.renderedPageContext = renderedPageContext
+        self.mobileContentAnalytics = mobileContentAnalytics
         
         super.init()
     }
@@ -78,12 +82,21 @@ class MobileContentViewModel: NSObject {
 
 extension MobileContentViewModel {
     
-    func viewTapped(mobileContentAnalytics: MobileContentAnalytics) {
+    func viewTapped() {
                 
         mobileContentAnalytics.trackEvents(
             events: getClickableAnalyticsEvents(),
             renderedPageContext: renderedPageContext
         )
+    }
+    
+    func getIsClickable() -> Bool {
+        
+        guard let clickableModel = baseModel as? Clickable else {
+            return false
+        }
+        
+        return clickableModel.isClickable
     }
     
     func getClickableAnalyticsEvents() -> [AnalyticsEvent] {

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/Page/MobileContentPageViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/Page/MobileContentPageViewModel.swift
@@ -15,12 +15,12 @@ class MobileContentPageViewModel: MobileContentViewModel {
     private let pageModel: Page
     private let hidesBackgroundImage: Bool
         
-    init(pageModel: Page, renderedPageContext: MobileContentRenderedPageContext, hidesBackgroundImage: Bool) {
+    init(pageModel: Page, renderedPageContext: MobileContentRenderedPageContext, mobileContentAnalytics: MobileContentAnalytics, hidesBackgroundImage: Bool) {
         
         self.pageModel = pageModel
         self.hidesBackgroundImage = hidesBackgroundImage
         
-        super.init(baseModel: pageModel, renderedPageContext: renderedPageContext)
+        super.init(baseModel: pageModel, renderedPageContext: renderedPageContext, mobileContentAnalytics: mobileContentAnalytics)
     }
     
     var analyticsScreenName: String {

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/Spacer/MobileContentSpacerViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/Spacer/MobileContentSpacerViewModel.swift
@@ -15,7 +15,7 @@ class MobileContentSpacerViewModel: MobileContentViewModel {
     
     let height: MobileContentSpacerHeight
     
-    init(spacerModel: Spacer, renderedPageContext: MobileContentRenderedPageContext) {
+    init(spacerModel: Spacer, renderedPageContext: MobileContentRenderedPageContext, mobileContentAnalytics: MobileContentAnalytics) {
         
         self.spacerModel = spacerModel
         
@@ -28,6 +28,6 @@ class MobileContentSpacerViewModel: MobileContentViewModel {
             height = .auto
         }
         
-        super.init(baseModel: spacerModel, renderedPageContext: renderedPageContext)
+        super.init(baseModel: spacerModel, renderedPageContext: renderedPageContext, mobileContentAnalytics: mobileContentAnalytics)
     }
 }

--- a/godtools/App/Services/Renderer/Views/Tool/ViewFactory/ToolPageViewFactory.swift
+++ b/godtools/App/Services/Renderer/Views/Tool/ViewFactory/ToolPageViewFactory.swift
@@ -61,6 +61,7 @@ class ToolPageViewFactory: MobileContentPageViewFactoryType {
             let viewModel = ToolPageHeaderViewModel(
                 headerModel: headerModel,
                 renderedPageContext: renderedPageContext,
+                mobileContentAnalytics: mobileContentAnalytics,
                 viewedTrainingTipsService: viewedTrainingTipsService
             )
 
@@ -85,6 +86,7 @@ class ToolPageViewFactory: MobileContentPageViewFactoryType {
             let viewModel = ToolPageCardsViewModel(
                 cards: cardsModel.cards,
                 renderedPageContext: renderedPageContext,
+                mobileContentAnalytics: mobileContentAnalytics,
                 cardJumpService: cardJumpService
             )
             
@@ -100,6 +102,7 @@ class ToolPageViewFactory: MobileContentPageViewFactoryType {
             let viewModel = ToolPageFormViewModel(
                 formModel: formModel,
                 renderedPageContext: renderedPageContext,
+                mobileContentAnalytics: mobileContentAnalytics,
                 followUpService: followUpService,
                 localizationServices: localizationServices
             )
@@ -112,7 +115,8 @@ class ToolPageViewFactory: MobileContentPageViewFactoryType {
             
             let viewModel = ToolPageModalViewModel(
                 modalModel: modalModel,
-                renderedPageContext: renderedPageContext
+                renderedPageContext: renderedPageContext,
+                mobileContentAnalytics: mobileContentAnalytics
             )
             
             let view = ToolPageModalView(viewModel: viewModel)
@@ -123,7 +127,8 @@ class ToolPageViewFactory: MobileContentPageViewFactoryType {
             
             let viewModel = ToolPageModalsViewModel(
                 modals: modalsModel.modals,
-                renderedPageContext: renderedPageContext
+                renderedPageContext: renderedPageContext,
+                mobileContentAnalytics: mobileContentAnalytics
             )
             
             let view = ToolPageModalsView(
@@ -158,6 +163,7 @@ class ToolPageViewFactory: MobileContentPageViewFactoryType {
         let viewModel = ToolPageCallToActionViewModel(
             callToActionModel: callToActionModel,
             renderedPageContext: renderedPageContext,
+            mobileContentAnalytics: mobileContentAnalytics,
             fontService: fontService
         )
         

--- a/godtools/App/Services/Renderer/Views/Tool/Views/CallToAction/ToolPageCallToActionViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/Tool/Views/CallToAction/ToolPageCallToActionViewModel.swift
@@ -14,12 +14,12 @@ class ToolPageCallToActionViewModel: MobileContentViewModel {
     private let callToActionModel: CallToAction?
     private let fontService: FontService
         
-    required init(callToActionModel: CallToAction?, renderedPageContext: MobileContentRenderedPageContext, fontService: FontService) {
+    init(callToActionModel: CallToAction?, renderedPageContext: MobileContentRenderedPageContext, mobileContentAnalytics: MobileContentAnalytics, fontService: FontService) {
         
         self.callToActionModel = callToActionModel
         self.fontService = fontService
         
-        super.init(baseModel: callToActionModel, renderedPageContext: renderedPageContext)
+        super.init(baseModel: callToActionModel, renderedPageContext: renderedPageContext, mobileContentAnalytics: mobileContentAnalytics)
     }
     
     var languageDirectionSemanticContentAttribute: UISemanticContentAttribute {

--- a/godtools/App/Services/Renderer/Views/Tool/Views/Card/ToolPageCardViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/Tool/Views/Card/ToolPageCardViewModel.swift
@@ -62,7 +62,7 @@ class ToolPageCardViewModel: MobileContentViewModel {
             hidesHeaderTrainingTip = !hasTrainingTip
         }
         
-        super.init(baseModel: cardModel, renderedPageContext: renderedPageContext)
+        super.init(baseModel: cardModel, renderedPageContext: renderedPageContext, mobileContentAnalytics: mobileContentAnalytics)
     }
     
     private var analyticsScreenName: String {

--- a/godtools/App/Services/Renderer/Views/Tool/Views/Cards/ToolPageCardsViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/Tool/Views/Cards/ToolPageCardsViewModel.swift
@@ -16,14 +16,14 @@ class ToolPageCardsViewModel: MobileContentViewModel {
     
     let hidesCardJump: ObservableValue<Bool> = ObservableValue(value: true)
     
-    required init(cards: [TractPage.Card], renderedPageContext: MobileContentRenderedPageContext, cardJumpService: CardJumpService) {
+    init(cards: [TractPage.Card], renderedPageContext: MobileContentRenderedPageContext, mobileContentAnalytics: MobileContentAnalytics, cardJumpService: CardJumpService) {
         
         let visibleCards: [TractPage.Card] = cards.filter({!$0.isHidden})
         
         self.cards = cards
         self.cardJumpService = cardJumpService
         
-        super.init(baseModels: cards, renderedPageContext: renderedPageContext)
+        super.init(baseModels: cards, renderedPageContext: renderedPageContext, mobileContentAnalytics: mobileContentAnalytics)
         
         setupBinding()
         

--- a/godtools/App/Services/Renderer/Views/Tool/Views/Form/ToolPageFormViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/Tool/Views/Form/ToolPageFormViewModel.swift
@@ -17,12 +17,12 @@ class ToolPageFormViewModel: MobileContentFormViewModel {
     let didSendFollowUpSignal: SignalValue<[EventId]> = SignalValue()
     let error: ObservableValue<MobileContentErrorViewModel?> = ObservableValue(value: nil)
     
-    init(formModel: Form, renderedPageContext: MobileContentRenderedPageContext, followUpService: FollowUpsService, localizationServices: LocalizationServices) {
+    init(formModel: Form, renderedPageContext: MobileContentRenderedPageContext, mobileContentAnalytics: MobileContentAnalytics, followUpService: FollowUpsService, localizationServices: LocalizationServices) {
         
         self.followUpService = followUpService
         self.localizationServices = localizationServices
         
-        super.init(formModel: formModel, renderedPageContext: renderedPageContext)
+        super.init(formModel: formModel, renderedPageContext: renderedPageContext, mobileContentAnalytics: mobileContentAnalytics)
     }
     
     // MARK: - Follow Up

--- a/godtools/App/Services/Renderer/Views/Tool/Views/Header/ToolPageHeaderViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/Tool/Views/Header/ToolPageHeaderViewModel.swift
@@ -15,11 +15,11 @@ class ToolPageHeaderViewModel: MobileContentViewModel {
     
     private var mobileContentPageViewFactory: MobileContentPageViewFactory?
             
-    required init(headerModel: Header, renderedPageContext: MobileContentRenderedPageContext, viewedTrainingTipsService: ViewedTrainingTipsService) {
+    init(headerModel: Header, renderedPageContext: MobileContentRenderedPageContext, mobileContentAnalytics: MobileContentAnalytics, viewedTrainingTipsService: ViewedTrainingTipsService) {
         
         self.headerModel = headerModel
         
-        super.init(baseModel: headerModel, renderedPageContext: renderedPageContext)
+        super.init(baseModel: headerModel, renderedPageContext: renderedPageContext, mobileContentAnalytics: mobileContentAnalytics)
         
         for factory in renderedPageContext.pageViewFactories.factories {
             if let mobileContentPageViewFactory = factory as? MobileContentPageViewFactory {

--- a/godtools/App/Services/Renderer/Views/Tool/Views/Hero/ToolPageHeroViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/Tool/Views/Hero/ToolPageHeroViewModel.swift
@@ -24,7 +24,7 @@ class ToolPageHeroViewModel: MobileContentViewModel {
             renderedPageContext: renderedPageContext
         )
         
-        super.init(baseModel: heroModel, renderedPageContext: renderedPageContext)
+        super.init(baseModel: heroModel, renderedPageContext: renderedPageContext, mobileContentAnalytics: mobileContentAnalytics)
     }
     
     deinit {

--- a/godtools/App/Services/Renderer/Views/Tool/Views/Modal/ToolPageModalViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/Tool/Views/Modal/ToolPageModalViewModel.swift
@@ -13,11 +13,11 @@ class ToolPageModalViewModel: MobileContentViewModel {
     
     private let modalModel: Modal
             
-    init(modalModel: Modal, renderedPageContext: MobileContentRenderedPageContext) {
+    init(modalModel: Modal, renderedPageContext: MobileContentRenderedPageContext, mobileContentAnalytics: MobileContentAnalytics) {
         
         self.modalModel = modalModel
         
-        super.init(baseModel: modalModel, renderedPageContext: renderedPageContext)
+        super.init(baseModel: modalModel, renderedPageContext: renderedPageContext, mobileContentAnalytics: mobileContentAnalytics)
     }
     
     var backgroundColor: UIColor {

--- a/godtools/App/Services/Renderer/Views/Tool/Views/Modals/ToolPageModalsViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/Tool/Views/Modals/ToolPageModalsViewModel.swift
@@ -13,10 +13,10 @@ class ToolPageModalsViewModel: MobileContentViewModel {
     
     private let modals: [Modal]
     
-    required init(modals: [Modal], renderedPageContext: MobileContentRenderedPageContext) {
+    init(modals: [Modal], renderedPageContext: MobileContentRenderedPageContext, mobileContentAnalytics: MobileContentAnalytics) {
         
         self.modals = modals
         
-        super.init(baseModels: modals, renderedPageContext: renderedPageContext)
+        super.init(baseModels: modals, renderedPageContext: renderedPageContext, mobileContentAnalytics: mobileContentAnalytics)
     }
 }

--- a/godtools/App/Services/Renderer/Views/Tool/Views/Page/ToolPageViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/Tool/Views/Page/ToolPageViewModel.swift
@@ -31,7 +31,7 @@ class ToolPageViewModel: MobileContentPageViewModel {
             renderedPageContext: renderedPageContext
         )
         
-        super.init(pageModel: pageModel, renderedPageContext: renderedPageContext, hidesBackgroundImage: false)
+        super.init(pageModel: pageModel, renderedPageContext: renderedPageContext, mobileContentAnalytics: mobileContentAnalytics, hidesBackgroundImage: false)
     }
     
     override var analyticsScreenName: String {

--- a/godtools/App/Services/Renderer/Views/Training/ViewFactory/TrainingViewFactory.swift
+++ b/godtools/App/Services/Renderer/Views/Training/ViewFactory/TrainingViewFactory.swift
@@ -11,10 +11,12 @@ import GodToolsToolParser
 
 class TrainingViewFactory: MobileContentPageViewFactoryType {
     
+    private let mobileContentAnalytics: MobileContentAnalytics
     private let viewedTrainingTipsService: ViewedTrainingTipsService
             
-    required init(viewedTrainingTipsService: ViewedTrainingTipsService) {
-        
+    init(mobileContentAnalytics: MobileContentAnalytics, viewedTrainingTipsService: ViewedTrainingTipsService) {
+    
+        self.mobileContentAnalytics = mobileContentAnalytics
         self.viewedTrainingTipsService = viewedTrainingTipsService
     }
     
@@ -37,7 +39,8 @@ class TrainingViewFactory: MobileContentPageViewFactoryType {
             
             let viewModel = TrainingPageViewModel(
                 pageModel: pageModel,
-                renderedPageContext: renderedPageContext
+                renderedPageContext: renderedPageContext,
+                mobileContentAnalytics: mobileContentAnalytics
             )
             
             let view = TrainingPageView(viewModel: viewModel)
@@ -57,6 +60,7 @@ class TrainingViewFactory: MobileContentPageViewFactoryType {
         let viewModel = TrainingTipViewModel(
             tipModel: tipModel,
             renderedPageContext: renderedPageContext,
+            mobileContentAnalytics: mobileContentAnalytics,
             viewType: trainingTipViewType,
             viewedTrainingTipsService: viewedTrainingTipsService
         )

--- a/godtools/App/Services/Renderer/Views/Training/Views/Page/TrainingPageViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/Training/Views/Page/TrainingPageViewModel.swift
@@ -13,10 +13,10 @@ class TrainingPageViewModel: MobileContentViewModel {
     
     private let pageModel: TipPage
     
-    required init(pageModel: TipPage, renderedPageContext: MobileContentRenderedPageContext) {
+    init(pageModel: TipPage, renderedPageContext: MobileContentRenderedPageContext, mobileContentAnalytics: MobileContentAnalytics) {
         
         self.pageModel = pageModel
         
-        super.init(baseModel: pageModel, renderedPageContext: renderedPageContext)
+        super.init(baseModel: pageModel, renderedPageContext: renderedPageContext, mobileContentAnalytics: mobileContentAnalytics)
     }
 }

--- a/godtools/App/Services/Renderer/Views/Training/Views/TrainingTip/TrainingTipViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/Training/Views/TrainingTip/TrainingTipViewModel.swift
@@ -19,13 +19,13 @@ class TrainingTipViewModel: MobileContentViewModel {
     let trainingTipBackgroundImage: ObservableValue<UIImage?> = ObservableValue(value: nil)
     let trainingTipForegroundImage: ObservableValue<UIImage?> = ObservableValue(value: nil)
     
-    required init(tipModel: Tip, renderedPageContext: MobileContentRenderedPageContext, viewType: TrainingTipViewType, viewedTrainingTipsService: ViewedTrainingTipsService) {
+    init(tipModel: Tip, renderedPageContext: MobileContentRenderedPageContext, mobileContentAnalytics: MobileContentAnalytics, viewType: TrainingTipViewType, viewedTrainingTipsService: ViewedTrainingTipsService) {
         
         self.tipModel = tipModel
         self.viewType = viewType
         self.viewedTrainingTipsService = viewedTrainingTipsService
             
-        super.init(baseModel: tipModel, renderedPageContext: renderedPageContext)
+        super.init(baseModel: tipModel, renderedPageContext: renderedPageContext, mobileContentAnalytics: mobileContentAnalytics)
         
         let trainingTipViewed: Bool = getTrainingTipViewed()
         


### PR DESCRIPTION
This PR consolidates tap gesture recognition for views in the renderer by moving tap gesture handling into base MobileContentView.swift.  If a model is ```Clickable``` then MobileContentViews will add a tap gesture recognizer to process tap events.

MobileContentAnalytics was also moved into the base MobileContentViewModel.  This required a lot of file changes since all of the renderer view models inherit this class.

The main classes that were changed are:
- MobileContentView.swift (consolidates tap gesture handling by checking if a model is clickable)
- MobileContentViewModel.swift (now references MobileContentAnalytics for tracking clickable analytics events)
- MobileContentAnimationView.swift (removes tap gesture handling since this logic has moved to base MobileContentView)
- MobileContentButtonView.swift (removes tap gesture handling since this logic has moved to base MobileContentView)
- MobileContentCardView.swift (removes tap gesture handling since this logic has moved to base MobileContentView)
- MobileContentImageView.swift (removes tap gesture handling since this logic has moved to base MobileContentView)
- MobileContentLinkView.swift (removes tap gesture handling since this logic has moved to base MobileContentView)