### PR TITLE
GT-2026 update menu section after login

### DIFF
--- a/godtools/App/Features/Menu/Domain/UseCases/AuthenticateUserUseCase/AuthenticateUserUseCase.swift
+++ b/godtools/App/Features/Menu/Domain/UseCases/AuthenticateUserUseCase/AuthenticateUserUseCase.swift
@@ -23,9 +23,7 @@ class AuthenticateUserUseCase {
     }
     
     func authenticatePublisher(provider: AuthenticationProviderType, policy: AuthenticationPolicy) -> AnyPublisher<Bool, Error> {
-                
-        // TODO: Uncomment and implement in GT-2012. ~Levi
-        
+                        
         return authenticateByAuthTypePublisher(provider: provider, policy: policy)
             .flatMap({ (success: Bool) -> AnyPublisher<AuthUserDomainModel?, Error> in
                                 
@@ -46,9 +44,7 @@ class AuthenticateUserUseCase {
     }
     
     private func authenticateByAuthTypePublisher(provider: AuthenticationProviderType, policy: AuthenticationPolicy) -> AnyPublisher<Bool, Error> {
-                
-        // TODO: Implement in GT-2012. ~Levi
-                
+                                
         switch policy {
             
         case .renewAccessTokenElseAskUserToAuthenticate(let fromViewController):

--- a/godtools/App/Features/Menu/Presentation/LegacyMenu/LegacyMenuViewModel.swift
+++ b/godtools/App/Features/Menu/Presentation/LegacyMenu/LegacyMenuViewModel.swift
@@ -21,6 +21,7 @@ class LegacyMenuViewModel {
     private let analytics: AnalyticsContainer
     private let getOptInOnboardingTutorialAvailableUseCase: GetOptInOnboardingTutorialAvailableUseCase
     private let disableOptInOnboardingBannerUseCase: DisableOptInOnboardingBannerUseCase
+    private let authenticationCompletedSubject: PassthroughSubject<Void, Never> = PassthroughSubject()
     
     private var cancellables: Set<AnyCancellable> = Set()
     
@@ -49,6 +50,14 @@ class LegacyMenuViewModel {
         navTitle.accept(value: localizationServices.stringForMainBundle(key: "settings"))
                 
         reloadMenuDataSource()
+        
+        authenticationCompletedSubject
+            .receiveOnMain()
+            .sink { [weak self] _ in
+            
+                self?.reloadMenuDataSource()
+            }
+            .store(in: &cancellables)
     }
     
     private func getMenuAnalyticsScreenName () -> String {
@@ -283,7 +292,7 @@ extension LegacyMenuViewModel {
     }
     
     func loginTapped(fromViewController: UIViewController) {
-        flowDelegate?.navigate(step: .loginTappedFromMenu)
+        flowDelegate?.navigate(step: .loginTappedFromMenu(authenticationCompletedSubject: authenticationCompletedSubject))
     }
     
     func activityTapped() {
@@ -291,7 +300,7 @@ extension LegacyMenuViewModel {
     }
     
     func createAccountTapped(fromViewController: UIViewController) {
-        flowDelegate?.navigate(step: .createAccountTappedFromMenu)
+        flowDelegate?.navigate(step: .createAccountTappedFromMenu(authenticationCompletedSubject: authenticationCompletedSubject))
     }
     
     func logoutTapped(fromViewController: UIViewController) {

--- a/godtools/App/Features/Menu/Presentation/SocialSignIn/SocialSignInViewModel.swift
+++ b/godtools/App/Features/Menu/Presentation/SocialSignIn/SocialSignInViewModel.swift
@@ -14,6 +14,7 @@ class SocialSignInViewModel: ObservableObject {
     
     private let presentAuthViewController: UIViewController
     private let authenticationType: SocialSignInAuthenticationType
+    private let authenticationCompletedSubject: PassthroughSubject<Void, Never>
     private let authenticateUserUseCase: AuthenticateUserUseCase
     private let localizationServices: LocalizationServices
     
@@ -45,11 +46,12 @@ class SocialSignInViewModel: ObservableObject {
         )
     }()
     
-    init(flowDelegate: FlowDelegate, presentAuthViewController: UIViewController, authenticationType: SocialSignInAuthenticationType, authenticateUserUseCase: AuthenticateUserUseCase, localizationServices: LocalizationServices) {
+    init(flowDelegate: FlowDelegate, presentAuthViewController: UIViewController, authenticationType: SocialSignInAuthenticationType, authenticationCompletedSubject: PassthroughSubject<Void, Never>, authenticateUserUseCase: AuthenticateUserUseCase, localizationServices: LocalizationServices) {
         
         self.flowDelegate = flowDelegate
         self.presentAuthViewController = presentAuthViewController
         self.authenticationType = authenticationType
+        self.authenticationCompletedSubject = authenticationCompletedSubject
         self.authenticateUserUseCase = authenticateUserUseCase
         self.localizationServices = localizationServices
         
@@ -81,6 +83,8 @@ class SocialSignInViewModel: ObservableObject {
     }
     
     private func handleAuthenticationCompleted(error: Error?) {
+        
+        authenticationCompletedSubject.send(())
         
         switch authenticationType {
         

--- a/godtools/App/Flows/FlowStep.swift
+++ b/godtools/App/Flows/FlowStep.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 import GodToolsToolParser
+import Combine
 
 enum FlowStep {
     
@@ -93,8 +94,8 @@ enum FlowStep {
     case doneTappedFromMenu
     case tutorialTappedFromMenu
     case languageSettingsTappedFromMenu
-    case loginTappedFromMenu
-    case createAccountTappedFromMenu
+    case loginTappedFromMenu(authenticationCompletedSubject: PassthroughSubject<Void, Never>)
+    case createAccountTappedFromMenu(authenticationCompletedSubject: PassthroughSubject<Void, Never>)
     case activityTappedFromMenu
     case sendFeedbackTappedFromMenu
     case backTappedFromSendFeedback

--- a/godtools/App/Flows/Menu/MenuFlow.swift
+++ b/godtools/App/Flows/Menu/MenuFlow.swift
@@ -9,6 +9,7 @@
 import UIKit
 import MessageUI
 import SwiftUI
+import Combine
 
 class MenuFlow: Flow {
     
@@ -74,15 +75,15 @@ class MenuFlow: Flow {
         case .doneTappedFromMenu:
             flowDelegate?.navigate(step: .doneTappedFromMenu)
             
-        case .loginTappedFromMenu:
-            let view = getSocialSignInView(authenticationType: .login)
+        case .loginTappedFromMenu(let authenticationCompletedSubject):
+            let view = getSocialSignInView(authenticationType: .login, authenticationCompletedSubject: authenticationCompletedSubject)
             navigationController.present(view, animated: true)
             
         case .closeTappedFromLogin:
             navigationController.dismiss(animated: true)
             
-        case .createAccountTappedFromMenu:
-            let view = getSocialSignInView(authenticationType: .createAccount)
+        case .createAccountTappedFromMenu(let authenticationCompletedSubject):
+            let view = getSocialSignInView(authenticationType: .createAccount, authenticationCompletedSubject: authenticationCompletedSubject)
             navigationController.present(view, animated: true)
             
         case .closeTappedFromCreateAccount:
@@ -249,7 +250,7 @@ class MenuFlow: Flow {
         return hostingView*/
     }
     
-    private func getSocialSignInView(authenticationType: SocialSignInAuthenticationType) -> UIViewController {
+    private func getSocialSignInView(authenticationType: SocialSignInAuthenticationType, authenticationCompletedSubject: PassthroughSubject<Void, Never>) -> UIViewController {
         
         let viewBackgroundColor: Color = ColorPalette.gtBlue.color
         let viewBackgroundUIColor: UIColor = UIColor(viewBackgroundColor)
@@ -258,6 +259,7 @@ class MenuFlow: Flow {
             flowDelegate: self,
             presentAuthViewController: navigationController,
             authenticationType: authenticationType,
+            authenticationCompletedSubject: authenticationCompletedSubject,
             authenticateUserUseCase: appDiContainer.domainLayer.getAuthenticateUserUseCase(),
             localizationServices: appDiContainer.localizationServices
         )


### PR DESCRIPTION
In this PR reload the menu data source after a login is made.  Needed to send a PassthroughValueSubject to the SocialSignInViewModel in order to communicate back to the MenuViewModel.