### PR TITLE
GT-Enable code coverage in fastlane run tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
         run: bundle exec pod install --repo-update
 
       - name: Run Tests
-        run: bundle exec fastlane cru_shared_lane_run_tests
+        run: bundle exec fastlane cru_shared_lane_run_tests code_coverage:true output_directory:'./fastlane/run_tests_output_directory'
 
       - name: Configure AWS credentials
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
@@ -112,6 +112,13 @@ jobs:
         with:
           name: xcode-logs
           path: "/Users/runner/Library/Developer/Xcode/DerivedData/Logs/godtools-*/**"
+
+      - name: Archive Fastlane Run Tests Output Directory
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: fastlane-run-tests-reports
+          path: "./fastlane/run_tests_output_directory/**"
 
       - name: Archive Fastlane Gym Logs
         if: always()


### PR DESCRIPTION
- Enable code coverage and set output directory in fastlane run_tests
- Attempt to archive fastlane run_tests output directory

Hey @frett going to see if I can use the upload artifact to upload files in the fastlane run_tests output directory.  I'm curious to see what will be in there.