### PR TITLE
GT-1875 Fix strange scroll effect in iOS 16

### DIFF
--- a/godtools/App/Features/Dashboard/Presentation/Home/FavoritesContentView.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Home/FavoritesContentView.swift
@@ -43,6 +43,7 @@ struct FavoritesContentView: View {
                             .foregroundColor(ColorPalette.gtGrey.color)
                             .padding(.top, 12)
                             .padding(.bottom, 15)
+                            .padding(.leading, leadingTrailingPadding)
                         
                         FeaturedLessonCardsView(viewModel: viewModel.featuredLessonCardsViewModel, width: width, leadingPadding: leadingTrailingPadding)
                             .listRowInsets(EdgeInsets())

--- a/godtools/App/Share/SwiftUI Views/BackwardCompatibleList.swift
+++ b/godtools/App/Share/SwiftUI Views/BackwardCompatibleList.swift
@@ -24,7 +24,7 @@ struct BackwardCompatibleList<Content: View>: View {
             // Pull to refresh is supported only in iOS 15+
             
             ScrollView(.vertical) {
-                LazyVStack(spacing: 0) {
+                LazyVStack(alignment: .leading, spacing: 0) {
                     content()
                 }
             }
@@ -35,7 +35,7 @@ struct BackwardCompatibleList<Content: View>: View {
         } else {
             
             ScrollView(.vertical) {
-                LazyVStack(spacing: 0) {
+                LazyVStack(alignment: .leading, spacing: 0) {
                     content()
                 }
             }

--- a/godtools/App/Share/SwiftUI Views/BackwardCompatibleList.swift
+++ b/godtools/App/Share/SwiftUI Views/BackwardCompatibleList.swift
@@ -16,17 +16,6 @@ struct BackwardCompatibleList<Content: View>: View {
     init<T: View>(rootViewType: T.Type, @ViewBuilder content: @escaping () -> Content, refreshHandler: @escaping () -> Void) {
         self.content = content
         self.refreshHandler = refreshHandler
-        
-        /*
-         About removing the List separators:
-         - iOS 15 - use the `listRowSeparator` view modifier to hide the separators
-         - iOS 13 - list is built on UITableView, so `UITableView.appearance` works to set the separator style
-         - iOS 14 - `appearance` no longer works, and the modifier doesn't yet exist.  Solution is the AllToolsListIOS14 view.
-         */
-        if #available(iOS 14.0, *) {} else {
-            // TODO: - When we stop supporting iOS 13, get rid of this.
-            UITableView.appearance(whenContainedInInstancesOf: [UIHostingController<T>.self]).separatorStyle = .none
-        }
     }
     
     var body: some View {
@@ -34,32 +23,21 @@ struct BackwardCompatibleList<Content: View>: View {
         if #available(iOS 15.0, *) {
             // Pull to refresh is supported only in iOS 15+
             
-            List {
+            ScrollView(.vertical) {
                 content()
-                    .listRowSeparator(.hidden)
-                    
             }
-            .modifier(PlainList())
             .refreshable {
                 refreshHandler()
             }
             
-        } else if #available(iOS 14.0, *) {
+        } else {
             
-            ScrollView {
+            ScrollView(.vertical) {
                 LazyVStack(spacing: 0) {
                     content()
                 }
             }
-                                    
-        } else {
-            
-            List {
-                content()
-            }
-            .modifier(PlainList())
         }
-        
     }
 }
 

--- a/godtools/App/Share/SwiftUI Views/BackwardCompatibleList.swift
+++ b/godtools/App/Share/SwiftUI Views/BackwardCompatibleList.swift
@@ -24,7 +24,9 @@ struct BackwardCompatibleList<Content: View>: View {
             // Pull to refresh is supported only in iOS 15+
             
             ScrollView(.vertical) {
-                content()
+                LazyVStack(spacing: 0) {
+                    content()
+                }
             }
             .refreshable {
                 refreshHandler()


### PR DESCRIPTION
There was a strange scroll effect that was occurring in iOS 16 for favorites, tool spotlight, and tool categories. (https://jira.cru.org/browse/GT-1875)

Found a related issue posted to Stackoverflow here:  https://stackoverflow.com/questions/74042635/nested-scrollview-in-a-list-refreshable-strange-behaviour-in-ios-16

Seems to be fixed by using a ScrollView instead of a List.  It's nice to use a ScrollView here too since we don't have to worry about how the System might style the List element and since we have custom content going into the ScrollView.

Also removed some iOS 13 code in BackwardsCompatibleList.swift since we're now pointing to iOS 14.