### PR TITLE
GT-1997 parse manifest async

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -13,7 +13,7 @@ use_frameworks!
 def shared_pods
   
   # CruGlobal pods
-  pod 'GodToolsShared', '0.8.3-SNAPSHOT'
+  pod 'GodToolsShared', '0.9.0-SNAPSHOT'
 end
 
 target 'godtools' do

--- a/Podfile
+++ b/Podfile
@@ -13,7 +13,7 @@ use_frameworks!
 def shared_pods
   
   # CruGlobal pods
-  pod 'GodToolsShared', '0.8.2'
+  pod 'GodToolsShared', '0.8.3-SNAPSHOT'
 end
 
 target 'godtools' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -6,14 +6,14 @@ PODS:
   - FBSDKCoreKit/Core (8.2.0):
     - FBSDKCoreKit/Basics
   - Fuzi (3.1.3)
-  - GodToolsShared (0.8.2)
+  - GodToolsShared (0.8.3-SNAPSHOT)
   - GoogleConversionTracking (3.4.0)
   - Starscream (4.0.4)
 
 DEPENDENCIES:
   - FBSDKCoreKit (~> 8.2.0)
   - Fuzi (~> 3.1.1)
-  - GodToolsShared (= 0.8.2)
+  - GodToolsShared (= 0.8.3-SNAPSHOT)
   - GoogleConversionTracking (~> 3.4.0)
   - Starscream (~> 4.0.0)
 
@@ -29,10 +29,10 @@ SPEC REPOS:
 SPEC CHECKSUMS:
   FBSDKCoreKit: 4afd6ff53d8133a433dbcda44451c9498f8c6ce4
   Fuzi: 4c10d6449c0b49a85cd75b13844c559c0fc71220
-  GodToolsShared: 0d33c22c140466d37b87643148931016debb6098
+  GodToolsShared: 4f1ae76d12a2e9bd86d01b7777fc2019e0e993ea
   GoogleConversionTracking: ca8c89abda2bd28bb6472b316eeb4ece9264e279
   Starscream: 5178aed56b316f13fa3bc55694e583d35dd414d9
 
-PODFILE CHECKSUM: e84bd94f9844248d3240982d23f0a07dc11744e6
+PODFILE CHECKSUM: cd4e733e8b09c63cdf3b748590f830b868ab210f
 
 COCOAPODS: 1.12.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -6,14 +6,14 @@ PODS:
   - FBSDKCoreKit/Core (8.2.0):
     - FBSDKCoreKit/Basics
   - Fuzi (3.1.3)
-  - GodToolsShared (0.8.3-SNAPSHOT)
+  - GodToolsShared (0.9.0-SNAPSHOT)
   - GoogleConversionTracking (3.4.0)
   - Starscream (4.0.4)
 
 DEPENDENCIES:
   - FBSDKCoreKit (~> 8.2.0)
   - Fuzi (~> 3.1.1)
-  - GodToolsShared (= 0.8.3-SNAPSHOT)
+  - GodToolsShared (= 0.9.0-SNAPSHOT)
   - GoogleConversionTracking (~> 3.4.0)
   - Starscream (~> 4.0.0)
 
@@ -29,10 +29,10 @@ SPEC REPOS:
 SPEC CHECKSUMS:
   FBSDKCoreKit: 4afd6ff53d8133a433dbcda44451c9498f8c6ce4
   Fuzi: 4c10d6449c0b49a85cd75b13844c559c0fc71220
-  GodToolsShared: 4f1ae76d12a2e9bd86d01b7777fc2019e0e993ea
+  GodToolsShared: 2ea6e6f53f11eca4ed6dc56c7d4db9da727f867a
   GoogleConversionTracking: ca8c89abda2bd28bb6472b316eeb4ece9264e279
   Starscream: 5178aed56b316f13fa3bc55694e583d35dd414d9
 
-PODFILE CHECKSUM: cd4e733e8b09c63cdf3b748590f830b868ab210f
+PODFILE CHECKSUM: ffb5817436d6bfe85e6940eb45bbdf8f2fbdbb08
 
 COCOAPODS: 1.12.0

--- a/godtools/App/Features/ToolDetails/Presentation/ToolDetails/ToolDetailsViewModel.swift
+++ b/godtools/App/Features/ToolDetails/Presentation/ToolDetails/ToolDetailsViewModel.swift
@@ -194,7 +194,7 @@ class ToolDetailsViewModel: ObservableObject {
             translationsRepository: translationsRepository
         )
         
