### PR TITLE
GT-1951 Fix deeplink to cyoa

### DIFF
--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -730,6 +730,8 @@
 		45D2073D28D5107900F38DD7 /* UILabel+Underline.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D2073C28D5107900F38DD7 /* UILabel+Underline.swift */; };
 		45D266E9277499AD00960990 /* UIViewController+DismissPresented.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D266E8277499AD00960990 /* UIViewController+DismissPresented.swift */; };
 		45D3AAE1298AA69F0017E6DF /* VideoViewPlayerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D3AAE0298AA69F0017E6DF /* VideoViewPlayerState.swift */; };
+		45D4A6CD29B126BB00DED984 /* MobileContentPagesPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D4A6CC29B126BB00DED984 /* MobileContentPagesPage.swift */; };
+		45D4A6CF29B12AE200DED984 /* ToolDeepLinkPage+MobileContentPagesPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D4A6CE29B12AE200DED984 /* ToolDeepLinkPage+MobileContentPagesPage.swift */; };
 		45D5433628B4001400C4E70F /* GetResourcesAttachments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D5433328B4001400C4E70F /* GetResourcesAttachments.swift */; };
 		45D5433728B4001400C4E70F /* GetResourcesAndLanguagesData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D5433428B4001400C4E70F /* GetResourcesAndLanguagesData.swift */; };
 		45D63E52288F67CE009B4610 /* AppDomainLayerDependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D63E50288F67CD009B4610 /* AppDomainLayerDependencies.swift */; };
@@ -1794,6 +1796,8 @@
 		45D2073C28D5107900F38DD7 /* UILabel+Underline.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+Underline.swift"; sourceTree = "<group>"; };
 		45D266E8277499AD00960990 /* UIViewController+DismissPresented.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIViewController+DismissPresented.swift"; sourceTree = "<group>"; };
 		45D3AAE0298AA69F0017E6DF /* VideoViewPlayerState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoViewPlayerState.swift; sourceTree = "<group>"; };
+		45D4A6CC29B126BB00DED984 /* MobileContentPagesPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileContentPagesPage.swift; sourceTree = "<group>"; };
+		45D4A6CE29B12AE200DED984 /* ToolDeepLinkPage+MobileContentPagesPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ToolDeepLinkPage+MobileContentPagesPage.swift"; sourceTree = "<group>"; };
 		45D5433328B4001400C4E70F /* GetResourcesAttachments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GetResourcesAttachments.swift; sourceTree = "<group>"; };
 		45D5433428B4001400C4E70F /* GetResourcesAndLanguagesData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GetResourcesAndLanguagesData.swift; sourceTree = "<group>"; };
 		45D5433528B4001400C4E70F /* DownloadInitialResourcesScript.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DownloadInitialResourcesScript.swift; sourceTree = "<group>"; };
@@ -3446,6 +3450,7 @@
 			children = (
 				45BF2B9D27A9573F00D23EDA /* MobileContentPagesInitialPageRenderingType.swift */,
 				455583B4269F2DA500C3FF14 /* MobileContentPagesNavigationModel.swift */,
+				45D4A6CC29B126BB00DED984 /* MobileContentPagesPage.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -4569,6 +4574,7 @@
 			children = (
 				459E86D728EDA86C00E197A5 /* ParsedDeepLinkType.swift */,
 				459E86D828EDA86C00E197A5 /* ToolDeepLink.swift */,
+				45D4A6CE29B12AE200DED984 /* ToolDeepLinkPage+MobileContentPagesPage.swift */,
 			);
 			path = ParsedDeepLink;
 			sourceTree = "<group>";
@@ -7946,6 +7952,7 @@
 				4554512528948D220072EC6E /* LanguageSettingsRepository.swift in Sources */,
 				45860A562923E7B30089C836 /* FixedHorizontalSpacer.swift in Sources */,
 				45F71648290A12D70019B715 /* MenuSectionHeaderViewModel.swift in Sources */,
