### PR TITLE
GT-1847 delete auth token on logout

### DIFF
--- a/godtools/App/DependencyContainer/AppDomainLayerDependencies.swift
+++ b/godtools/App/DependencyContainer/AppDomainLayerDependencies.swift
@@ -124,7 +124,8 @@ class AppDomainLayerDependencies {
     func getLogOutUserUseCase() -> LogOutUserUseCase {
         return LogOutUserUseCase(
             cruOktaAuthentication: dataLayer.getCruOktaAuthentication(),
-            firebaseAnalytics: dataLayer.getAnalytics().firebaseAnalytics
+            firebaseAnalytics: dataLayer.getAnalytics().firebaseAnalytics,
+            mobileContentAuthTokenRepository: dataLayer.getMobileContentAuthTokenRepository()
         )
     }
     

--- a/godtools/App/Features/Menu/Domain/UseCases/LogOutUserUseCase/LogOutUserUseCase.swift
+++ b/godtools/App/Features/Menu/Domain/UseCases/LogOutUserUseCase/LogOutUserUseCase.swift
@@ -14,11 +14,13 @@ class LogOutUserUseCase {
     
     private let cruOktaAuthentication: CruOktaAuthentication
     private let firebaseAnalytics: FirebaseAnalytics
+    private let mobileContentAuthTokenRepository: MobileContentAuthTokenRepository
     
-    init(cruOktaAuthentication: CruOktaAuthentication, firebaseAnalytics: FirebaseAnalytics) {
+    init(cruOktaAuthentication: CruOktaAuthentication, firebaseAnalytics: FirebaseAnalytics, mobileContentAuthTokenRepository: MobileContentAuthTokenRepository) {
         
         self.cruOktaAuthentication = cruOktaAuthentication
         self.firebaseAnalytics = firebaseAnalytics
+        self.mobileContentAuthTokenRepository = mobileContentAuthTokenRepository
     }
     
     func logOutPublisher(fromViewController: UIViewController) -> AnyPublisher<Bool, Never> {
@@ -27,6 +29,7 @@ class LogOutUserUseCase {
             .flatMap({ (response: OktaSignOutResponse) -> AnyPublisher<Bool, Never> in
                 
                 self.setAnalyticsUserProperties()
+                self.mobileContentAuthTokenRepository.deleteCachedAuthToken()
                 
                 return Just(true)
                     .eraseToAnyPublisher()

--- a/godtools/App/Share/Data/MobileContentAuthTokenRepository/Cache/MobileContentAuthTokenCache.swift
+++ b/godtools/App/Share/Data/MobileContentAuthTokenRepository/Cache/MobileContentAuthTokenCache.swift
@@ -41,6 +41,6 @@ class MobileContentAuthTokenCache {
     
     func deleteAuthToken(for userId: String) {
         
-        keychainAccessor.deleteMobileContentAuthToken(userId: userId)
+        keychainAccessor.deleteMobileContentAuthTokenAndUserId(userId: userId)
     }
 }

--- a/godtools/App/Share/Data/MobileContentAuthTokenRepository/Cache/MobileContentAuthTokenCache.swift
+++ b/godtools/App/Share/Data/MobileContentAuthTokenRepository/Cache/MobileContentAuthTokenCache.swift
@@ -38,4 +38,9 @@ class MobileContentAuthTokenCache {
         
         return keychainAccessor.getMobileContentUserId()
     }
+    
+    func deleteAuthToken(for userId: String) {
+        
+        keychainAccessor.deleteMobileContentAuthToken(userId: userId)
+    }
 }

--- a/godtools/App/Share/Data/MobileContentAuthTokenRepository/Cache/MobileContentAuthTokenKeychainAccessor.swift
+++ b/godtools/App/Share/Data/MobileContentAuthTokenRepository/Cache/MobileContentAuthTokenKeychainAccessor.swift
@@ -26,10 +26,13 @@ class MobileContentAuthTokenKeychainAccessor {
         try saveAuthToken(authTokenDataModel)
     }
     
-    func deleteMobileContentAuthToken(userId: String) {
+    func deleteMobileContentAuthTokenAndUserId(userId: String) {
         
-        let deleteQuery = buildDeleteQueryForAuthToken(userId: userId)
-        let _ = SecItemDelete(deleteQuery)
+        let authTokenDeleteQuery = buildDeleteQueryForAuthToken(userId: userId)
+        let _ = SecItemDelete(authTokenDeleteQuery)
+        
+        let userIdDeleteQuery = buildDeleteQueryForUserId()
+        let _ = SecItemDelete(userIdDeleteQuery)
     }
     
     func getMobileContentAuthToken(userId: String) -> String? {
@@ -221,7 +224,7 @@ extension MobileContentAuthTokenKeychainAccessor {
             kSecAttrAccount as String: userId
         ] as CFDictionary
     }
-        
+    
     private func buildGetQueryForAuthToken(userId: String) -> CFDictionary {
         
         return [
@@ -239,6 +242,15 @@ extension MobileContentAuthTokenKeychainAccessor {
             kSecAttrService as String: Service.mobileContent.rawValue,
             kSecAttrAccount as String: Account.userId.rawValue,
             kSecReturnData as String: true
+        ] as CFDictionary
+    }
+    
+    private func buildDeleteQueryForUserId() -> CFDictionary {
+        
+        return [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: Service.mobileContent.rawValue,
+            kSecAttrAccount as String: Account.userId.rawValue,
         ] as CFDictionary
     }
     

--- a/godtools/App/Share/Data/MobileContentAuthTokenRepository/Cache/MobileContentAuthTokenKeychainAccessor.swift
+++ b/godtools/App/Share/Data/MobileContentAuthTokenRepository/Cache/MobileContentAuthTokenKeychainAccessor.swift
@@ -26,6 +26,12 @@ class MobileContentAuthTokenKeychainAccessor {
         try saveAuthToken(authTokenDataModel)
     }
     
+    func deleteMobileContentAuthToken(userId: String) {
+        
+        let deleteQuery = buildDeleteQueryForAuthToken(userId: userId)
+        let _ = SecItemDelete(deleteQuery)
+    }
+    
     func getMobileContentAuthToken(userId: String) -> String? {
         
         let getQuery = buildGetQueryForAuthToken(userId: userId)
@@ -207,6 +213,15 @@ extension MobileContentAuthTokenKeychainAccessor {
         return (updateQuery, updateAttributes)
     }
     
+    private func buildDeleteQueryForAuthToken(userId: String) -> CFDictionary {
+        
+        return [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: Service.mobileContentAuthToken.rawValue,
+            kSecAttrAccount as String: userId
+        ] as CFDictionary
+    }
+        
     private func buildGetQueryForAuthToken(userId: String) -> CFDictionary {
         
         return [

--- a/godtools/App/Share/Data/MobileContentAuthTokenRepository/MobileContentAuthTokenRepository.swift
+++ b/godtools/App/Share/Data/MobileContentAuthTokenRepository/MobileContentAuthTokenRepository.swift
@@ -56,4 +56,11 @@ class MobileContentAuthTokenRepository {
         
         return getCachedAuthTokenModel()?.token
     }
+    
+    func deleteCachedAuthToken() {
+        
+        guard let userId = getUserId() else { return }
+        
+        cache.deleteAuthToken(for: userId)
+    }
 }


### PR DESCRIPTION
When a user logs out, delete the cached userId and auth token.  This won't account for the case where Okta logs a user out automatically-- not sure that there's a good way to know that.  But since Okta is being removed anyway, we may want to revisit this as other login methods are added.  It's also not strictly necessary that the auth token get deleted on logout, but preferable to leaving it there.