### PR TITLE
GT-1925 Fix control colors to be consistent with shared GTBlue color

### DIFF
--- a/godtools/App/Features/ToolSettings/ShareToolScreenTutorial/ShareToolScreenTutorialView.swift
+++ b/godtools/App/Features/ToolSettings/ShareToolScreenTutorial/ShareToolScreenTutorialView.swift
@@ -101,7 +101,7 @@ class ShareToolScreenTutorialView: UIViewController {
             skipButton = addBarButtonItem(
                 to: buttonPosition,
                 title: viewModel.skipTitle,
-                style: .done,
+                style: .plain,
                 color: ColorPalette.gtBlue.uiColor,
                 target: self,
                 action: #selector(handleSkip(barButtonItem:))

--- a/godtools/App/Flows/DownloadToolTranslations/DownloadToolTranslationsFlow.swift
+++ b/godtools/App/Flows/DownloadToolTranslations/DownloadToolTranslationsFlow.swift
@@ -110,7 +110,7 @@ class DownloadToolTranslationsFlow: Flow {
         
         let view = DownloadToolView(viewModel: viewModel)
         
-        let modal = ModalNavigationController(rootView: view, navBarColor: .white, navBarIsTranslucent: false)
+        let modal = ModalNavigationController.defaultModal(rootView: view)
         
         navigationController.present(modal, animated: true, completion: nil)
         

--- a/godtools/App/Flows/LearnToShareTool/LearnToShareToolFlow.swift
+++ b/godtools/App/Flows/LearnToShareTool/LearnToShareToolFlow.swift
@@ -27,7 +27,7 @@ class LearnToShareToolFlow: Flow {
         
         navigationController.navigationBar.setupNavigationBarAppearance(
             backgroundColor: .clear,
-            controlColor: nil,
+            controlColor: ColorPalette.gtBlue.uiColor,
             titleFont: nil,
             titleColor: nil,
             isTranslucent: true

--- a/godtools/App/Flows/Onboarding/OnboardingFlow.swift
+++ b/godtools/App/Flows/Onboarding/OnboardingFlow.swift
@@ -37,7 +37,7 @@ class OnboardingFlow: Flow {
         
         navigationController.navigationBar.setupNavigationBarAppearance(
             backgroundColor: .clear,
-            controlColor: nil,
+            controlColor: ColorPalette.gtBlue.uiColor,
             titleFont: nil,
             titleColor: nil,
             isTranslucent: true

--- a/godtools/App/Flows/ToolSettings/ToolSettingsFlow.swift
+++ b/godtools/App/Flows/ToolSettings/ToolSettingsFlow.swift
@@ -273,7 +273,7 @@ class ToolSettingsFlow: Flow {
         )
 
         let view = ShareToolScreenTutorialView(viewModel: viewModel)
-        let modal = ModalNavigationController(rootView: view)
+        let modal = ModalNavigationController.defaultModal(rootView: view)
 
         navigationController.present(
             modal,
@@ -295,7 +295,7 @@ class ToolSettingsFlow: Flow {
         )
         let view = LoadingView(viewModel: viewModel)
         
-        let modal = ModalNavigationController(rootView: view)
+        let modal = ModalNavigationController.defaultModal(rootView: view)
         
         navigationController.present(modal, animated: true, completion: nil)
         

--- a/godtools/App/Flows/Tutorial/TutorialFlow.swift
+++ b/godtools/App/Flows/Tutorial/TutorialFlow.swift
@@ -30,7 +30,7 @@ class TutorialFlow: Flow {
         navigationController.setNavigationBarHidden(false, animated: false)
         navigationController.navigationBar.setupNavigationBarAppearance(
             backgroundColor: .white,
-            controlColor: nil,
+            controlColor: ColorPalette.gtBlue.uiColor,
             titleFont: nil,
             titleColor: nil,
             isTranslucent: false

--- a/godtools/App/Flows/VideoModal/Flow+VideoModal.swift
+++ b/godtools/App/Flows/VideoModal/Flow+VideoModal.swift
@@ -29,7 +29,7 @@ extension Flow {
         
         hostingView.view.backgroundColor = UIColor(videoBackgroundColor)
         
-        let modal = ModalNavigationController(rootView: hostingView, navBarColor: .black, navBarIsTranslucent: true)
+        let modal = ModalNavigationController(rootView: hostingView, navBarColor: .black, navBarIsTranslucent: true, controlColor: .white)
                
         modal.view.backgroundColor = UIColor(videoBackgroundColor)
         

--- a/godtools/App/Share/NavControllers/ModalNavigationController.swift
+++ b/godtools/App/Share/NavControllers/ModalNavigationController.swift
@@ -9,23 +9,36 @@
 import UIKit
 
 class ModalNavigationController: UINavigationController {
-    
-    private static let defaultNavBarColor: UIColor = .white
-    private static let defaultNavBarIsTranslucent = false
-    
+        
     private let rootView: UIViewController
-    private let navBarColor: UIColor
-    private let navBarIsTranslucent: Bool
     
-    required init(rootView: UIViewController, navBarColor: UIColor = ModalNavigationController.defaultNavBarColor, navBarIsTranslucent: Bool = ModalNavigationController.defaultNavBarIsTranslucent) {
+    static func defaultModal(rootView: UIViewController) -> ModalNavigationController {
+        
+        return ModalNavigationController(
+            rootView: rootView,
+            navBarColor: UIColor.white,
+            navBarIsTranslucent: false,
+            controlColor: ColorPalette.gtBlue.uiColor
+        )
+    }
+    
+    init(rootView: UIViewController, navBarColor: UIColor, navBarIsTranslucent: Bool, controlColor: UIColor) {
         
         self.rootView = rootView
-        self.navBarColor = navBarColor
-        self.navBarIsTranslucent = navBarIsTranslucent
         
         super.init(nibName: nil, bundle: nil)
         
         modalPresentationStyle = .fullScreen
+        
+        navigationBar.setupNavigationBarAppearance(
+            backgroundColor: navBarColor,
+            controlColor: controlColor,
+            titleFont: nil,
+            titleColor: nil,
+            isTranslucent: navBarIsTranslucent
+        )
+                                
+        setViewControllers([rootView], animated: false)
     }
     
     required init?(coder aDecoder: NSCoder) {
@@ -36,15 +49,6 @@ class ModalNavigationController: UINavigationController {
     deinit {
         
         print("x deinit: \(type(of: self))")
-    }
-    
-    override func viewDidLoad() {
-        
-        super.viewDidLoad()
-        
-        navigationBar.setupNavigationBarAppearance(backgroundColor: navBarColor, controlColor: nil, titleFont: nil, titleColor: nil, isTranslucent: navBarIsTranslucent)
-                                
-        setViewControllers([rootView], animated: false)
     }
     
     override var preferredStatusBarStyle: UIStatusBarStyle {


### PR DESCRIPTION
There was some inconsistencies between the tutorials (learn to share tool, tutorial behind menu) and the remote share screen tutorial in the way the navigation bar control color was getting set.  Updated to be consistent and use the shared GTblue color.