### PR TITLE
GT-1919 Fix learn to share navigation to tool

### DIFF
--- a/godtools/App/Flows/App/AppFlow.swift
+++ b/godtools/App/Flows/App/AppFlow.swift
@@ -377,12 +377,14 @@ class AppFlow: NSObject, ToolNavigationFlow, Flow {
             navigateToLearnToShareTool(resource: resource)
             
         case .continueTappedFromLearnToShareTool(let resource):
-            navigateToTool(resourceId: resource.id, trainingTipsEnabled: true)
-            dismissLearnToShareToolFlow()
+            dismissLearnToShareToolFlow {
+                self.navigateToTool(resourceId: resource.id, trainingTipsEnabled: true)
+            }
             
         case .closeTappedFromLearnToShareTool(let resource):
-            navigateToTool(resourceId: resource.id, trainingTipsEnabled: true)
-            dismissLearnToShareToolFlow()
+            dismissLearnToShareToolFlow {
+                self.navigateToTool(resourceId: resource.id, trainingTipsEnabled: true)
+            }
             
         case .closeTappedFromLessonEvaluation:
             dismissLessonEvaluation()
@@ -882,13 +884,14 @@ extension AppFlow {
         }
     }
     
-    private func dismissLearnToShareToolFlow() {
+    private func dismissLearnToShareToolFlow(completion: (() -> Void)?) {
         
         guard learnToShareToolFlow != nil else {
+            completion?()
             return
         }
         
-        navigationController.dismissPresented(animated: true, completion: nil)
+        navigationController.dismissPresented(animated: true, completion: completion)
         learnToShareToolFlow = nil
     }
 }


### PR DESCRIPTION
The issue was when a tool needs to be downloaded it presents the download modal.  That was failing because the learn to share modal was presented.  The fix is to ensure that the learn to share modal is dismissed first, then present the download modal.