### PR TITLE
GT-1929 Allow TextWithLinks (UITextView) to support dynamic type

### DIFF
--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -359,6 +359,7 @@
 		45828BCA279CCB6900F6B5F3 /* MobileContentCardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45828BC9279CCB6900F6B5F3 /* MobileContentCardViewModel.swift */; };
 		45828BD1279CCBD200F6B5F3 /* MobileContentFlowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45828BCE279CCBD200F6B5F3 /* MobileContentFlowView.swift */; };
 		45828BD3279CCBD200F6B5F3 /* MobileContentFlowViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45828BD0279CCBD200F6B5F3 /* MobileContentFlowViewModel.swift */; };
+		45838F0329E847D4003B5578 /* ToolDetailsSectionDescriptionTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45838F0229E847D3003B5578 /* ToolDetailsSectionDescriptionTextView.swift */; };
 		458585DD2924593F005042C2 /* GetAccountCreationIsSupportedUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 458585DC2924593F005042C2 /* GetAccountCreationIsSupportedUseCase.swift */; };
 		458585DF2924596C005042C2 /* AccountCreationIsSupportedDomainModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 458585DE2924596C005042C2 /* AccountCreationIsSupportedDomainModel.swift */; };
 		4585E0692706560600DD6608 /* TransparentModalCustomView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4585E0682706560600DD6608 /* TransparentModalCustomView.swift */; };
@@ -1432,6 +1433,7 @@
 		45828BC9279CCB6900F6B5F3 /* MobileContentCardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileContentCardViewModel.swift; sourceTree = "<group>"; };
 		45828BCE279CCBD200F6B5F3 /* MobileContentFlowView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MobileContentFlowView.swift; sourceTree = "<group>"; };
 		45828BD0279CCBD200F6B5F3 /* MobileContentFlowViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MobileContentFlowViewModel.swift; sourceTree = "<group>"; };
+		45838F0229E847D3003B5578 /* ToolDetailsSectionDescriptionTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolDetailsSectionDescriptionTextView.swift; sourceTree = "<group>"; };
 		458585DC2924593F005042C2 /* GetAccountCreationIsSupportedUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetAccountCreationIsSupportedUseCase.swift; sourceTree = "<group>"; };
 		458585DE2924596C005042C2 /* AccountCreationIsSupportedDomainModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountCreationIsSupportedDomainModel.swift; sourceTree = "<group>"; };
 		4585E0682706560600DD6608 /* TransparentModalCustomView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransparentModalCustomView.swift; sourceTree = "<group>"; };
@@ -4051,6 +4053,7 @@
 				4573133028C1821100481640 /* ToolDetailsAboutView.swift */,
 				4573132F28C1821100481640 /* ToolDetailsMediaView.swift */,
 				4573133428C1821100481640 /* ToolDetailsPrimaryButtonsView.swift */,
+				45838F0229E847D3003B5578 /* ToolDetailsSectionDescriptionTextView.swift */,
 				4573133528C1821100481640 /* ToolDetailsSegmentType.swift */,
 				4573132E28C1821100481640 /* ToolDetailsTitleHeaderView.swift */,
 				4573132D28C1821100481640 /* ToolDetailsToggleFavoriteButton.swift */,
@@ -8837,6 +8840,7 @@
 				D1E98EDD27974F0000D1B738 /* LessonEvaluationViewModelType.swift in Sources */,
 				45BDA61B2954FE3E007E259B /* ArticleManifestAemRepository.swift in Sources */,
 				45AD22A12593CE8900A096A0 /* ColorPalette.swift in Sources */,
+				45838F0329E847D4003B5578 /* ToolDetailsSectionDescriptionTextView.swift in Sources */,
 				45AD1B2225938A4F00A096A0 /* LearnToShareToolCellViewModelType.swift in Sources */,
 				45E8FAA92882FD4B00D7D569 /* SHA256FileModel.swift in Sources */,
 				45D63E5E288F689F009B4610 /* RealmTranslation.swift in Sources */,

