### PR TITLE
GT-2027 Integrate Apple Sign In

### DIFF
--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -948,6 +948,7 @@
 		D1FF263825BA0C0E00C825DB /* FirebaseInAppMessagingType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1FF263725BA0C0E00C825DB /* FirebaseInAppMessagingType.swift */; };
 		D1FF263E25BA0C1C00C825DB /* FirebaseInAppMessaging.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1FF263D25BA0C1C00C825DB /* FirebaseInAppMessaging.swift */; };
 		D40393C628D36F1400C098BD /* LanguageAvailabilityDomainModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D40393C528D36F1400C098BD /* LanguageAvailabilityDomainModel.swift */; };
+		D407F72B2A13FE23009773F9 /* AppleAuthentication+AuthenticationProviderInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = D407F72A2A13FE23009773F9 /* AppleAuthentication+AuthenticationProviderInterface.swift */; };
 		D409F2A8291D9C2300D9D2FE /* MobileContentApiAuthSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = D409F2A7291D9C2300D9D2FE /* MobileContentApiAuthSession.swift */; };
 		D409F2AA292559F100D9D2FE /* MobileContentAuthTokenError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D409F2A9292559F100D9D2FE /* MobileContentAuthTokenError.swift */; };
 		D409F2AD2928110E00D9D2FE /* UserDetailsAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = D409F2AC2928110E00D9D2FE /* UserDetailsAPI.swift */; };
@@ -2076,6 +2077,7 @@
 		D1FF263725BA0C0E00C825DB /* FirebaseInAppMessagingType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseInAppMessagingType.swift; sourceTree = "<group>"; };
 		D1FF263D25BA0C1C00C825DB /* FirebaseInAppMessaging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseInAppMessaging.swift; sourceTree = "<group>"; };
 		D40393C528D36F1400C098BD /* LanguageAvailabilityDomainModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageAvailabilityDomainModel.swift; sourceTree = "<group>"; };
+		D407F72A2A13FE23009773F9 /* AppleAuthentication+AuthenticationProviderInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppleAuthentication+AuthenticationProviderInterface.swift"; sourceTree = "<group>"; };
 		D409F2A7291D9C2300D9D2FE /* MobileContentApiAuthSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileContentApiAuthSession.swift; sourceTree = "<group>"; };
 		D409F2A9292559F100D9D2FE /* MobileContentAuthTokenError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileContentAuthTokenError.swift; sourceTree = "<group>"; };
 		D409F2AC2928110E00D9D2FE /* UserDetailsAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDetailsAPI.swift; sourceTree = "<group>"; };
@@ -3904,6 +3906,7 @@
 				455F04762A0006DE00536CB9 /* AuthenticationProviderAccessToken.swift */,
 				455F04722A0002F100536CB9 /* AuthenticationProviderInterface.swift */,
 				455F047E2A0038B000536CB9 /* AuthenticationProviderType.swift */,
+				D407F72A2A13FE23009773F9 /* AppleAuthentication+AuthenticationProviderInterface.swift */,
 				455F04742A00036400536CB9 /* FacebookAuthentication+AuthenticationProviderInterface.swift */,
 			);
 			path = AuthenticationProviders;
@@ -8319,6 +8322,7 @@
 				4533C4CB28AC2C2400F9628B /* StoreInitialFavoritedToolsUseCase.swift in Sources */,
 				450D7B0428E32965006C3FDF /* DownloadedTranslationDataModel.swift in Sources */,
 				454D1C4227A4BDD700ED7F99 /* HorizontallyCenteredCollectionViewCellSize.swift in Sources */,
+				D407F72B2A13FE23009773F9 /* AppleAuthentication+AuthenticationProviderInterface.swift in Sources */,
 				455583CF269F2DA500C3FF14 /* MobileContentFormView.swift in Sources */,
 				45B365322885963A0012BE53 /* TranslationManifestParserFactory.swift in Sources */,
 				45D63EA5288F77D4009B4610 /* ResourceModel.swift in Sources */,

--- a/godtools/App/Share/Data/UserAuthentication/AuthenticationProviders/AppleAuthentication+AuthenticationProviderInterface.swift
+++ b/godtools/App/Share/Data/UserAuthentication/AuthenticationProviders/AppleAuthentication+AuthenticationProviderInterface.swift
@@ -1,0 +1,55 @@
+//
+//  AppleAuthentication+AuthenticationProviderInterface.swift
+//  godtools
+//
+//  Created by Rachael Skeath on 5/16/23.
+//  Copyright © 2023 Cru. All rights reserved.
+//
+
+import Foundation
+import UIKit
+import SocialAuthentication
+import Combine
+
+extension AppleAuthentication: AuthenticationProviderInterface {
+    func getPersistedAccessToken() -> AuthenticationProviderAccessToken? {
+        
+        // TODO: - access token renewal will come through MobileContentAPI?
+        
+        return nil
+    }
+    
+    func authenticatePublisher(presentingViewController: UIViewController) -> AnyPublisher<AuthenticationProviderAccessToken?, Error> {
+        
+        return authenticatePublisher()
+            .map { (response: AppleAuthenticationResponse) in
+                
+                guard let idToken = response.identityToken else {
+                    return nil
+                }
+                
+                // TODO: - include name once AppleAuth is updated
+                return AuthenticationProviderAccessToken.apple(
+                    idToken: idToken,
+                    givenName: "first name",
+                    familyName: "last name"
+                )
+            }
+            .eraseToAnyPublisher()
+    }
+    
+    func renewAccessTokenPublisher() -> AnyPublisher<AuthenticationProviderAccessToken, Error> {
+        
+        // TODO: - access token renewal will come through MobileContentAPI?
+        
+        return Just(AuthenticationProviderAccessToken.apple(idToken: "", givenName: "", familyName: ""))
+            .setFailureType(to: Error.self)
+            .eraseToAnyPublisher()
+    }
+    
+    func signOutPublisher() -> AnyPublisher<Void, Error> {
+        
+        return Just(()).setFailureType(to: Error.self)
+            .eraseToAnyPublisher()
+    }
+}


### PR DESCRIPTION
Hey @levieggertcru, I went ahead and created the provider interface extension for AppleAuthentication, but I know we had talked about getting the token renewal from MobileContentAPI.  Is that still the way it's going to work?  I'm assuming work needs to be done on that end still.