+				45D4A6CF29B12AE200DED984 /* ToolDeepLinkPage+MobileContentPagesPage.swift in Sources */,
 				D1DD79FF26690CBA000F1351 /* TrackActionModel.swift in Sources */,
 				45828BD3279CCBD200F6B5F3 /* MobileContentFlowViewModel.swift in Sources */,
 				45325F29285CF8B40078D932 /* TextViewLinksCoordinator.swift in Sources */,
@@ -8440,6 +8447,7 @@
 				45AD1BE425938A4F00A096A0 /* CustomViewBuilderType.swift in Sources */,
 				4573133F28C1821100481640 /* ToolDetailsVersionsCardView.swift in Sources */,
 				455583D2269F2DA500C3FF14 /* MobileContentFormViewModel.swift in Sources */,
+				45D4A6CD29B126BB00DED984 /* MobileContentPagesPage.swift in Sources */,
 				45677783287DB21F0044AEB2 /* ToolTrainingAnimatedTransitioning.swift in Sources */,
 				456FBE0527A48D2D0033FBCB /* HorizontallyCenteredCollectionViewCell.swift in Sources */,
 				45AD20BB25938F1A00A096A0 /* ObservableValue.swift in Sources */,

--- a/godtools/App/Features/ChooseYourOwnAdventure/ChooseYourOwnAdventureViewModel.swift
+++ b/godtools/App/Features/ChooseYourOwnAdventure/ChooseYourOwnAdventureViewModel.swift
@@ -21,7 +21,7 @@ class ChooseYourOwnAdventureViewModel: MobileContentPagesViewModel {
     let navBarColors: ObservableValue<ChooseYourOwnAdventureNavBarModel>
     let navBarTitleType: ChooseYourOwnAdventureNavBarTitleType
     
-    init(flowDelegate: FlowDelegate, renderer: MobileContentRenderer, page: Int?, resourcesRepository: ResourcesRepository, translationsRepository: TranslationsRepository, mobileContentEventAnalytics: MobileContentEventAnalyticsTracking, fontService: FontService, trainingTipsEnabled: Bool, incrementUserCounterUseCase: IncrementUserCounterUseCase) {
+    init(flowDelegate: FlowDelegate, renderer: MobileContentRenderer, initialPage: MobileContentPagesPage?, resourcesRepository: ResourcesRepository, translationsRepository: TranslationsRepository, mobileContentEventAnalytics: MobileContentEventAnalyticsTracking, fontService: FontService, trainingTipsEnabled: Bool, incrementUserCounterUseCase: IncrementUserCounterUseCase) {
         
         self.flowDelegate = flowDelegate
         self.fontService = fontService
@@ -54,7 +54,7 @@ class ChooseYourOwnAdventureViewModel: MobileContentPagesViewModel {
             navBarTitleType = .title(title: "GodTools")
         }
         
-        super.init(renderer: renderer, page: page, resourcesRepository: resourcesRepository, translationsRepository: translationsRepository, mobileContentEventAnalytics: mobileContentEventAnalytics, initialPageRenderingType: .chooseYourOwnAdventure, trainingTipsEnabled: trainingTipsEnabled, incrementUserCounterUseCase: incrementUserCounterUseCase)
+        super.init(renderer: renderer, initialPage: initialPage, resourcesRepository: resourcesRepository, translationsRepository: translationsRepository, mobileContentEventAnalytics: mobileContentEventAnalytics, initialPageRenderingType: .chooseYourOwnAdventure, trainingTipsEnabled: trainingTipsEnabled, incrementUserCounterUseCase: incrementUserCounterUseCase)
     }
     
     override func pageDidAppear(page: Int) {

--- a/godtools/App/Features/ChooseYourOwnAdventure/ChooseYourOwnAdventureViewModel.swift
+++ b/godtools/App/Features/ChooseYourOwnAdventure/ChooseYourOwnAdventureViewModel.swift
@@ -89,7 +89,7 @@ extension ChooseYourOwnAdventureViewModel {
     
     func navBackTapped() {
         
-        let isFirstPage: Bool = currentPage == 0
+        let isFirstPage: Bool = currentRenderedPageNumber == 0
         
         if isFirstPage {
             flowDelegate?.navigate(step: FlowStep.backTappedFromChooseYourOwnAdventure)

--- a/godtools/App/Features/Lesson/Lesson/LessonViewModel.swift
+++ b/godtools/App/Features/Lesson/Lesson/LessonViewModel.swift
@@ -16,11 +16,11 @@ class LessonViewModel: MobileContentPagesViewModel {
     
     let progress: ObservableValue<AnimatableValue<CGFloat>> = ObservableValue(value: AnimatableValue(value: 0, animated: false))
     
-    init(flowDelegate: FlowDelegate, renderer: MobileContentRenderer, resource: ResourceModel, primaryLanguage: LanguageDomainModel, page: Int?, resourcesRepository: ResourcesRepository, translationsRepository: TranslationsRepository, mobileContentEventAnalytics: MobileContentEventAnalyticsTracking, trainingTipsEnabled: Bool, incrementUserCounterUseCase: IncrementUserCounterUseCase) {
+    init(flowDelegate: FlowDelegate, renderer: MobileContentRenderer, resource: ResourceModel, primaryLanguage: LanguageDomainModel, initialPage: MobileContentPagesPage?, resourcesRepository: ResourcesRepository, translationsRepository: TranslationsRepository, mobileContentEventAnalytics: MobileContentEventAnalyticsTracking, trainingTipsEnabled: Bool, incrementUserCounterUseCase: IncrementUserCounterUseCase) {
                 
         self.flowDelegate = flowDelegate
         
-        super.init(renderer: renderer, page: page, resourcesRepository: resourcesRepository, translationsRepository: translationsRepository, mobileContentEventAnalytics: mobileContentEventAnalytics, initialPageRenderingType: .visiblePages, trainingTipsEnabled: trainingTipsEnabled, incrementUserCounterUseCase: incrementUserCounterUseCase)
+        super.init(renderer: renderer,initialPage: initialPage, resourcesRepository: resourcesRepository, translationsRepository: translationsRepository, mobileContentEventAnalytics: mobileContentEventAnalytics, initialPageRenderingType: .visiblePages, trainingTipsEnabled: trainingTipsEnabled, incrementUserCounterUseCase: incrementUserCounterUseCase)
     }
 
     override func handleDismissToolEvent() {

--- a/godtools/App/Features/Tool/ToolViewModel.swift
+++ b/godtools/App/Features/Tool/ToolViewModel.swift
@@ -28,7 +28,7 @@ class ToolViewModel: MobileContentPagesViewModel {
     let navBarViewModel: ObservableValue<ToolNavBarViewModel>
     let didSubscribeForRemoteSharePublishing: ObservableValue<Bool> = ObservableValue(value: false)
         
-    init(flowDelegate: FlowDelegate, backButtonImageType: ToolBackButtonImageType, renderer: MobileContentRenderer, tractRemoteSharePublisher: TractRemoteSharePublisher, tractRemoteShareSubscriber: TractRemoteShareSubscriber, localizationServices: LocalizationServices, fontService: FontService, resourceViewsService: ResourceViewsService, analytics: AnalyticsContainer, resourcesRepository: ResourcesRepository, translationsRepository: TranslationsRepository, mobileContentEventAnalytics: MobileContentEventAnalyticsTracking, toolOpenedAnalytics: ToolOpenedAnalytics, liveShareStream: String?, page: Int?, trainingTipsEnabled: Bool, incrementUserCounterUseCase: IncrementUserCounterUseCase) {
+    init(flowDelegate: FlowDelegate, backButtonImageType: ToolBackButtonImageType, renderer: MobileContentRenderer, tractRemoteSharePublisher: TractRemoteSharePublisher, tractRemoteShareSubscriber: TractRemoteShareSubscriber, localizationServices: LocalizationServices, fontService: FontService, resourceViewsService: ResourceViewsService, analytics: AnalyticsContainer, resourcesRepository: ResourcesRepository, translationsRepository: TranslationsRepository, mobileContentEventAnalytics: MobileContentEventAnalyticsTracking, toolOpenedAnalytics: ToolOpenedAnalytics, liveShareStream: String?, initialPage: MobileContentPagesPage?, trainingTipsEnabled: Bool, incrementUserCounterUseCase: IncrementUserCounterUseCase) {
         
         self.flowDelegate = flowDelegate
         self.backButtonImageType = backButtonImageType
@@ -45,7 +45,7 @@ class ToolViewModel: MobileContentPagesViewModel {
         
         self.navBarViewModel = ObservableValue(value: navBarViewModelValue)
         
-        super.init(renderer: renderer, page: page, resourcesRepository: resourcesRepository, translationsRepository: translationsRepository, mobileContentEventAnalytics: mobileContentEventAnalytics, initialPageRenderingType: .visiblePages, trainingTipsEnabled: trainingTipsEnabled, incrementUserCounterUseCase: incrementUserCounterUseCase)
+        super.init(renderer: renderer, initialPage: initialPage, resourcesRepository: resourcesRepository, translationsRepository: translationsRepository, mobileContentEventAnalytics: mobileContentEventAnalytics, initialPageRenderingType: .visiblePages, trainingTipsEnabled: trainingTipsEnabled, incrementUserCounterUseCase: incrementUserCounterUseCase)
         
         setupBinding()
     }

--- a/godtools/App/Flows/ChooseYourOwnAdventure/ChooseYourOwnAdventureFlow.swift
+++ b/godtools/App/Flows/ChooseYourOwnAdventure/ChooseYourOwnAdventureFlow.swift
@@ -22,7 +22,7 @@ class ChooseYourOwnAdventureFlow: ToolNavigationFlow {
     var tractFlow: TractFlow?
     var downloadToolTranslationFlow: DownloadToolTranslationsFlow?
     
-    required init(flowDelegate: FlowDelegate, appDiContainer: AppDiContainer, sharedNavigationController: UINavigationController, toolTranslations: ToolTranslationsDomainModel) {
+    required init(flowDelegate: FlowDelegate, appDiContainer: AppDiContainer, sharedNavigationController: UINavigationController, toolTranslations: ToolTranslationsDomainModel, initialPage: MobileContentPagesPage?) {
         
         self.flowDelegate = flowDelegate
         self.appDiContainer = appDiContainer
@@ -42,7 +42,7 @@ class ChooseYourOwnAdventureFlow: ToolNavigationFlow {
         let viewModel = ChooseYourOwnAdventureViewModel(
             flowDelegate: self,
             renderer: renderer,
-            page: nil,
+            initialPage: initialPage,
             resourcesRepository: appDiContainer.dataLayer.getResourcesRepository(),
             translationsRepository: appDiContainer.dataLayer.getTranslationsRepository(),
             mobileContentEventAnalytics: appDiContainer.getMobileContentEventAnalyticsTracking(),

--- a/godtools/App/Flows/Lesson/LessonFlow.swift
+++ b/godtools/App/Flows/Lesson/LessonFlow.swift
@@ -22,7 +22,7 @@ class LessonFlow: ToolNavigationFlow, Flow {
     var tractFlow: TractFlow?
     var downloadToolTranslationFlow: DownloadToolTranslationsFlow?
     
-    required init(flowDelegate: FlowDelegate, appDiContainer: AppDiContainer, sharedNavigationController: UINavigationController, toolTranslations: ToolTranslationsDomainModel, trainingTipsEnabled: Bool, page: Int?) {
+    required init(flowDelegate: FlowDelegate, appDiContainer: AppDiContainer, sharedNavigationController: UINavigationController, toolTranslations: ToolTranslationsDomainModel, trainingTipsEnabled: Bool, initialPage: MobileContentPagesPage?) {
         
         self.flowDelegate = flowDelegate
         self.appDiContainer = appDiContainer
@@ -44,7 +44,7 @@ class LessonFlow: ToolNavigationFlow, Flow {
             renderer: renderer,
             resource: renderer.resource,
             primaryLanguage: renderer.primaryLanguage,
-            page: page,
+            initialPage: initialPage,
             resourcesRepository: appDiContainer.dataLayer.getResourcesRepository(),
             translationsRepository: appDiContainer.dataLayer.getTranslationsRepository(),
             mobileContentEventAnalytics: appDiContainer.getMobileContentEventAnalyticsTracking(),

--- a/godtools/App/Flows/ToolNavigation/ToolNavigationFlow.swift
+++ b/godtools/App/Flows/ToolNavigation/ToolNavigationFlow.swift
@@ -34,7 +34,7 @@ extension ToolNavigationFlow {
             determineToolTranslationsToDownload: determineDeepLinkedToolTranslationsToDownload,
             liveShareStream: toolDeepLink.liveShareStream,
             trainingTipsEnabled: false,
-            page: toolDeepLink.page
+            initialPage: toolDeepLink.mobileContentPage
         )
     }
     
@@ -55,11 +55,11 @@ extension ToolNavigationFlow {
             languageIds: languageIds,
             liveShareStream: nil,
             trainingTipsEnabled: trainingTipsEnabled,
-            page: nil
+            initialPage: nil
         )
     }
     
-    func navigateToTool(resourceId: String, languageIds: [String], liveShareStream: String?, trainingTipsEnabled: Bool, page: Int?) {
+    func navigateToTool(resourceId: String, languageIds: [String], liveShareStream: String?, trainingTipsEnabled: Bool, initialPage: MobileContentPagesPage?) {
         
         let determineToolTranslationsToDownload = DetermineToolTranslationsToDownload(
             resourceId: resourceId,
@@ -72,11 +72,11 @@ extension ToolNavigationFlow {
             determineToolTranslationsToDownload: determineToolTranslationsToDownload,
             liveShareStream: liveShareStream,
             trainingTipsEnabled: trainingTipsEnabled,
-            page: page
+            initialPage: initialPage
         )
     }
     
-    private func navigateToToolAndDetermineToolTranslationsToDownload(determineToolTranslationsToDownload: DetermineToolTranslationsToDownloadType, liveShareStream: String?, trainingTipsEnabled: Bool, page: Int?) {
+    private func navigateToToolAndDetermineToolTranslationsToDownload(determineToolTranslationsToDownload: DetermineToolTranslationsToDownloadType, liveShareStream: String?, trainingTipsEnabled: Bool, initialPage: MobileContentPagesPage?) {
         
         let didDownloadToolTranslationsClosure = { [weak self] (result: Result<ToolTranslationsDomainModel, URLResponseError>) in
                         
@@ -88,7 +88,7 @@ extension ToolNavigationFlow {
                     toolTranslations: toolTranslations,
                     liveShareStream: liveShareStream,
                     trainingTipsEnabled: trainingTipsEnabled,
-                    page: page
+                    initialPage: initialPage
                 )
                 
             case .failure(let responseError):
@@ -108,7 +108,7 @@ extension ToolNavigationFlow {
         self.downloadToolTranslationFlow = downloadToolTranslationFlow
     }
     
-    private func navigateToTool(toolTranslations: ToolTranslationsDomainModel, liveShareStream: String?, trainingTipsEnabled: Bool, page: Int?) {
+    private func navigateToTool(toolTranslations: ToolTranslationsDomainModel, liveShareStream: String?, trainingTipsEnabled: Bool, initialPage: MobileContentPagesPage?) {
         
         let resourceType: ResourceType = toolTranslations.tool.resourceTypeEnum
         
@@ -131,7 +131,7 @@ extension ToolNavigationFlow {
                 sharedNavigationController: navigationController,
                 toolTranslations: toolTranslations,
                 trainingTipsEnabled: trainingTipsEnabled,
-                page: page
+                initialPage: initialPage
             )
             
         case .tract:
@@ -143,7 +143,7 @@ extension ToolNavigationFlow {
                 toolTranslations: toolTranslations,
                 liveShareStream: liveShareStream,
                 trainingTipsEnabled: trainingTipsEnabled,
-                page: page
+                initialPage: initialPage
             )
             
         case .chooseYourOwnAdventure:
@@ -152,7 +152,8 @@ extension ToolNavigationFlow {
                 flowDelegate: self,
                 appDiContainer: appDiContainer,
                 sharedNavigationController: navigationController,
-                toolTranslations: toolTranslations
+                toolTranslations: toolTranslations,
+                initialPage: initialPage
             )
             
         case .metaTool:

--- a/godtools/App/Flows/Tract/TractFlow.swift
+++ b/godtools/App/Flows/Tract/TractFlow.swift
@@ -24,7 +24,7 @@ class TractFlow: ToolNavigationFlow, Flow {
     var tractFlow: TractFlow?
     var downloadToolTranslationFlow: DownloadToolTranslationsFlow?
     
-    required init(flowDelegate: FlowDelegate, appDiContainer: AppDiContainer, sharedNavigationController: UINavigationController?, toolTranslations: ToolTranslationsDomainModel, liveShareStream: String?, trainingTipsEnabled: Bool, page: Int?) {
+    required init(flowDelegate: FlowDelegate, appDiContainer: AppDiContainer, sharedNavigationController: UINavigationController?, toolTranslations: ToolTranslationsDomainModel, liveShareStream: String?, trainingTipsEnabled: Bool, initialPage: MobileContentPagesPage?) {
         
         self.flowDelegate = flowDelegate
         self.appDiContainer = appDiContainer
@@ -58,7 +58,7 @@ class TractFlow: ToolNavigationFlow, Flow {
             mobileContentEventAnalytics: appDiContainer.getMobileContentEventAnalyticsTracking(),
             toolOpenedAnalytics: appDiContainer.getToolOpenedAnalytics(),
             liveShareStream: liveShareStream,
-            page: page,
+            initialPage: initialPage,
             trainingTipsEnabled: trainingTipsEnabled,
             incrementUserCounterUseCase: appDiContainer.domainLayer.getIncrementUserCounterUseCase()
         )

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/Pages/MobileContentPagesViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/Pages/MobileContentPagesViewModel.swift
@@ -286,8 +286,9 @@ extension MobileContentPagesViewModel {
                 
                 let introPageId: String = "intro"
                 let categoriesPageId: String = "categories"
+                let pageIsCategoryPage: Bool = value != categoriesPageId && value != introPageId
                 
-                guard value != categoriesPageId && value != introPageId else {
+                guard pageIsCategoryPage else {
                     return
                 }
                 

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/Pages/MobileContentPagesViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/Pages/MobileContentPagesViewModel.swift
@@ -403,42 +403,6 @@ extension MobileContentPagesViewModel {
 
 extension MobileContentPagesViewModel {
     
-    private var initialPageNumber: Int? {
-        
-        guard let initialPage = self.initialPage else {
-            return nil
-        }
-        
-        let pageModels: [Page] = currentPageRenderer.value.getRenderablePageModels()
-        
-        let pageNumber: Int?
-        
-        switch initialPage {
-            
-        case .pageNumber(let value):
-            
-            pageNumber = value
-            
-        case .pageId(let value):
-            
-            guard let pageModel = pageModels.filter({$0.id == value}).first else {
-                return nil
-            }
-            
-            pageNumber = Int(pageModel.position)
-        }
-        
-        guard let pageNumber = pageNumber else {
-            return nil
-        }
-        
-        guard pageNumber >= 0 && pageNumber < pageModels.count else {
-            return nil
-        }
-        
-        return pageNumber
-    }
-    
     private func updateTranslationsIfNeeded() {
         
         var translationsNeededDownloading: [TranslationModel] = Array()

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/Pages/MobileContentPagesViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/Pages/MobileContentPagesViewModel.swift
@@ -281,53 +281,29 @@ extension MobileContentPagesViewModel {
         switch page {
             
         case .pageId(let value):
-                     
-            if isChooseYourOwnAdventure {
-                
-                let introPageId: String = "intro"
-                let categoriesPageId: String = "categories"
-                let pageIsCategoryPage: Bool = value != categoriesPageId && value != introPageId
-                
-                guard pageIsCategoryPage else {
-                    return
-                }
-                
-                guard let pageModelMatchingPageId = renderablePages.first(where: {$0.id == value}) else {
-                    return
-                }
-                
-                if let introPage = renderablePages.first(where: {$0.id == introPageId}),
-                   let categoriesPage = renderablePages.first(where: {$0.id == categoriesPageId}) {
-                    
-                    pagesToRender = [introPage, categoriesPage, pageModelMatchingPageId]
-                }
-                else {
-                    
-                    pagesToRender = [pageModelMatchingPageId]
-                }
-                
-                navigateToPageModel = pageModelMatchingPageId
-                shouldReloadPagesUI = true
+                   
+            guard let pageModelMatchingPageId = renderablePages.first(where: {$0.id == value}) else {
+                return
             }
-            else {
-                
-                var pageModelsToRenderUpToPageToNavigateTo: [Page] = Array()
-                var pageModelMatchingPageId: Page?
-                
-                for pageModel in renderablePages {
-                    
-                    pageModelsToRenderUpToPageToNavigateTo.append(pageModel)
-                    
-                    if pageModel.id == value {
-                        pageModelMatchingPageId = pageModel
-                        break
-                    }
+            
+            var pageModelsToRenderUpToPageToNavigateTo: [Page] = [pageModelMatchingPageId]
+            
+            while true {
+            
+                guard let parentPage = pageModelsToRenderUpToPageToNavigateTo[0].parentPage else {
+                    break
                 }
                 
-                pagesToRender = pageModelsToRenderUpToPageToNavigateTo
-                navigateToPageModel = pageModelMatchingPageId
-                shouldReloadPagesUI = true
+                guard !pageModelsToRenderUpToPageToNavigateTo.contains(parentPage) else {
+                    break
+                }
+                
+                pageModelsToRenderUpToPageToNavigateTo.insert(parentPage, at: 0)
             }
+            
+            pagesToRender = pageModelsToRenderUpToPageToNavigateTo
+            navigateToPageModel = pageModelMatchingPageId
+            shouldReloadPagesUI = true
             
         case .pageNumber(let value):
                         

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/Pages/Models/MobileContentPagesPage.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/Pages/Models/MobileContentPagesPage.swift
@@ -1,0 +1,15 @@
+//
+//  MobileContentPagesPage.swift
+//  godtools
+//
+//  Created by Levi Eggert on 3/2/23.
+//  Copyright © 2023 Cru. All rights reserved.
+//
+
+import Foundation
+
+enum MobileContentPagesPage {
+    
+    case pageId(value: String)
+    case pageNumber(value: Int)
+}

--- a/godtools/App/Share/Data/DeepLinkingService/ParsedDeepLink/ToolDeepLinkPage+MobileContentPagesPage.swift
+++ b/godtools/App/Share/Data/DeepLinkingService/ParsedDeepLink/ToolDeepLinkPage+MobileContentPagesPage.swift
@@ -1,0 +1,24 @@
+//
+//  ToolDeepLinkPage+MobileContentPagesPage.swift
+//  godtools
+//
+//  Created by Levi Eggert on 3/2/23.
+//  Copyright © 2023 Cru. All rights reserved.
+//
+
+import Foundation
+
+extension ToolDeepLink {
+    
+    var mobileContentPage: MobileContentPagesPage? {
+        
+        if let page = self.page {
+            return .pageNumber(value: page)
+        }
+        else if let pageId = self.pageId {
+            return .pageId(value: pageId)
+        }
+        
+        return nil
+    }
+}


### PR DESCRIPTION
This PR fixes deeplinking to a ```cyoa``` tool with a pageId that is a category.  In iOS if the page is a category page, not (```intro``` or ```categories```) then we will build the intro, categories, and then category page in the renderer navigation stack.

Changes in this PR:
- Remove ```page: Int?``` from ```MobileContentPagesViewModel``` ```init()``` and replace with ```initialPage: MobileContentPagesPage?``` which encapsulates either a ```pageId: String``` or ```pageNumber: Int``` for the initial page to renderer.
- Change ```MobileContentPagesViewModel``` ```currentPage``` attribute to ```currentRenderedPageNumber```.
- Update renderer navigation to include page ids. 