### PR TITLE
GT-1931 Fix ToolSettings language flip

### DIFF
--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/Pages/MobileContentPagesView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/Pages/MobileContentPagesView.swift
@@ -109,7 +109,7 @@ class MobileContentPagesView: UIViewController {
             cellReuseIdentifier: MobileContentPageCell.reuseIdentifier
         )
         pageNavigationView.setContentInset(contentInset: .zero)
-        pageNavigationView.setSemanticContentAttribute(semanticContentAttribute: viewModel.pageNavigationSemanticContentAttribute)
+        pageNavigationView.setSemanticContentAttribute(semanticContentAttribute: viewModel.pageNavigationSemanticContentAttribute.value)
         
         if #available(iOS 11.0, *) {
             pageNavigationView.setContentInsetAdjustmentBehavior(contentInsetAdjustmentBehavior: .never)
@@ -128,6 +128,28 @@ class MobileContentPagesView: UIViewController {
             
             pagesView.initialPagePositions.removeAll()
             pagesView.initialPagePositions = pagesView.getAllVisiblePagesPositions()
+        }
+        
+        viewModel.pageNavigationSemanticContentAttribute.addObserver(self) { [weak self] (pageNavigationSemanticContentAttribute: UISemanticContentAttribute) in
+            
+            guard let weakSelf = self else {
+                return
+            }
+            
+            let currentPageNavigationSemanticContentAttribute: UISemanticContentAttribute = weakSelf.pageNavigationView.getSemanticContentAttribute()
+            let currentPage: Int = weakSelf.pageNavigationView.currentPage
+            let numberOfPages: Int = weakSelf.pageNavigationView.numberOfPages
+            
+            guard currentPageNavigationSemanticContentAttribute != pageNavigationSemanticContentAttribute else {
+                return
+            }
+            
+            guard numberOfPages > 0 else {
+                return
+            }
+            
+            weakSelf.pageNavigationView.setSemanticContentAttribute(semanticContentAttribute: pageNavigationSemanticContentAttribute)
+            weakSelf.pageNavigationView.scrollToPage(page: currentPage, animated: false)
         }
     }
     

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/Pages/MobileContentPagesViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/Pages/MobileContentPagesViewModel.swift
@@ -32,7 +32,7 @@ class MobileContentPagesViewModel: NSObject {
     private(set) weak var window: UIViewController?
     
     let numberOfPages: ObservableValue<Int> = ObservableValue(value: 0)
-    let pageNavigationSemanticContentAttribute: UISemanticContentAttribute
+    let pageNavigationSemanticContentAttribute: ObservableValue<UISemanticContentAttribute>
     let rendererWillChangeSignal: Signal = Signal()
     let pageNavigation: ObservableValue<MobileContentPagesNavigationModel?> = ObservableValue(value: nil)
     let pagesRemoved: ObservableValue<[IndexPath]> = ObservableValue(value: [])
@@ -50,7 +50,7 @@ class MobileContentPagesViewModel: NSObject {
         self.trainingTipsEnabled = trainingTipsEnabled
         self.incrementUserCounterUseCase = incrementUserCounterUseCase
         
-        pageNavigationSemanticContentAttribute = UISemanticContentAttribute.from(languageDirection: renderer.primaryLanguage.direction)
+        pageNavigationSemanticContentAttribute = ObservableValue(value: UISemanticContentAttribute.from(languageDirection: renderer.primaryLanguage.direction))
         
         super.init()
         
@@ -310,6 +310,8 @@ class MobileContentPagesViewModel: NSObject {
         
         self.renderer.send(renderer)
         
+        pageNavigationSemanticContentAttribute.accept(value: UISemanticContentAttribute.from(languageDirection: renderer.primaryLanguage.direction))
+        
         setPageRenderer(pageRenderer: pageRenderer)
     }
     
@@ -344,7 +346,6 @@ class MobileContentPagesViewModel: NSObject {
             
             pageModelsToRender = pageRenderer.getVisibleRenderablePageModels()
         }
-        
         
         rendererWillChangeSignal.accept()
         

--- a/godtools/App/Share/Views/PageNavigationCollectionView/PageNavigationCollectionView.swift
+++ b/godtools/App/Share/Views/PageNavigationCollectionView/PageNavigationCollectionView.swift
@@ -273,6 +273,10 @@ class PageNavigationCollectionView: UIView, NibBased {
         return collectionView.visibleCells
     }
     
+    func getSemanticContentAttribute() -> UISemanticContentAttribute {
+        return collectionView.semanticContentAttribute
+    }
+    
     private func didEndPageScrolling() {
         
         let currentPage: Int = self.currentPage


### PR DESCRIPTION
This PR fixes page navigation in tract rendering when changing the primary language from a left to right or right to left language.  Navigation direction should match the primary language direction (left to right, right to left).

This was fixed by making ```pageNavigationSemanticContentAttribute``` an ```ObservableValue``` on the ViewModel ``` and when this value changes the View will set the semantic content attribute on the UICollectionView.


![tool-settings](https://user-images.githubusercontent.com/59846460/220128657-a3c1799c-8080-4439-854f-88cd0bcf9f50.png)
