### PR TITLE
GT Add team id to fastlane env

### DIFF
--- a/fastlane/.env.default
+++ b/fastlane/.env.default
@@ -7,6 +7,7 @@ RUN_TESTS_SCHEME = "godtools"
 CODE_SIGNING_APP_BUNDLE_IDS = "org.cru.godtools"
 CODE_SIGNING_PROVISIONING_PROFILE_NAMES = "match AppStore org.cru.godtools"
 CODE_SIGNING_TARGETS = "godtools"
+CODE_SIGNING_TEAM_ID = "DQ48D9BF2V"
 
 ## Match
 MATCH_GIT_BRANCH = "master"


### PR DESCRIPTION
Adding team id to fastlane env.  Will need for code signing and testflight deployment.

https://github.com/CruGlobal/cru-fastlane-files/pull/37