### PR TITLE
GT Remove SharedAppleExtensionsTests target from tests

### DIFF
--- a/godtools.xcodeproj/xcshareddata/xcschemes/GodTools-Production.xcscheme
+++ b/godtools.xcodeproj/xcshareddata/xcschemes/GodTools-Production.xcscheme
@@ -76,16 +76,6 @@
                ReferencedContainer = "container:godtools.xcodeproj">
             </BuildableReference>
          </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "SharedAppleExtensionsTests"
-               BuildableName = "SharedAppleExtensionsTests"
-               BlueprintName = "SharedAppleExtensionsTests"
-               ReferencedContainer = "container:godtools/Packages/Common/SharedAppleExtensions">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/godtools.xcodeproj/xcshareddata/xcschemes/godtools.xcscheme
+++ b/godtools.xcodeproj/xcshareddata/xcschemes/godtools.xcscheme
@@ -76,16 +76,6 @@
                ReferencedContainer = "container:godtools.xcodeproj">
             </BuildableReference>
          </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "SharedAppleExtensionsTests"
-               BuildableName = "SharedAppleExtensionsTests"
-               BlueprintName = "SharedAppleExtensionsTests"
-               ReferencedContainer = "container:godtools/Packages/Common/SharedAppleExtensions">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction


### PR DESCRIPTION
Removed SharedAppleExtensionsTests from the godtools and GodToolsProduction schemes.
 
SharedAppleExtensions swift package has been removed and those tests are now part of the godtoolsTests target.