### PR TITLE
GT Update provisioning and entitlements for Apple Sign In

### DIFF
--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -9564,6 +9564,7 @@
 				CURRENT_PROJECT_VERSION = 927;
 				DEVELOPMENT_ASSET_PATHS = "godtools/Preview\\ Content godtools/Preview\\ Content/Preview\\ Assets.xcassets";
 				DEVELOPMENT_TEAM = DQ48D9BF2V;
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = DQ48D9BF2V;
 				DISPLAY_NAME = GodTools;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				INFOPLIST_FILE = godtools/Info.plist;
@@ -9579,6 +9580,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				PROVISIONING_PROFILE_SPECIFIER = "GodTools Production";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "GodTools Production";
 				SWIFT_OBJC_BRIDGING_HEADER = "godtools/godtools-Bridging-Header.h";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
@@ -9775,6 +9777,7 @@
 				CURRENT_PROJECT_VERSION = 927;
 				DEVELOPMENT_ASSET_PATHS = "godtools/Preview\\ Content godtools/Preview\\ Content/Preview\\ Assets.xcassets";
 				DEVELOPMENT_TEAM = DQ48D9BF2V;
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = DQ48D9BF2V;
 				DISPLAY_NAME = GodTools;
 				INFOPLIST_FILE = godtools/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
@@ -9789,6 +9792,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				PROVISIONING_PROFILE_SPECIFIER = "GodTools Release Profile";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "GodTools Release Profile";
 				SWIFT_OBJC_BRIDGING_HEADER = "godtools/godtools-Bridging-Header.h";
 				VERSIONING_SYSTEM = "apple-generic";
 			};

--- a/godtools/godtools.entitlements
+++ b/godtools/godtools.entitlements
@@ -4,6 +4,10 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:knowgod.com</string>


### PR DESCRIPTION
This PR does some pre-configuration for Apple Sign In.  

- Configured Apple Id (org.cru.godtools) to include Sign in with Apple.
- Created a Services Key in Apple Developer and shared private key with Andrew Roth for validating authorization code.
- Downloaded release and production provisioning with included Sign in with Apple and imported into Xcode project.
- Added Sign in with Apple to capabilities / godtools.entitlements.

<img width="1193" alt="godtools-sign-in-with-apple" src="https://user-images.githubusercontent.com/59846460/225417281-495b41bf-dce9-4ee3-9d81-cc07b6095974.png">


<img width="821" alt="godtools-entitlements" src="https://user-images.githubusercontent.com/59846460/225417329-b032f897-a1b7-48c3-9731-b2f850bc3442.png">

