### PR TITLE
GT-1945 Realm User Counter crash

### DIFF
--- a/godtools/App/Share/Data/UserCountersRepository/Cache/RealmUserCountersCache.swift
+++ b/godtools/App/Share/Data/UserCountersRepository/Cache/RealmUserCountersCache.swift
@@ -51,32 +51,15 @@ class RealmUserCountersCache {
     func incrementUserCounterBy1(id: String) -> AnyPublisher<UserCounterDataModel, Error> {
         
         return userCountersSync.incrementUserCounterBy1(id: id)
-            .flatMap { realmUserCounter in
-                
-                return Just(UserCounterDataModel(realmUserCounter: realmUserCounter))
-            }
-            .eraseToAnyPublisher()
     }
     
     func syncUserCounter(_ userCounter: UserCounterDecodable, incrementValueBeforeRemoteUpdate: Int) -> AnyPublisher<UserCounterDataModel, Error> {
         
         return userCountersSync.syncUserCounter(userCounter, incrementValueBeforeRemoteUpdate: incrementValueBeforeRemoteUpdate)
-            .flatMap { realmUserCounter in
-                
-                return Just(UserCounterDataModel(realmUserCounter: realmUserCounter))
-            }
-            .eraseToAnyPublisher()
     }
     
     func syncUserCounters(_ userCounters: [UserCounterDecodable]) -> AnyPublisher<[UserCounterDataModel], Error> {
         
         return userCountersSync.syncUserCounters(userCounters)
-            .flatMap { realmUserCounters in
-                
-                let userCounterDataModels = realmUserCounters.map{ UserCounterDataModel(realmUserCounter: $0) }
-                
-                return Just(userCounterDataModels)
-            }
-            .eraseToAnyPublisher()
     }
 }

--- a/godtools/App/Share/Data/UserCountersRepository/Cache/Sync/RealmUserCountersSync.swift
+++ b/godtools/App/Share/Data/UserCountersRepository/Cache/Sync/RealmUserCountersSync.swift
@@ -18,7 +18,7 @@ class RealmUserCountersCacheSync {
         self.realmDatabase = realmDatabase
     }
     
-    func incrementUserCounterBy1(id: String) -> AnyPublisher<RealmUserCounter, Error> {
+    func incrementUserCounterBy1(id: String) -> AnyPublisher<UserCounterDataModel, Error> {
         
         return Future() { promise in
             
@@ -43,7 +43,7 @@ class RealmUserCountersCacheSync {
                         realm.add(newUserCounter, update: .all)
                     }
                     
-                    promise(.success(newUserCounter))
+                    promise(.success(UserCounterDataModel(realmUserCounter: newUserCounter)))
                     
                 } catch let error {
                     
@@ -54,7 +54,7 @@ class RealmUserCountersCacheSync {
         .eraseToAnyPublisher()
     }
     
-    func syncUserCounter(_ userCounter: UserCounterDecodable, incrementValueBeforeRemoteUpdate: Int) -> AnyPublisher<RealmUserCounter, Error> {
+    func syncUserCounter(_ userCounter: UserCounterDecodable, incrementValueBeforeRemoteUpdate: Int) -> AnyPublisher<UserCounterDataModel, Error> {
         
         return Future() { promise in
             
@@ -75,7 +75,7 @@ class RealmUserCountersCacheSync {
                         realm.add(newUserCounter, update: .all)
                     }
                     
-                    promise(.success(newUserCounter))
+                    promise(.success(UserCounterDataModel(realmUserCounter: newUserCounter)))
                     
                 } catch let error {
                     
@@ -86,7 +86,7 @@ class RealmUserCountersCacheSync {
         .eraseToAnyPublisher()
     }
     
-    func syncUserCounters(_ userCounters: [UserCounterDecodable]) -> AnyPublisher<[RealmUserCounter], Error> {
+    func syncUserCounters(_ userCounters: [UserCounterDecodable]) -> AnyPublisher<[UserCounterDataModel], Error> {
         
         return Future() { promise in
             
@@ -111,7 +111,9 @@ class RealmUserCountersCacheSync {
                         realm.add(newUserCounters, update: .all)
                     }
                     
-                    promise(.success(newUserCounters))
+                    let userCounterDataModels = newUserCounters.map { UserCounterDataModel(realmUserCounter: $0) }
+                    
+                    promise(.success(userCounterDataModels))
                     
                 } catch let error {
                     


### PR DESCRIPTION
Hey @levieggertcru, I was never able to reproduce this crash, but I went ahead and made the sync class return all dataModels so we don't risk having realm objects potentially being accessed from different threads.