### PR TITLE
GT-1894 Fix crash when writing to existing RealmGlobalAnalytics object

### DIFF
--- a/godtools/App/Share/Data/GlobalAnalyticsRepository/Cache/RealmGlobalAnalytics.swift
+++ b/godtools/App/Share/Data/GlobalAnalyticsRepository/Cache/RealmGlobalAnalytics.swift
@@ -22,4 +22,14 @@ class RealmGlobalAnalytics: Object {
     override static func primaryKey() -> String? {
         return "id"
     }
+    
+    func mapFrom(decodable: MobileContentGlobalAnalyticsDecodable) {
+        
+        countries = decodable.countries
+        createdAt = Date()
+        gospelPresentations = decodable.gospelPresentations
+        launches = decodable.launches
+        type = decodable.type
+        users = decodable.users
+    }
 }

--- a/godtools/App/Share/Data/GlobalAnalyticsRepository/Cache/RealmGlobalAnalyticsCache.swift
+++ b/godtools/App/Share/Data/GlobalAnalyticsRepository/Cache/RealmGlobalAnalyticsCache.swift
@@ -38,19 +38,27 @@ class RealmGlobalAnalyticsCache {
 
             self.realmDatabase.background { (realm: Realm) in
                 
-                let realmGlobalAnalytics: RealmGlobalAnalytics = realm.object(ofType: RealmGlobalAnalytics.self, forPrimaryKey: globalAnalytics.id) ?? RealmGlobalAnalytics()
+                let realmGlobalAnalytics: RealmGlobalAnalytics
                 
-                realmGlobalAnalytics.countries = globalAnalytics.countries
-                realmGlobalAnalytics.createdAt = Date()
-                realmGlobalAnalytics.id = globalAnalytics.id
-                realmGlobalAnalytics.gospelPresentations = globalAnalytics.gospelPresentations
-                realmGlobalAnalytics.launches = globalAnalytics.launches
-                realmGlobalAnalytics.type = globalAnalytics.type
-                realmGlobalAnalytics.users = globalAnalytics.users
-                                                                
+                if let existingRealmGlobalAnalytics = realm.object(ofType: RealmGlobalAnalytics.self, forPrimaryKey: globalAnalytics.id) {
+                   
+                    realmGlobalAnalytics = existingRealmGlobalAnalytics
+                }
+                else {
+                    
+                    let newRealmGlobalAnalytics = RealmGlobalAnalytics()
+                    
+                    newRealmGlobalAnalytics.id = globalAnalytics.id
+                    
+                    realmGlobalAnalytics = newRealmGlobalAnalytics
+                }
+                
                 do {
                     
                     try realm.write {
+                        
+                        realmGlobalAnalytics.mapFrom(decodable: globalAnalytics)
+                        
                         realm.add(realmGlobalAnalytics, update: .all)
                     }
                     


### PR DESCRIPTION
The existing RealmGlobalAnalytics object was getting mutated outside of a write transaction which would cause a crash.  Also, since id is a primaryKey it cannot be mutated from a write transaction and instead set when a new object is created.