### PR TITLE
GT-2012 Add getAuthUserPublisher to AuthenticationProviderInterface

### DIFF
--- a/godtools/App/Features/Menu/Domain/UseCases/AuthenticateUserUseCase/AuthenticateUserUseCase.swift
+++ b/godtools/App/Features/Menu/Domain/UseCases/AuthenticateUserUseCase/AuthenticateUserUseCase.swift
@@ -27,15 +27,17 @@ class AuthenticateUserUseCase {
         // TODO: Uncomment and implement in GT-2012. ~Levi
         
         return authenticateByAuthTypePublisher(provider: provider, policy: policy)
-            .flatMap({ (success: Bool) -> AnyPublisher<AuthUserDomainModel, Error> in
+            .flatMap({ (success: Bool) -> AnyPublisher<AuthUserDomainModel?, Error> in
                                 
                 return self.userAuthentication.getAuthUserPublisher()
                     .eraseToAnyPublisher()
             })
-            .flatMap({ (authUser: AuthUserDomainModel) -> AnyPublisher<Bool, Error> in
+            .flatMap({ (authUser: AuthUserDomainModel?) -> AnyPublisher<Bool, Error> in
                 
-                self.postEmailSignUp(authUser: authUser)
-                self.setAnalyticsUserProperties(authUser: authUser)
+                if let authUser = authUser {
+                    self.postEmailSignUp(authUser: authUser)
+                    self.setAnalyticsUserProperties(authUser: authUser)
+                }
                 
                 return Just(true).setFailureType(to: Error.self)
                     .eraseToAnyPublisher()

--- a/godtools/App/Features/Menu/Domain/UseCases/GetUserAccountProfileNameUseCase/GetUserAccountProfileNameUseCase.swift
+++ b/godtools/App/Features/Menu/Domain/UseCases/GetUserAccountProfileNameUseCase/GetUserAccountProfileNameUseCase.swift
@@ -18,29 +18,25 @@ class GetUserAccountProfileNameUseCase {
         self.userAuthentication = userAuthentication
     }
     
-    private func getEmptyAuthUser() -> AuthUserDomainModel {
-        return AuthUserDomainModel(email: "", firstName: nil, grMasterPersonId: nil, lastName: nil, ssoGuid: nil)
-    }
-    
     func getProfileNamePublisher() -> AnyPublisher<AccountProfileNameDomainModel, Never> {
      
         return userAuthentication.getAuthUserPublisher()
-            .catch({ (error: Error) -> AnyPublisher<AuthUserDomainModel, Never> in
+            .catch({ (error: Error) -> AnyPublisher<AuthUserDomainModel?, Never> in
                 
-                return Just(self.getEmptyAuthUser())
+                return Just(nil)
                     .eraseToAnyPublisher()
             })
-            .flatMap({ (authUser: AuthUserDomainModel) -> AnyPublisher<AccountProfileNameDomainModel, Never> in
+            .flatMap({ (authUser: AuthUserDomainModel?) -> AnyPublisher<AccountProfileNameDomainModel, Never> in
                                 
                 let profileName: String
                 
-                if let firstName = authUser.firstName, let lastName = authUser.lastName {
+                if let firstName = authUser?.firstName, let lastName = authUser?.lastName {
                     profileName = firstName + " " + lastName
                 }
-                else if let firstName = authUser.firstName {
+                else if let firstName = authUser?.firstName {
                     profileName = firstName
                 }
-                else if let lastName = authUser.lastName {
+                else if let lastName = authUser?.lastName {
                     profileName = lastName
                 }
                 else {

--- a/godtools/App/Share/Data/UserAuthentication/AuthenticationProviders/AuthenticationProviderInterface.swift
+++ b/godtools/App/Share/Data/UserAuthentication/AuthenticationProviders/AuthenticationProviderInterface.swift
@@ -16,4 +16,5 @@ protocol AuthenticationProviderInterface {
     func authenticatePublisher(presentingViewController: UIViewController) -> AnyPublisher<AuthenticationProviderAccessToken?, Error>
     func renewAccessTokenPublisher() -> AnyPublisher<AuthenticationProviderAccessToken, Error>
     func signOutPublisher() -> AnyPublisher<Void, Error>
+    func getAuthUserPublisher() -> AnyPublisher<AuthUserDomainModel?, Error>
 }

--- a/godtools/App/Share/Data/UserAuthentication/AuthenticationProviders/FacebookAuthentication+AuthenticationProviderInterface.swift
+++ b/godtools/App/Share/Data/UserAuthentication/AuthenticationProviders/FacebookAuthentication+AuthenticationProviderInterface.swift
@@ -10,6 +10,7 @@ import Foundation
 import UIKit
 import SocialAuthentication
 import Combine
+import FBSDKLoginKit
 
 extension FacebookAuthentication: AuthenticationProviderInterface {
     
@@ -59,5 +60,36 @@ extension FacebookAuthentication: AuthenticationProviderInterface {
         
         return Just(()).setFailureType(to: Error.self)
             .eraseToAnyPublisher()
+    }
+    
+    func getAuthUserPublisher() -> AnyPublisher<AuthUserDomainModel?, Error> {
+                
+        if let profile = getCurrentUserProfile() {
+                    
+            return Just(mapProfileToAuthUser(profile: profile)).setFailureType(to: Error.self)
+                .eraseToAnyPublisher()
+        }
+        
+        return loadUserProfilePublisher()
+            .map { (profile: Profile?) in
+                
+                if let profile = profile {
+                    return self.mapProfileToAuthUser(profile: profile)
+                }
+                
+                return nil
+            }
+            .eraseToAnyPublisher()
+    }
+    
+    private func mapProfileToAuthUser(profile: Profile) -> AuthUserDomainModel {
+        
+        return  AuthUserDomainModel(
+            email: profile.email ?? "",
+            firstName: profile.firstName,
+            grMasterPersonId: nil,
+            lastName: profile.lastName,
+            ssoGuid: nil
+        )
     }
 }

--- a/godtools/App/Share/Data/UserAuthentication/AuthenticationProviders/GoogleAuthentication+AuthenticationProviderInterface.swift
+++ b/godtools/App/Share/Data/UserAuthentication/AuthenticationProviders/GoogleAuthentication+AuthenticationProviderInterface.swift
@@ -10,6 +10,7 @@ import Foundation
 import UIKit
 import SocialAuthentication
 import Combine
+import GoogleSignIn
 
 extension GoogleAuthentication: AuthenticationProviderInterface {
     
@@ -60,5 +61,33 @@ extension GoogleAuthentication: AuthenticationProviderInterface {
         
         return Just(()).setFailureType(to: Error.self)
             .eraseToAnyPublisher()
+    }
+    
+    func getAuthUserPublisher() -> AnyPublisher<AuthUserDomainModel?, Error> {
+        
+        let authUser: AuthUserDomainModel?
+        
+        if let profile = getCurrentUserProfile() {
+        
+            authUser = mapProfileToAuthUser(profile: profile)
+        }
+        else {
+            
+            authUser = nil
+        }
+        
+        return Just(authUser).setFailureType(to: Error.self)
+            .eraseToAnyPublisher()
+    }
+    
+    private func mapProfileToAuthUser(profile: GIDProfileData) -> AuthUserDomainModel {
+        
+        return AuthUserDomainModel(
+            email: profile.email,
+            firstName: profile.givenName,
+            grMasterPersonId: nil,
+            lastName: profile.familyName,
+            ssoGuid: nil
+        )
     }
 }

--- a/godtools/App/Share/Data/UserAuthentication/UserAuthentication.swift
+++ b/godtools/App/Share/Data/UserAuthentication/UserAuthentication.swift
@@ -64,11 +64,14 @@ class UserAuthentication {
             .eraseToAnyPublisher()
     }
     
-    func getAuthUserPublisher() -> AnyPublisher<AuthUserDomainModel, Error> {
+    func getAuthUserPublisher() -> AnyPublisher<AuthUserDomainModel?, Error> {
         
-        let authUser = AuthUserDomainModel(email: "", firstName: nil, grMasterPersonId: nil, lastName: nil, ssoGuid: nil)
+        guard let lastAuthProvider = getLastAuthenticatedProvider() else {
+            return Just(nil).setFailureType(to: Error.self)
+                .eraseToAnyPublisher()
+        }
         
-        return Just(authUser).setFailureType(to: Error.self)
+        return lastAuthProvider.getAuthUserPublisher()
             .eraseToAnyPublisher()
     }
     
@@ -76,6 +79,7 @@ class UserAuthentication {
     
         return getAuthenticationProvider(provider: provider)
             .flatMap({ (provider: AuthenticationProviderInterface) -> AnyPublisher<AuthenticationProviderAccessToken?, Error> in
+                
                 return provider.authenticatePublisher(presentingViewController: fromViewController)
             })
             .map { (providerAccessToken: AuthenticationProviderAccessToken?) in


### PR DESCRIPTION
Changes in this PR:

- Add ```func getAuthUserPublisher() -> AnyPublisher<AuthUserDomainModel?, Error>``` to AuthenticationProviderInterface.
- Implement getAuthUserPublisher in Facebook and Google Authentication providers.