### PR TITLE
GT Upload code coverage reports to CruGlobal codecov account

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,13 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 1
+    patch:
+      default:
+        target: 0%
+        threshold: 1
+codecov:
+  max_report_age: off
+github_checks:
+  annotations: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,6 +67,8 @@ jobs:
         with:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
+          xcode: true
+          xcode_archive_path: '.build/test-results/GodTools-Production.xcresult'
           verbose: true
 
       - name: Configure AWS credentials

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,6 +62,13 @@ jobs:
       - name: Run Tests
         run: bundle exec fastlane cru_shared_lane_run_tests
 
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true
+
       - name: Configure AWS credentials
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: aws-actions/configure-aws-credentials@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,15 +62,6 @@ jobs:
       - name: Run Tests
         run: bundle exec fastlane cru_shared_lane_run_tests
 
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          fail_ci_if_error: true
-          token: ${{ secrets.CODECOV_TOKEN }}
-          xcode: true
-          xcode_archive_path: '.build/test-results/GodTools-Production.xcresult'
-          verbose: true
-
       - name: Configure AWS credentials
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: aws-actions/configure-aws-credentials@v2

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@ source 'https://rubygems.org'
 
 gem 'fastlane'
 gem 'cocoapods', '~> 1.12'
-gem 'xcov', '~> 1.8'
 gem 'xcode-install', '~> 2.8'
 
 eval_gemfile('./fastlane/Pluginfile')

--- a/godtools.xcodeproj/xcshareddata/xcschemes/GodTools-Production.xcscheme
+++ b/godtools.xcodeproj/xcshareddata/xcschemes/GodTools-Production.xcscheme
@@ -54,7 +54,8 @@
       buildConfiguration = "Production"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/godtools.xcodeproj/xcshareddata/xcschemes/GodTools-Production.xcscheme
+++ b/godtools.xcodeproj/xcshareddata/xcschemes/GodTools-Production.xcscheme
@@ -55,7 +55,17 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4F5732881EA69CF00082035C"
+            BuildableName = "godtools.app"
+            BlueprintName = "godtools"
+            ReferencedContainer = "container:godtools.xcodeproj">
+         </BuildableReference>
+      </CodeCoverageTargets>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/godtools.xcodeproj/xcshareddata/xcschemes/godtools.xcscheme
+++ b/godtools.xcodeproj/xcshareddata/xcschemes/godtools.xcscheme
@@ -55,7 +55,8 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -65,6 +66,15 @@
             ReferencedContainer = "container:godtools.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4F5732881EA69CF00082035C"
+            BuildableName = "godtools.app"
+            BlueprintName = "godtools"
+            ReferencedContainer = "container:godtools.xcodeproj">
+         </BuildableReference>
+      </CodeCoverageTargets>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/godtools.xcodeproj/xcshareddata/xcschemes/godtools.xcscheme
+++ b/godtools.xcodeproj/xcshareddata/xcschemes/godtools.xcscheme
@@ -51,7 +51,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Production"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
@@ -79,7 +79,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Production"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
@@ -124,7 +124,7 @@
       </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
-      buildConfiguration = "Debug">
+      buildConfiguration = "Production">
    </AnalyzeAction>
    <ArchiveAction
       buildConfiguration = "Release"


### PR DESCRIPTION
This PR is enabling code coverage reports to be uploaded to codecov under CruGlobal/godtools-swift

- Point ```godtools``` scheme Tests to Production build configuration.
- Add upload codecov reports in workflow.
- Enable godtools-swift in codecov CruGlobal account https://app.codecov.io/gh/CruGlobal/godtools-swift and add token to GitHub secrets