### PR TITLE
GT-1699 support 2 lines of text in rendered card header

### DIFF
--- a/godtools/App/Services/Renderer/Views/Tool/Views/Card/ToolPageCardView.swift
+++ b/godtools/App/Services/Renderer/Views/Tool/Views/Card/ToolPageCardView.swift
@@ -255,9 +255,22 @@ class ToolPageCardView: MobileContentView, NibBased {
     }
     
     // MARK: -
-
-    static var cardHeaderHeight: CGFloat {
+    
+    static var minimumCardHeaderHeight: CGFloat {
         return 50
+    }
+
+    func getCardHeaderHeight() -> CGFloat {
+        
+        let minimumHeaderHeight: CGFloat = ToolPageCardView.minimumCardHeaderHeight
+        
+        let headerHeight: CGFloat = titleSeparatorLine.frame.origin.y
+        
+        guard headerHeight > minimumHeaderHeight else {
+            return minimumHeaderHeight
+        }
+        
+        return headerHeight
     }
     
     @objc func headerTapped() {

--- a/godtools/App/Services/Renderer/Views/Tool/Views/Cards/Models/ToolPageCardTopConstantState.swift
+++ b/godtools/App/Services/Renderer/Views/Tool/Views/Cards/Models/ToolPageCardTopConstantState.swift
@@ -10,9 +10,9 @@ import Foundation
 
 enum ToolPageCardTopConstantState {
     
-    case starting(cardPosition: Int)
+    case starting
     case showing
     case showingKeyboard
-    case collapsed(cardPosition: Int)
+    case collapsed
     case hidden
 }

--- a/godtools/App/Services/Renderer/Views/Tool/Views/Cards/ToolPageCardsView.swift
+++ b/godtools/App/Services/Renderer/Views/Tool/Views/Cards/ToolPageCardsView.swift
@@ -89,7 +89,7 @@ class ToolPageCardsView: MobileContentView {
                 let cardBounceAnimation = ToolPageCardBounceAnimation(
                     card: firstCard,
                     cardTopConstraint: firstCardTopConstraint,
-                    cardStartingTopConstant: cardsView.getCardTopConstant(state: .starting(cardPosition: 0)),
+                    cardStartingTopConstant: cardsView.getCardTopConstant(state: .starting, cardPosition: 0),
                     layoutView: cardsParent,
                     delegate: cardsView
                 )
@@ -282,8 +282,7 @@ extension ToolPageCardsView {
     private var showCardBottomInset: CGFloat {
         
         let numberOfVisibleCardsFloatValue: CGFloat = CGFloat(allCards.filter({!$0.isHidden}).count)
-        let cardHeaderHeight: CGFloat = ToolPageCardView.cardHeaderHeight
-        let cardTopVisibilityHeight: CGFloat = floor(cardHeaderHeight * cardCollapsedVisibilityPercentage)
+        let cardTopVisibilityHeight: CGFloat = floor(ToolPageCardView.minimumCardHeaderHeight * cardCollapsedVisibilityPercentage)
         let collapsedCardsHeight: CGFloat = (cardTopVisibilityHeight * (numberOfVisibleCardsFloatValue - 1))
         let availableBottomSpaces: [CGFloat] = [collapsedCardsHeight, cardParentContentInsets.bottom]
         let maxBottomSpace: CGFloat = availableBottomSpaces.max() ?? 0
@@ -328,6 +327,8 @@ extension ToolPageCardsView {
         
         renderedCards.append(cardView)
         
+        let cardPosition: Int = getRenderedCardPosition(cardView: cardView) ?? 0
+        
         cardsParentView.addSubview(cardView)
 
         cardView.translatesAutoresizingMaskIntoConstraints = false
@@ -370,7 +371,7 @@ extension ToolPageCardsView {
         
         cardView.setHeightConstraint(height: cardHeight)
         
-        top.constant = getCardTopConstant(state: .hidden)
+        top.constant = getCardTopConstant(state: .hidden, cardPosition: cardPosition)
                     
         cardTopConstraints.append(top)
         
@@ -403,7 +404,7 @@ extension ToolPageCardsView {
         
         if animated, let cardPosition = getRenderedCardPosition(cardView: cardView) {
             
-            cardTopConstraints[cardPosition].constant = getCardTopConstant(state: .hidden)
+            cardTopConstraints[cardPosition].constant = getCardTopConstant(state: .hidden, cardPosition: cardPosition)
             
             removeRenderedCard(index: cardPosition, shouldRemoveFromView: false)
             
@@ -471,15 +472,21 @@ extension ToolPageCardsView {
         return screenHeight - topInset - bottomInset
     }
     
-    private func getCardTopConstant(state: ToolPageCardTopConstantState) -> CGFloat {
+    private func getCardTopConstant(state: ToolPageCardTopConstantState, cardPosition: Int) -> CGFloat {
         
         let numberOfVisibleCardsFloatValue: CGFloat = CGFloat(renderedCards.count)
-        let cardHeaderHeight: CGFloat = ToolPageCardView.cardHeaderHeight
         
         switch state {
             
-        case .starting(let cardPosition):
-            return UIScreen.main.bounds.size.height - safeArea.bottom - (cardHeaderHeight * (numberOfVisibleCardsFloatValue - CGFloat(cardPosition)))
+        case .starting:
+            
+            var combinedCardHeaderHeightsFollowingCardPosition: CGFloat = 0
+            
+            for index in cardPosition ..< renderedCards.count {
+                combinedCardHeaderHeightsFollowingCardPosition += renderedCards[index].getCardHeaderHeight()
+            }
+            
+            return UIScreen.main.bounds.size.height - safeArea.bottom - combinedCardHeaderHeightsFollowingCardPosition
         
         case .showing:
             return showCardTopInset
@@ -487,8 +494,8 @@ extension ToolPageCardsView {
         case .showingKeyboard:
             return showCardTopInset
             
-        case .collapsed(let cardPosition):
-            let cardTopVisibilityHeight: CGFloat = floor(cardHeaderHeight * cardCollapsedVisibilityPercentage)
+        case .collapsed:
+            let cardTopVisibilityHeight: CGFloat = floor(ToolPageCardView.minimumCardHeaderHeight * cardCollapsedVisibilityPercentage)
             return UIScreen.main.bounds.size.height - safeArea.bottom - (cardTopVisibilityHeight * (numberOfVisibleCardsFloatValue - CGFloat(cardPosition)))
     
         case .hidden:
@@ -508,7 +515,7 @@ extension ToolPageCardsView {
                         
             for cardPosition in 0 ..< renderedCards.count {
                 
-                cardTopConstraints[cardPosition].constant = getCardTopConstant(state: .starting(cardPosition: cardPosition))
+                cardTopConstraints[cardPosition].constant = getCardTopConstant(state: .starting, cardPosition: cardPosition)
             }
             
         case .showingCard(let showingCardAtPosition):
@@ -533,10 +540,10 @@ extension ToolPageCardsView {
                 let shouldShowCard: Bool = cardPosition <= showCardAtPosition
                 
                 if shouldShowCard {
-                    cardTop = getCardTopConstant(state: .showing)
+                    cardTop = getCardTopConstant(state: .showing, cardPosition: cardPosition)
                 }
                 else {
-                    cardTop = getCardTopConstant(state: .collapsed(cardPosition: cardPosition))
+                    cardTop = getCardTopConstant(state: .collapsed, cardPosition: cardPosition)
                 }
                 
                 cardTopConstraints[cardPosition].constant = cardTop
@@ -549,7 +556,7 @@ extension ToolPageCardsView {
             for cardPosition in 0 ..< renderedCards.count {
                                 
                 if cardPosition <= showingCardAtPosition {
-                    cardTopConstraints[cardPosition].constant = getCardTopConstant(state: .showingKeyboard)
+                    cardTopConstraints[cardPosition].constant = getCardTopConstant(state: .showingKeyboard, cardPosition: cardPosition)
                 }
             }
                         
@@ -561,7 +568,7 @@ extension ToolPageCardsView {
                         
             for cardPosition in 0 ..< renderedCards.count {
                                 
-                cardTopConstraints[cardPosition].constant = getCardTopConstant(state: .collapsed(cardPosition: cardPosition))
+                cardTopConstraints[cardPosition].constant = getCardTopConstant(state: .collapsed, cardPosition: cardPosition)
             }
             
         case .initialized:
@@ -637,5 +644,20 @@ extension ToolPageCardsView {
     
     func getNumberOfRenderedCards() -> Int {
         return renderedCards.count
+    }
+    
+    func getCombinedCardHeaderHeightForRenderedCards() -> CGFloat? {
+        
+        guard renderedCards.count >= 0 else {
+            return nil
+        }
+        
+        var combinedCardsHeaderHeight: CGFloat = 0
+        
+        for card in renderedCards {
+            combinedCardsHeaderHeight += card.getCardHeaderHeight()
+        }
+        
+        return combinedCardsHeaderHeight
     }
 }

--- a/godtools/App/Services/Renderer/Views/Tool/Views/Page/ToolPageView.swift
+++ b/godtools/App/Services/Renderer/Views/Tool/Views/Page/ToolPageView.swift
@@ -248,9 +248,8 @@ extension ToolPageView {
         }
         else if !hidesCards {
             
-            let numberOfVisibleCardsFloatValue: CGFloat =  CGFloat(numberOfVisibleCards)
-            let cardHeaderHeight: CGFloat = ToolPageCardView.cardHeaderHeight
-            heroHeight.constant = maximumHeight - (numberOfVisibleCardsFloatValue * cardHeaderHeight)
+            let combineCardHeaderHeight: CGFloat = cardsView?.getCombinedCardHeaderHeightForRenderedCards() ?? 0
+            heroHeight.constant = maximumHeight - combineCardHeaderHeight
         }
                      
         heroTop.constant = headerHeight + topInset


### PR DESCRIPTION
This PR updates tracts card headers to display the full title when in the starting state.  The rendering states for tract cards are (hidden, collapsed, starting, showing, showingKeyboard).

The rendering state that needed to be fixed was the ```starting``` state which shows all cards at the bottom of the screen with visible title headers. 

![Simulator Screen Shot - iPhone 8 - 2023-04-03 at 16 37 51](https://user-images.githubusercontent.com/59846460/229626341-79c96da7-9b92-4261-932d-4af985c6eb61.png)


![Simulator Screen Shot - iPhone 8 - 2023-04-03 at 16 38 07](https://user-images.githubusercontent.com/59846460/229626353-2dd566ae-685a-405d-8dab-064c5150706a.png)
