### PR TITLE
GT-1933 Fix settings primary language changed observing

### DIFF
--- a/godtools/App/Share/Data/LanguageSettingsRepository/LanguageSettingsRepository.swift
+++ b/godtools/App/Share/Data/LanguageSettingsRepository/LanguageSettingsRepository.swift
@@ -20,9 +20,8 @@ class LanguageSettingsRepository {
     
     func getPrimaryLanguageChanged() -> AnyPublisher<Void, Never> {
         return cache.getPrimaryLanguageChanged()
-            .flatMap { _ in
-                
-                return Empty()
+            .map { _ in
+                return ()
             }
             .eraseToAnyPublisher()
     }


### PR DESCRIPTION
Hey @rachaelblue I noticed after merging ```GT-1933``` which fixed the language title observing that when I chose a new primary language from the languages list, the primary language button title wouldn't update on the prior screen.

This screen here wouldn't update after choosing Arabic:
![primary-language-button-title](https://user-images.githubusercontent.com/59846460/220443368-8822027f-d5bc-4f62-85bf-c4adce410a40.png)

I didn't realize, but ```Empty()``` will cause a publisher to finish immediately.  So what happened was the first time that button was set the publisher finished and no longer received changes.
https://developer.apple.com/documentation/combine/empty

It also appears that using ```Empty(completeImmediately: false)``` still wouldn't send changes.  

```Empty()``` seems a bit misleading in the naming as you would expect an empty response. 

Instead changed to use ```map``` to return ```Void```.  Could have also used ```flatMap``` and returned ```Just(()).eraseToAnyPublisher()```.