--- a/godtools/App/Features/ToolDetails/Presentation/ToolDetails/Subviews/ToolDetailsAboutView.swift
+++ b/godtools/App/Features/ToolDetails/Presentation/ToolDetails/Subviews/ToolDetailsAboutView.swift
@@ -10,30 +10,29 @@ import SwiftUI
 
 struct ToolDetailsAboutView: View {
            
-    @ObservedObject var viewModel: ToolDetailsViewModel
+    private let geometry: GeometryProxy
     
-    let width: CGFloat
-    
+    @ObservedObject private var viewModel: ToolDetailsViewModel
+        
     @State private var accordionExpandedConversationStarters: Bool = false
     @State private var accordionExpandedOutline: Bool = false
     @State private var accordionExpandedBibleReferences: Bool = false
     @State private var accordionExpandedLanguageAvailability: Bool = false
     
+    init(viewModel: ToolDetailsViewModel, geometry: GeometryProxy) {
+        
+        self.viewModel = viewModel
+        self.geometry = geometry
+    }
+    
     var body: some View {
         
         VStack(alignment: .leading, spacing: 0) {
             
-            TextWithLinks(
-                text: viewModel.aboutDetails,
-                textColor: ColorPalette.gtGrey.uiColor,
-                font: FontLibrary.sfProTextRegular.uiFont(size: 16),
-                lineSpacing: 3,
-                width: width,
-                adjustsFontForContentSizeCategory: true,
-                didInteractWithUrlClosure: { (url: URL) in
-                    viewModel.urlTapped(url: url)
-                    return true
-                }
+            ToolDetailsSectionDescriptionTextView(
+                viewModel: viewModel,
+                geometry: geometry,
+                text: viewModel.aboutDetails
             )
             
             Rectangle()
@@ -62,6 +61,7 @@ struct ToolDetailsAboutView: View {
                     AccordionView(title: viewModel.availableLanguagesTitle, contents: viewModel.availableLanguagesList, isExpanded: $accordionExpandedLanguageAvailability)
                 }
             }
+            .padding(ToolDetailsView.sectionDescriptionTextInsets)
             
             if accordionExpandedConversationStarters || accordionExpandedOutline || accordionExpandedBibleReferences || accordionExpandedLanguageAvailability {
                 Spacer()

--- a/godtools/App/Features/ToolDetails/Presentation/ToolDetails/Subviews/ToolDetailsAboutView.swift
+++ b/godtools/App/Features/ToolDetails/Presentation/ToolDetails/Subviews/ToolDetailsAboutView.swift
@@ -29,6 +29,7 @@ struct ToolDetailsAboutView: View {
                 font: FontLibrary.sfProTextRegular.uiFont(size: 16),
                 lineSpacing: 3,
                 width: width,
+                adjustsFontForContentSizeCategory: true,
                 didInteractWithUrlClosure: { (url: URL) in
                     viewModel.urlTapped(url: url)
                     return true

--- a/godtools/App/Features/ToolDetails/Presentation/ToolDetails/Subviews/ToolDetailsSectionDescriptionTextView.swift
+++ b/godtools/App/Features/ToolDetails/Presentation/ToolDetails/Subviews/ToolDetailsSectionDescriptionTextView.swift
@@ -24,7 +24,7 @@ struct ToolDetailsSectionDescriptionTextView: View {
     
     var body: some View {
         
-        VStack(alignment: .leading, spacing: 0) {
+        VStack(alignment: .center, spacing: 0) {
            
             TextWithLinks(
                 text: text,

--- a/godtools/App/Features/ToolDetails/Presentation/ToolDetails/Subviews/ToolDetailsSectionDescriptionTextView.swift
+++ b/godtools/App/Features/ToolDetails/Presentation/ToolDetails/Subviews/ToolDetailsSectionDescriptionTextView.swift
@@ -1,0 +1,44 @@
+//
+//  ToolDetailsSectionDescriptionTextView.swift
+//  godtools
+//
+//  Created by Levi Eggert on 4/13/23.
+//  Copyright © 2023 Cru. All rights reserved.
+//
+
+import SwiftUI
+
+struct ToolDetailsSectionDescriptionTextView: View {
+        
+    private let geometry: GeometryProxy
+    private let text: String
+    
+    @ObservedObject private var viewModel: ToolDetailsViewModel
+    
+    init(viewModel: ToolDetailsViewModel, geometry: GeometryProxy, text: String) {
+        
+        self.viewModel = viewModel
+        self.geometry = geometry
+        self.text = text
+    }
+    
+    var body: some View {
+        
+        VStack(alignment: .leading, spacing: 0) {
+           
+            TextWithLinks(
+                text: text,
+                textColor: ColorPalette.gtGrey.uiColor,
+                font: FontLibrary.sfProTextRegular.uiFont(size: 16),
+                lineSpacing: 3,
+                width: geometry.size.width - ToolDetailsView.sectionDescriptionTextInsets.leading - ToolDetailsView.sectionDescriptionTextInsets.trailing,
+                adjustsFontForContentSizeCategory: true,
+                didInteractWithUrlClosure: { (url: URL) in
+                    viewModel.urlTapped(url: url)
+                    return true
+                }
+            )
+        }
+        .padding(ToolDetailsView.sectionDescriptionTextInsets)
+    }
+}

--- a/godtools/App/Features/ToolDetails/Presentation/ToolDetails/Subviews/ToolDetailsVersionsView.swift
+++ b/godtools/App/Features/ToolDetails/Presentation/ToolDetails/Subviews/ToolDetailsVersionsView.swift
@@ -16,6 +16,7 @@ struct ToolDetailsVersionsView: View {
     @ObservedObject var viewModel: ToolDetailsViewModel
     
     let geometry: GeometryProxy
+    let textEdgeInsets: EdgeInsets
     let toolVersionTappedClosure: (() -> Void)
         
     var body: some View {
@@ -25,7 +26,7 @@ struct ToolDetailsVersionsView: View {
             Text(viewModel.versionsMessage)
                 .foregroundColor(ColorPalette.gtGrey.color)
                 .font(FontLibrary.sfProTextRegular.font(size: 16))
-                .padding(EdgeInsets(top: 0, leading: 30, bottom: 10, trailing: 30))
+                .padding(textEdgeInsets)
             
             ForEach(viewModel.toolVersions) { toolVersion in
                          

--- a/godtools/App/Features/ToolDetails/Presentation/ToolDetails/Subviews/ToolDetailsVersionsView.swift
+++ b/godtools/App/Features/ToolDetails/Presentation/ToolDetails/Subviews/ToolDetailsVersionsView.swift
@@ -35,22 +35,22 @@ struct ToolDetailsVersionsView: View {
                 text: viewModel.versionsMessage
             )
             
-            ForEach(viewModel.toolVersions) { toolVersion in
-                         
-                Rectangle()
-                    .frame(width: geometry.size.width, height: cardSpacing)
-                    .foregroundColor(.clear)
+            LazyVStack(alignment: .center, spacing: cardSpacing) {
                 
-                ToolDetailsVersionsCardView(
-                    viewModel: viewModel.toolVersionCardWillAppear(toolVersion: toolVersion),
-                    width: geometry.size.width - (cardHorizontalInsets * 2)
-                )
-                .padding(EdgeInsets(top: 0, leading: cardHorizontalInsets, bottom: 0, trailing: cardHorizontalInsets))
-                .onTapGesture {
-                    viewModel.toolVersionTapped(toolVersion: toolVersion)
-                    toolVersionTappedClosure()
+                ForEach(viewModel.toolVersions) { toolVersion in
+                             
+                    ToolDetailsVersionsCardView(
+                        viewModel: viewModel.toolVersionCardWillAppear(toolVersion: toolVersion),
+                        width: geometry.size.width - (cardHorizontalInsets * 2)
+                    )
+                    .padding(EdgeInsets(top: 0, leading: cardHorizontalInsets, bottom: 0, trailing: cardHorizontalInsets))
+                    .onTapGesture {
+                        viewModel.toolVersionTapped(toolVersion: toolVersion)
+                        toolVersionTappedClosure()
+                    }
                 }
             }
+            .padding(EdgeInsets(top: 15, leading: 0, bottom: 15, trailing: 0))
         }
     }
 }

--- a/godtools/App/Features/ToolDetails/Presentation/ToolDetails/Subviews/ToolDetailsVersionsView.swift
+++ b/godtools/App/Features/ToolDetails/Presentation/ToolDetails/Subviews/ToolDetailsVersionsView.swift
@@ -10,23 +10,30 @@ import SwiftUI
 
 struct ToolDetailsVersionsView: View {
         
+    private let geometry: GeometryProxy
     private let cardHorizontalInsets: CGFloat = 20
     private let cardSpacing: CGFloat = 15
     
-    @ObservedObject var viewModel: ToolDetailsViewModel
+    @ObservedObject private var viewModel: ToolDetailsViewModel
     
-    let geometry: GeometryProxy
-    let textEdgeInsets: EdgeInsets
     let toolVersionTappedClosure: (() -> Void)
+       
+    init(viewModel: ToolDetailsViewModel, geometry: GeometryProxy, toolVersionTappedClosure: @escaping (() -> Void)) {
         
+        self.viewModel = viewModel
+        self.geometry = geometry
+        self.toolVersionTappedClosure = toolVersionTappedClosure
+    }
+    
     var body: some View {
                 
         VStack(alignment: .leading, spacing: 0) {
             
-            Text(viewModel.versionsMessage)
-                .foregroundColor(ColorPalette.gtGrey.color)
-                .font(FontLibrary.sfProTextRegular.font(size: 16))
-                .padding(textEdgeInsets)
+            ToolDetailsSectionDescriptionTextView(
+                viewModel: viewModel,
+                geometry: geometry,
+                text: viewModel.versionsMessage
+            )
             
             ForEach(viewModel.toolVersions) { toolVersion in
                          

--- a/godtools/App/Features/ToolDetails/Presentation/ToolDetails/ToolDetailsView.swift
+++ b/godtools/App/Features/ToolDetails/Presentation/ToolDetails/ToolDetailsView.swift
@@ -10,10 +10,11 @@ import SwiftUI
 
 struct ToolDetailsView: View {
     
+    static let sectionDescriptionTextInsets: EdgeInsets = EdgeInsets(top: 0, leading: 30, bottom: 0, trailing: 30)
+    
     private static let headerViewId: String = "HeaderViewId"
     
     private let contentInsets: EdgeInsets = EdgeInsets(top: 0, leading: 40, bottom: 0, trailing: 40)
-    private let sectionTextInsets: EdgeInsets = EdgeInsets(top: 0, leading: 30, bottom: 0, trailing: 30)
     
     @State private var selectedSegmentIndex: Int = 0
     
@@ -85,14 +86,12 @@ struct ToolDetailsView: View {
              switch viewModel.selectedSegment {
              
              case .about:
-                 ToolDetailsAboutView(viewModel: viewModel, width: contentWidth)
-                     .padding(sectionTextInsets)
+                 ToolDetailsAboutView(viewModel: viewModel, geometry: geometry)
              
              case .versions:
                  ToolDetailsVersionsView(
                     viewModel: viewModel,
                     geometry: geometry,
-                    textEdgeInsets: sectionTextInsets,
                     toolVersionTappedClosure: toolVersionTappedClosure
                  )
              }

--- a/godtools/App/Features/ToolDetails/Presentation/ToolDetails/ToolDetailsView.swift
+++ b/godtools/App/Features/ToolDetails/Presentation/ToolDetails/ToolDetailsView.swift
@@ -13,6 +13,7 @@ struct ToolDetailsView: View {
     private static let headerViewId: String = "HeaderViewId"
     
     private let contentInsets: EdgeInsets = EdgeInsets(top: 0, leading: 40, bottom: 0, trailing: 40)
+    private let sectionTextInsets: EdgeInsets = EdgeInsets(top: 0, leading: 30, bottom: 0, trailing: 30)
     
     @State private var selectedSegmentIndex: Int = 0
     
@@ -85,12 +86,13 @@ struct ToolDetailsView: View {
              
              case .about:
                  ToolDetailsAboutView(viewModel: viewModel, width: contentWidth)
-                     .padding(EdgeInsets(top: 0, leading: contentInsets.leading, bottom: 0, trailing: contentInsets.trailing))
+                     .padding(sectionTextInsets)
              
              case .versions:
                  ToolDetailsVersionsView(
                     viewModel: viewModel,
                     geometry: geometry,
+                    textEdgeInsets: sectionTextInsets,
                     toolVersionTappedClosure: toolVersionTappedClosure
                  )
              }

--- a/godtools/App/Features/ToolDetails/Presentation/ToolDetails/ToolDetailsView.swift
+++ b/godtools/App/Features/ToolDetails/Presentation/ToolDetails/ToolDetailsView.swift
@@ -86,7 +86,10 @@ struct ToolDetailsView: View {
              switch viewModel.selectedSegment {
              
              case .about:
-                 ToolDetailsAboutView(viewModel: viewModel, geometry: geometry)
+                 ToolDetailsAboutView(
+                    viewModel: viewModel,
+                    geometry: geometry
+                 )
              
              case .versions:
                  ToolDetailsVersionsView(

--- a/godtools/App/Share/SwiftUI Views/TextWithLinks/TextWithLinks.swift
+++ b/godtools/App/Share/SwiftUI Views/TextWithLinks/TextWithLinks.swift
@@ -17,9 +17,10 @@ struct TextWithLinks: UIViewRepresentable {
     private let lineSpacing: CGFloat?
     private let width: CGFloat
     private let linkTextColor: UIColor
+    private let adjustsFontForContentSizeCategory: Bool
     private let didInteractWithUrlClosure: ((_ url: URL) -> Bool)
         
-    init(text: String, textColor: UIColor, font: UIFont?, lineSpacing: CGFloat?, width: CGFloat, linkTextColor: UIColor = .systemBlue, didInteractWithUrlClosure: @escaping ((_ url: URL) -> Bool)) {
+    init(text: String, textColor: UIColor, font: UIFont?, lineSpacing: CGFloat?, width: CGFloat, linkTextColor: UIColor = .systemBlue, adjustsFontForContentSizeCategory: Bool = false, didInteractWithUrlClosure: @escaping ((_ url: URL) -> Bool)) {
         
         self.text = text
         self.textColor = textColor
@@ -27,6 +28,7 @@ struct TextWithLinks: UIViewRepresentable {
         self.lineSpacing = lineSpacing
         self.width = width
         self.linkTextColor = linkTextColor
+        self.adjustsFontForContentSizeCategory = adjustsFontForContentSizeCategory
         self.didInteractWithUrlClosure = didInteractWithUrlClosure
     }
     
@@ -65,6 +67,11 @@ struct TextWithLinks: UIViewRepresentable {
         textView.isUserInteractionEnabled = true
         textView.dataDetectorTypes = .link
         textView.linkTextAttributes = [.foregroundColor: linkTextColor]
+        
+        if adjustsFontForContentSizeCategory, let font = self.font {
+            textView.font = UIFontMetrics(forTextStyle: .body).scaledFont(for: font)
+            textView.adjustsFontForContentSizeCategory = true
+        }
         
         textView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         textView.setContentCompressionResistancePriority(.defaultLow, for: .vertical)


### PR DESCRIPTION
This PR makes follow updates to ToolDetailsView.swift:
- Updates TextWithLinks.swift (UITextView) to support dynamic type and enables About text in ToolDetails to support dynamic type.
- Adjusts About text and Versions text padding to match to edge of screen.
- Add ToolDetailsSectionDescriptionTextView to share between About and Versions sections.
