### PR TITLE
GT-1951 Fix navigation to page number

### DIFF
--- a/godtools/App/Services/Renderer/Renderer/MobileContentPageRenderer.swift
+++ b/godtools/App/Services/Renderer/Renderer/MobileContentPageRenderer.swift
@@ -35,13 +35,13 @@ class MobileContentPageRenderer {
         self.navigation = navigation
     }
     
-    func getRenderablePageModels() -> [Page] {
+    func getAllPageModels() -> [Page] {
         return manifest.pages
     }
     
     func getPageModel(page: Int) -> Page? {
         
-        let pageModels: [Page] = getRenderablePageModels()
+        let pageModels: [Page] = getAllPageModels()
         
         guard page >= 0 && page < pageModels.count else {
             return nil
@@ -49,14 +49,14 @@ class MobileContentPageRenderer {
         return pageModels[page]
     }
     
-    func getVisibleRenderablePageModels() -> [Page] {
-        let pageModels: [Page] = getRenderablePageModels()
+    func getVisiblePageModels() -> [Page] {
+        let pageModels: [Page] = getAllPageModels()
         return pageModels.filter({!$0.isHidden})
     }
     
     func getPageForListenerEvents(eventIds: [EventId]) -> Int? {
                 
-        let pageModels: [Page] = getRenderablePageModels()
+        let pageModels: [Page] = getAllPageModels()
         
         for pageIndex in 0 ..< pageModels.count {
             


### PR DESCRIPTION
The main fix for this is removing ```pagesToRender = renderablePages``` when navigating to a specific page number.  ```renderablePages``` encompassed all pages including hidden which we don't want include all hidden pages in the renderer.

