### PR TITLE
GT-Change release entitlements file from godtoolsRelease to godtools

### DIFF
--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -9652,7 +9652,7 @@
 			baseConfigurationReference = 3795EC9D424F0613AD8AF610 /* Pods-godtools.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_ENTITLEMENTS = godtools/godtoolsRelease.entitlements;
+				CODE_SIGN_ENTITLEMENTS = godtools/godtools.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;


### PR DESCRIPTION
I think ```godtoolsRelease.entitlements``` was auto generated when adding universal links for Firebase.  Removed and set back to ```godtools.entitlements```.