### PR TITLE
GT-1953 Fix categories list spacing issue

### DIFF
--- a/godtools/App/Services/Renderer/Views/ChooseYourOwnAdventure/ViewFactory/ChooseYourOwnAdventurePageViewFactory.swift
+++ b/godtools/App/Services/Renderer/Views/ChooseYourOwnAdventure/ViewFactory/ChooseYourOwnAdventurePageViewFactory.swift
@@ -24,16 +24,18 @@ class ChooseYourOwnAdventurePageViewFactory: MobileContentPageViewFactoryType {
         
         if let contentPage = renderableModel as? ContentPage {
             
-            let page: Int = renderedPageContext.page
             let contentInsets: UIEdgeInsets
             let itemSpacing: CGFloat
             
-            if page == 0 {
+            let isIntroPage: Bool = contentPage.id == "intro"
+            let isCategoriesPage: Bool = contentPage.id == "categories"
+            
+            if isIntroPage {
                 
                 contentInsets = UIEdgeInsets(top: 0, left: 60, bottom: 0, right: 60)
                 itemSpacing = 28
             }
-            else if page == 1 {
+            else if isCategoriesPage {
                 
                 contentInsets = UIEdgeInsets(top: 30, left: 20, bottom: 0, right: 20)
                 itemSpacing = 30


### PR DESCRIPTION
Because the categories page was inserted as the starting page on a deeplink it was using the content insets of 60 that is applied to the intro page.