-        hidesLearnToShareCancellable = getToolTranslationsFilesUseCase.getToolTranslationsFiles(filter: .downloadManifestForTipsCount, determineToolTranslationsToDownload: determineToolTranslationsToDownload, downloadStarted: {
+        hidesLearnToShareCancellable = getToolTranslationsFilesUseCase.getToolTranslationsFilesPublisher(filter: .downloadManifestForTipsCount, determineToolTranslationsToDownload: determineToolTranslationsToDownload, downloadStarted: {
             
         })
         .receiveOnMain()

--- a/godtools/App/Flows/DownloadToolTranslations/DownloadToolTranslationsFlow.swift
+++ b/godtools/App/Flows/DownloadToolTranslations/DownloadToolTranslationsFlow.swift
@@ -33,10 +33,12 @@ class DownloadToolTranslationsFlow: Flow {
         self.getToolTranslationsFilesUseCase = appDiContainer.domainLayer.getToolTranslationsFilesUseCase()
         self.didDownloadToolTranslations = didDownloadToolTranslations
         
-        getToolTranslationsFilesUseCase.getToolTranslationsFiles(filter: .downloadManifestAndRelatedFilesForRenderer, determineToolTranslationsToDownload: determineToolTranslationsToDownload, downloadStarted: { [weak self] in
-            self?.navigateToDownloadTool()
+        getToolTranslationsFilesUseCase.getToolTranslationsFilesPublisher(filter: .downloadManifestAndRelatedFilesForRenderer, determineToolTranslationsToDownload: determineToolTranslationsToDownload, downloadStarted: { [weak self] in
+            DispatchQueue.main.async { [weak self] in
+                self?.navigateToDownloadTool()
+            }
         })
-        .receive(on: DispatchQueue.main)
+        .receiveOnMain()
         .sink(receiveCompletion: { [weak self] completed in
             
             switch completed {

--- a/godtools/App/Share/Data/TranslationsRepository/TranslationsRepository.swift
+++ b/godtools/App/Share/Data/TranslationsRepository/TranslationsRepository.swift
@@ -65,7 +65,7 @@ extension TranslationsRepository {
         
         let manifestParser: TranslationManifestParser = TranslationManifestParser.getManifestParser(type: manifestParserType, infoPlist: infoPlist, resourcesFileCache: resourcesFileCache)
         
-        return manifestParser.parse(manifestName: translation.manifestName).publisher
+        return manifestParser.parsePublisher(manifestName: translation.manifestName)
             .flatMap({ manifest -> AnyPublisher<TranslationManifestFileDataModel, Error> in
             
                 guard includeRelatedFiles else {
@@ -147,7 +147,7 @@ extension TranslationsRepository {
                 
                 let manifestParser: TranslationManifestParser = TranslationManifestParser.getManifestParser(type: manifestParserType, infoPlist: self.infoPlist, resourcesFileCache: self.resourcesFileCache)
                 
-                return manifestParser.parse(manifestName: translation.manifestName).publisher
+                return manifestParser.parsePublisher(manifestName: translation.manifestName)
                     .mapError({ error in
                         return  .otherError(error: error)
                     })
@@ -273,7 +273,7 @@ extension TranslationsRepository {
                 
                 let manifestParser: TranslationManifestParser = TranslationManifestParser.getManifestParser(type: .manifestOnly, infoPlist: self.infoPlist, resourcesFileCache: self.resourcesFileCache)
                 
-                return manifestParser.parse(manifestName: translation.manifestName).publisher
+                return manifestParser.parsePublisher(manifestName: translation.manifestName)
                     .mapError({ error in
                         return .otherError(error: error)
                     })

--- a/godtools/App/Share/Domain/UseCases/GetToolTranslationsFilesUseCase/GetToolTranslationsFilesUseCase.swift
+++ b/godtools/App/Share/Domain/UseCases/GetToolTranslationsFilesUseCase/GetToolTranslationsFilesUseCase.swift
@@ -28,7 +28,7 @@ class GetToolTranslationsFilesUseCase {
         self.getLanguageUseCase = getLanguageUseCase
     }
     
-    func getToolTranslationsFiles(filter: GetToolTranslationsFilesFilter, determineToolTranslationsToDownload: DetermineToolTranslationsToDownloadType, downloadStarted: (() -> Void)?) -> AnyPublisher<ToolTranslationsDomainModel, URLResponseError> {
+    func getToolTranslationsFilesPublisher(filter: GetToolTranslationsFilesFilter, determineToolTranslationsToDownload: DetermineToolTranslationsToDownloadType, downloadStarted: (() -> Void)?) -> AnyPublisher<ToolTranslationsDomainModel, URLResponseError> {
                 
         let manifestParserType: TranslationManifestParserType
         let includeRelatedFiles: Bool
@@ -105,7 +105,6 @@ class GetToolTranslationsFilesUseCase {
                 return Just(maintainTranslationDownloadOrder).setFailureType(to: URLResponseError.self)
                     .eraseToAnyPublisher()
             })
-            .receive(on: DispatchQueue.main) // NOTE: Need to switch to main queue and parse manifests again because Manifests can't be passed across threads at this time. ~Levi
             .flatMap({ translationManifests -> AnyPublisher<[TranslationManifestFileDataModel], URLResponseError> in
                     
                 let translations: [TranslationModel] = translationManifests.map({ $0.translation })


### PR DESCRIPTION
Hey @frett was able to use async.  This PR includes:

- Replace IosManifestParser with ManifestParser to parse async.
- Needed to ensure parse async is called from main thread.
- Also on the getToolTranslationsFilesPublisher there is a closure downloadStarted which needed to be dispatched to the main thread in DownloadToolTranslationsFlow.swift.