### PR TITLE
GT-1942 Fix knowgod.com share link

### DIFF
--- a/godtools/App/Features/ToolSettings/ShareTool/ShareToolViewModel.swift
+++ b/godtools/App/Features/ToolSettings/ShareTool/ShareToolViewModel.swift
@@ -31,7 +31,7 @@ class ShareToolViewModel: ShareToolViewModelType {
         self.analytics = analytics
         self.pageNumber = pageNumber
         
-        var shareUrlString: String = "https://www.knowgod.com/\(language.localeIdentifier)/\(resource.abbreviation)"
+        var shareUrlString: String = "https://knowgod.com/\(language.localeIdentifier)/\(resource.abbreviation)"
 
         if pageNumber > 0 {
             shareUrlString = shareUrlString.appending("/").appending("\(pageNumber)")


### PR DESCRIPTION
Needed to remove ```www.``` from ```https://knowgod.com``` since we don't support ```https://www.knowgod.com``` in Universal links.