### PR TITLE
GT Add method for fetching UIColor with RGB values

### DIFF
--- a/godtools/App/Share/ColorPalette.swift
+++ b/godtools/App/Share/ColorPalette.swift
@@ -31,6 +31,10 @@ enum ColorPalette: String {
         Color(.sRGB, red: red / 255, green: green / 255, blue: blue / 255, opacity: opacity)
     }
     
+    static func getUIColorWithRGB(red: CGFloat, green: CGFloat, blue: CGFloat, opacity: CGFloat) -> UIColor {        
+        return UIColor(ColorPalette.getColorWithRGB(red: red, green: green, blue: blue, opacity: opacity))
+    }
+    
     var uiColor: UIColor {
                 
         if let color = UIColor(named: colorName, in: Bundle.main, compatibleWith: nil) {


### PR DESCRIPTION
There is an existing helper method for fetching a ```Color``` with RGB values and thought it would be a good idea to have the same helper method for fetching a ```UIColor``` since we are still using UIKit in some places.