### PR TITLE
GT-1926 Update shared buttons to include SwiftUI Button element.

### DIFF
--- a/godtools/App/Share/SwiftUI Views/GTBlueButton.swift
+++ b/godtools/App/Share/SwiftUI Views/GTBlueButton.swift
@@ -27,16 +27,26 @@ struct GTBlueButton: View {
     }
     
     var body: some View {
-        Text(title)
-            .font(FontLibrary.sfProTextRegular.font(size: fontSize))
-            .foregroundColor(Color.white)
-            .padding()
-            .frame(width: width, height: height, alignment: .center)
-            .background(ColorPalette.gtBlue.color)
-            .cornerRadius(cornerRadius)
-            .onTapGesture {
-                action()
+        
+        Button(action: {
+            action()
+        }) {
+            
+            ZStack(alignment: .center) {
+                
+                Rectangle()
+                    .fill(.clear)
+                    .frame(width: width, height: height)
+                    .cornerRadius(cornerRadius)
+                
+                Text(title)
+                    .font(FontLibrary.sfProTextRegular.font(size: fontSize))
+                    .foregroundColor(Color.white)
             }
+        }
+        .frame(width: width, height: height, alignment: .center)
+        .background(ColorPalette.gtBlue.color)
+        .cornerRadius(cornerRadius)
     }
 }
 

--- a/godtools/App/Share/SwiftUI Views/GTBlueButton.swift
+++ b/godtools/App/Share/SwiftUI Views/GTBlueButton.swift
@@ -42,6 +42,7 @@ struct GTBlueButton: View {
                 Text(title)
                     .font(FontLibrary.sfProTextRegular.font(size: fontSize))
                     .foregroundColor(Color.white)
+                    .padding()
             }
         }
         .frame(width: width, height: height, alignment: .center)

--- a/godtools/App/Share/SwiftUI Views/GTWhiteButton.swift
+++ b/godtools/App/Share/SwiftUI Views/GTWhiteButton.swift
@@ -42,6 +42,7 @@ struct GTWhiteButton: View {
                 Text(title)
                     .font(FontLibrary.sfProTextRegular.font(size: fontSize))
                     .foregroundColor(ColorPalette.gtBlue.color)
+                    .padding()
             }
         }
         .frame(width: width, height: height, alignment: .center)

--- a/godtools/App/Share/SwiftUI Views/GTWhiteButton.swift
+++ b/godtools/App/Share/SwiftUI Views/GTWhiteButton.swift
@@ -27,21 +27,31 @@ struct GTWhiteButton: View {
     }
     
     var body: some View {
-        Text(title)
-            .font(FontLibrary.sfProTextRegular.font(size: fontSize))
-            .foregroundColor(ColorPalette.gtBlue.color)
-            .padding()
-            .frame(width: width, height: height, alignment: .center)
-            .background(Color.white)
-            .accentColor(ColorPalette.gtBlue.color)
-            .cornerRadius(cornerRadius)
-            .overlay(
-                RoundedRectangle(cornerRadius: cornerRadius)
-                    .stroke(ColorPalette.gtBlue.color, lineWidth: 1)
-            )
-            .onTapGesture {
-                action()
+        
+        Button(action: {
+            action()
+        }) {
+            
+            ZStack(alignment: .center) {
+                
+                Rectangle()
+                    .fill(.clear)
+                    .frame(width: width, height: height)
+                    .cornerRadius(cornerRadius)
+                
+                Text(title)
+                    .font(FontLibrary.sfProTextRegular.font(size: fontSize))
+                    .foregroundColor(ColorPalette.gtBlue.color)
             }
+        }
+        .frame(width: width, height: height, alignment: .center)
+        .background(Color.white)
+        .accentColor(ColorPalette.gtBlue.color)
+        .cornerRadius(cornerRadius)
+        .overlay(
+            RoundedRectangle(cornerRadius: cornerRadius)
+                .stroke(ColorPalette.gtBlue.color, lineWidth: 1)
+        )
     }
 }
 


### PR DESCRIPTION
This PR updates the shared Button views to include the SwiftUI Button element.  By doing so we get the system highlight when a button is tapped which will highlight the Text element.  Basically any elements within the Button content or highlighted and since the Rectangle is a clear color there will be no highlight effect on the Rectangle element.
- Added a Rectangle element within the Button content which is needed for the tap area of the button. 