### PR TITLE
GT-1933 Lesson Titles Loading Slowly

### DIFF
--- a/godtools/App/Features/LanguageSettings/Domain/UseCases/GetSettingsPrimaryLanguageUseCase/GetSettingsPrimaryLanguageUseCase.swift
+++ b/godtools/App/Features/LanguageSettings/Domain/UseCases/GetSettingsPrimaryLanguageUseCase/GetSettingsPrimaryLanguageUseCase.swift
@@ -32,6 +32,7 @@ class GetSettingsPrimaryLanguageUseCase {
                 return Just(self.getPrimaryLanguage())
                     .eraseToAnyPublisher()
             })
+            .prepend(getPrimaryLanguage())
             .eraseToAnyPublisher()
     }
     

--- a/godtools/App/Features/LanguageSettings/Domain/UseCases/GetSettingsPrimaryLanguageUseCase/GetSettingsPrimaryLanguageUseCase.swift
+++ b/godtools/App/Features/LanguageSettings/Domain/UseCases/GetSettingsPrimaryLanguageUseCase/GetSettingsPrimaryLanguageUseCase.swift
@@ -26,12 +26,12 @@ class GetSettingsPrimaryLanguageUseCase {
     
     func getPrimaryLanguagePublisher() -> AnyPublisher<LanguageDomainModel?, Never> {
         
-        return Publishers.CombineLatest(languagesRepository.getLanguagesChanged(), languageSettingsRepository.getPrimaryLanguageChanged())
-            .flatMap({ (void: Void, primaryLanguageId: String?) -> AnyPublisher<LanguageDomainModel?, Never> in
+        return Publishers.Merge(languagesRepository.getLanguagesChanged(), languageSettingsRepository.getPrimaryLanguageChanged())
+            .flatMap { _ in
                 
                 return Just(self.getPrimaryLanguage())
                     .eraseToAnyPublisher()
-            })
+            }
             .prepend(getPrimaryLanguage())
             .eraseToAnyPublisher()
     }

--- a/godtools/App/Share/Data/LanguageSettingsRepository/Cache/LanguageSettingsCache.swift
+++ b/godtools/App/Share/Data/LanguageSettingsRepository/Cache/LanguageSettingsCache.swift
@@ -17,8 +17,12 @@ class LanguageSettingsCache {
         
     }
     
-    func getPrimaryLanguageChanged() -> AnyPublisher<String?, Never> {
+    func getPrimaryLanguageChanged() -> AnyPublisher<Void, Never> {
         return userDefaults.publisher(for: \.primaryLanguageId)
+            .flatMap { _ in
+                
+                return Empty()
+            }
             .eraseToAnyPublisher()
     }
     

--- a/godtools/App/Share/Data/LanguageSettingsRepository/Cache/LanguageSettingsCache.swift
+++ b/godtools/App/Share/Data/LanguageSettingsRepository/Cache/LanguageSettingsCache.swift
@@ -17,12 +17,8 @@ class LanguageSettingsCache {
         
     }
     
-    func getPrimaryLanguageChanged() -> AnyPublisher<Void, Never> {
+    func getPrimaryLanguageChanged() -> AnyPublisher<String?, Never> {
         return userDefaults.publisher(for: \.primaryLanguageId)
-            .flatMap { _ in
-                
-                return Empty()
-            }
             .eraseToAnyPublisher()
     }
     

--- a/godtools/App/Share/Data/LanguageSettingsRepository/LanguageSettingsRepository.swift
+++ b/godtools/App/Share/Data/LanguageSettingsRepository/LanguageSettingsRepository.swift
@@ -20,6 +20,11 @@ class LanguageSettingsRepository {
     
     func getPrimaryLanguageChanged() -> AnyPublisher<Void, Never> {
         return cache.getPrimaryLanguageChanged()
+            .flatMap { _ in
+                
+                return Empty()
+            }
+            .eraseToAnyPublisher()
     }
     
     func getParallelLanguageChanged() -> AnyPublisher<String?, Never> {

--- a/godtools/App/Share/Data/LanguageSettingsRepository/LanguageSettingsRepository.swift
+++ b/godtools/App/Share/Data/LanguageSettingsRepository/LanguageSettingsRepository.swift
@@ -18,7 +18,7 @@ class LanguageSettingsRepository {
         self.cache = cache
     }
     
-    func getPrimaryLanguageChanged() -> AnyPublisher<String?, Never> {
+    func getPrimaryLanguageChanged() -> AnyPublisher<Void, Never> {
         return cache.getPrimaryLanguageChanged()
     }
     


### PR DESCRIPTION
In `GetSettingsPrimaryLanguageUseCase`, the `getPrimaryLanguagePublisher()` wasn't firing immediately, which was causing a noticeable lag in generating the lesson titles.  By adding `.prepend(getPrimaryLanguage())` to the publisher, it will immediately fire with the current primary language value while we wait for any further values to come through.

The other thing I learned is that `CombineLatest(_, _)` doesn't actually fire until _both_ publishers being combined have a value:
```
The combined publisher doesn’t produce elements until each of its upstream publishers publishes at least one element.
```
https://developer.apple.com/documentation/combine/publishers/sequence/combinelatest(_:)
In this case, we don't care if both publishers have a value a simultaneously, we just want to be notified when either changes independently.

On the other hand, `merge` fires immediately whenever there's a new value, which I think is what we want here. https://developer.apple.com/documentation/combine/publisher/merge(with:)-7qt71
(Merge has to have the same return type because it's just firing with a value from one publisher, not the tuple)

