### PR TITLE
Switch to loading OneSky secrets from AWS SSM

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,10 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  id-token: write
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -58,11 +62,23 @@ jobs:
       - name: Run Tests
         run: bundle exec fastlane cru_shared_lane_run_tests
 
+      - name: Configure AWS credentials
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.AWS_IAM_ONESKY_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Import OneSky Keys
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        uses: dkershner6/aws-ssm-getparameters-action@v1
+        with:
+          parameterPairs: |
+            /shared/onesky/PUBLIC_KEY = ONESKY_PUBLIC_KEY,
+            /shared/onesky/SECRET_KEY = ONESKY_SECRET_KEY
+
       - name: Download And Commit Latest OneSky Localizations
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-        env:
-          ONESKY_PUBLIC_KEY: ${{ secrets.ONESKY_PUBLIC_KEY }}
-          ONESKY_SECRET_KEY: ${{ secrets.ONESKY_SECRET_KEY }}
         run: bundle exec fastlane cru_shared_lane_download_and_commit_latest_one_sky_localizations
 
       - name: Import App Store Connect API Key

--- a/.github/workflows/download_onesky_translations.yml
+++ b/.github/workflows/download_onesky_translations.yml
@@ -7,6 +7,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  id-token: write
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -27,10 +30,20 @@ jobs:
       - name: Bundle Install
         run: bundle install
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.AWS_IAM_ONESKY_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Import OneSky Keys
+        uses: dkershner6/aws-ssm-getparameters-action@v1
+        with:
+          parameterPairs: |
+            /shared/onesky/PUBLIC_KEY = ONESKY_PUBLIC_KEY,
+            /shared/onesky/SECRET_KEY = ONESKY_SECRET_KEY
+
       - name: Download And Commit Latest OneSky Localizations
-        env:
-          ONESKY_PUBLIC_KEY: ${{ secrets.ONESKY_PUBLIC_KEY }}
-          ONESKY_SECRET_KEY: ${{ secrets.ONESKY_SECRET_KEY }}
         run: bundle exec fastlane cru_shared_lane_download_and_commit_latest_one_sky_localizations
 
       - name: Create Pull Request


### PR DESCRIPTION
This moves management of the OneSky secrets to be centralized in AWS. I will be deleting the previous OneSky secrets from GHA secrets once this is merged.

Manual run of the download latest translations workflow: https://github.com/CruGlobal/godtools-swift/actions/runs/4534218676