### PR TITLE
GT Cache mobile-content-api auth token expiration date

### DIFF
--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -321,6 +321,8 @@
 		4561C41227C6891600C4A367 /* MobileContentAccordionSectionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4561C40E27C6891600C4A367 /* MobileContentAccordionSectionViewModel.swift */; };
 		456431DD284ACC5300846720 /* MobileContentRendererNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456431DC284ACC5200846720 /* MobileContentRendererNavigation.swift */; };
 		456431E1284ACCA400846720 /* DismissToolEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456431E0284ACCA400846720 /* DismissToolEvent.swift */; };
+		4566DCAE2A2686C000B989A2 /* RealmMobileContentAuthTokenCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4566DCAD2A2686C000B989A2 /* RealmMobileContentAuthTokenCache.swift */; };
+		4566DCB02A2686C900B989A2 /* RealmMobileContentAuthToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4566DCAF2A2686C900B989A2 /* RealmMobileContentAuthToken.swift */; };
 		45677765287DB1530044AEB2 /* TutorialFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45677763287DB1530044AEB2 /* TutorialFlow.swift */; };
 		45677769287DB1960044AEB2 /* GetTutorialUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45677767287DB1960044AEB2 /* GetTutorialUseCase.swift */; };
 		4567776A287DB1960044AEB2 /* TutorialModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45677768287DB1960044AEB2 /* TutorialModel.swift */; };
@@ -1436,6 +1438,8 @@
 		4561C40E27C6891600C4A367 /* MobileContentAccordionSectionViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MobileContentAccordionSectionViewModel.swift; sourceTree = "<group>"; };
 		456431DC284ACC5200846720 /* MobileContentRendererNavigation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MobileContentRendererNavigation.swift; sourceTree = "<group>"; };
 		456431E0284ACCA400846720 /* DismissToolEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DismissToolEvent.swift; sourceTree = "<group>"; };
+		4566DCAD2A2686C000B989A2 /* RealmMobileContentAuthTokenCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealmMobileContentAuthTokenCache.swift; sourceTree = "<group>"; };
+		4566DCAF2A2686C900B989A2 /* RealmMobileContentAuthToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealmMobileContentAuthToken.swift; sourceTree = "<group>"; };
 		45677763287DB1530044AEB2 /* TutorialFlow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TutorialFlow.swift; sourceTree = "<group>"; };
 		45677767287DB1960044AEB2 /* GetTutorialUseCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GetTutorialUseCase.swift; sourceTree = "<group>"; };
 		45677768287DB1960044AEB2 /* TutorialModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TutorialModel.swift; sourceTree = "<group>"; };
@@ -4070,6 +4074,15 @@
 				4515E9BE284FD2A600D3D197 /* MobileContentRendererNavigationDeepLinkType.swift */,
 			);
 			path = Navigation;
+			sourceTree = "<group>";
+		};
+		4566DCAC2A2686AB00B989A2 /* Realm */ = {
+			isa = PBXGroup;
+			children = (
+				4566DCAD2A2686C000B989A2 /* RealmMobileContentAuthTokenCache.swift */,
+				4566DCAF2A2686C900B989A2 /* RealmMobileContentAuthToken.swift */,
+			);
+			path = Realm;
 			sourceTree = "<group>";
 		};
 		45677761287DB1530044AEB2 /* Tutorial */ = {
@@ -7698,6 +7711,7 @@
 				D4B060062915647B005852D0 /* KeychainServiceResponse.swift */,
 				D4B060012912C335005852D0 /* MobileContentAuthTokenCache.swift */,
 				D4B060032913096A005852D0 /* MobileContentAuthTokenKeychainAccessor.swift */,
+				4566DCAC2A2686AB00B989A2 /* Realm */,
 			);
 			path = Cache;
 			sourceTree = "<group>";
@@ -8409,6 +8423,7 @@
 				45BDA5D02954F67D007E259B /* ResourceViewsService.swift in Sources */,
 				453A9EF32A045006007BB892 /* MenuViewModel.swift in Sources */,
 				45AD1BD025938A4F00A096A0 /* LoadingViewModelType.swift in Sources */,
+				4566DCAE2A2686C000B989A2 /* RealmMobileContentAuthTokenCache.swift in Sources */,
 				45052146295F3B9D0018ABD0 /* UserCounterDecodable.swift in Sources */,
 				453EA8DB2A1562650045EF06 /* GoogleAuthentication+AuthenticationProviderInterface.swift in Sources */,
 				45B3652B2885055E0012BE53 /* RealmTranslationsCache.swift in Sources */,
@@ -8600,6 +8615,7 @@
 				D42FEBD82876026A0002FAD9 /* GetOptInOnboardingBannerEnabledUseCase.swift in Sources */,
 				D45922E3286A376800904B87 /* LessonCardView.swift in Sources */,
 				D119788F271A090400E08580 /* TutorialPagerViewModel.swift in Sources */,
+				4566DCB02A2686C900B989A2 /* RealmMobileContentAuthToken.swift in Sources */,
 				45B6480925E581660098BAF1 /* (null) in Sources */,
 				45EB9B8329F16CF200CA74A8 /* Color+RGB.swift in Sources */,
 				454365B028B4F2F900CC97C1 /* Flow+NetworkErrorAlert.swift in Sources */,

--- a/godtools/App/DependencyContainer/AppDataLayerDependencies.swift
+++ b/godtools/App/DependencyContainer/AppDataLayerDependencies.swift
@@ -211,7 +211,7 @@ class AppDataLayerDependencies {
             ),
             cache: MobileContentAuthTokenCache(
                 mobileContentAuthTokenKeychainAccessor: getMobileContentAuthTokenKeychainAccessor(),
-                sharedUserDefaults: sharedUserDefaultsCache
+                realmCache: RealmMobileContentAuthTokenCache(realmDatabase: sharedRealmDatabase)
             )
         )
     }

--- a/godtools/App/DependencyContainer/AppDataLayerDependencies.swift
+++ b/godtools/App/DependencyContainer/AppDataLayerDependencies.swift
@@ -210,7 +210,8 @@ class AppDataLayerDependencies {
                 ignoreCacheSession: sharedIgnoreCacheSession
             ),
             cache: MobileContentAuthTokenCache(
-                mobileContentAuthTokenKeychainAccessor: getMobileContentAuthTokenKeychainAccessor()
+                mobileContentAuthTokenKeychainAccessor: getMobileContentAuthTokenKeychainAccessor(),
+                sharedUserDefaults: sharedUserDefaultsCache
             )
         )
     }

--- a/godtools/App/Share/Data/MobileContentAuthTokenRepository/Cache/MobileContentAuthTokenCache.swift
+++ b/godtools/App/Share/Data/MobileContentAuthTokenRepository/Cache/MobileContentAuthTokenCache.swift
@@ -10,38 +10,13 @@ import Foundation
 
 class MobileContentAuthTokenCache {
     
-    enum CacheKey: String {
-        
-        case expirationDate = "expirationDate"
-        
-        func getUserKey(userId: String) -> String {
-            return "MobileContentAuthTokenCache.\(userId).\(rawValue)"
-        }
-    }
+    private let keychainAccessor: MobileContentAuthTokenKeychainAccessor
+    private let realmCache: RealmMobileContentAuthTokenCache
     
-    private let sharedUserDefaults: SharedUserDefaultsCache
-    
-    let keychainAccessor: MobileContentAuthTokenKeychainAccessor
-    
-    init(mobileContentAuthTokenKeychainAccessor: MobileContentAuthTokenKeychainAccessor, sharedUserDefaults: SharedUserDefaultsCache) {
+    init(mobileContentAuthTokenKeychainAccessor: MobileContentAuthTokenKeychainAccessor, realmCache: RealmMobileContentAuthTokenCache) {
         
         self.keychainAccessor = mobileContentAuthTokenKeychainAccessor
-        self.sharedUserDefaults = sharedUserDefaults
-    }
-    
-    private func storeExpirationDate(userId: String, expirationDate: Date) {
-        
-        sharedUserDefaults.cache(value: expirationDate, forKey: CacheKey.expirationDate.getUserKey(userId: userId))
-    }
-    
-    private func getExpirationDate(userId: String) -> Date? {
-        
-        return sharedUserDefaults.getValue(key: CacheKey.expirationDate.getUserKey(userId: userId)) as? Date
-    }
-    
-    private func deleteExpirationDate(userId: String) {
-        
-        sharedUserDefaults.cache(value: nil, forKey: CacheKey.expirationDate.getUserKey(userId: userId))
+        self.realmCache = realmCache
     }
     
     func storeAuthToken(_ authTokenDataModel: MobileContentAuthTokenDataModel) {
@@ -50,10 +25,8 @@ class MobileContentAuthTokenCache {
             
             try keychainAccessor.saveMobileContentAuthToken(authTokenDataModel)
             
-            if let expirationDate = authTokenDataModel.expirationDate {
-                storeExpirationDate(userId: authTokenDataModel.userId, expirationDate: expirationDate)
-            }
-            
+            _ = realmCache.storeAuthTokenData(authTokenData: authTokenDataModel)
+
         } catch let error {
             
             assertionFailure("Keychain store failed with error: \(error.localizedDescription)")
@@ -65,9 +38,11 @@ class MobileContentAuthTokenCache {
         guard let userId = getUserId(), let authToken = getAuthToken(for: userId) else {
             return nil
         }
-            
+        
+        let authTokenData: RealmMobileContentAuthToken? = realmCache.getAuthTokenData(userId: userId)
+                
         return MobileContentAuthTokenDataModel(
-            expirationDate: getExpirationDate(userId: userId),
+            expirationDate: authTokenData?.expirationDate,
             userId: userId,
             token: authToken
         )
@@ -87,6 +62,6 @@ class MobileContentAuthTokenCache {
         
         keychainAccessor.deleteMobileContentAuthTokenAndUserId(userId: userId)
         
-        deleteExpirationDate(userId: userId)
+        _ = realmCache.deleteAuthTokenData(userId: userId)
     }
 }

--- a/godtools/App/Share/Data/MobileContentAuthTokenRepository/Cache/Realm/RealmMobileContentAuthToken.swift
+++ b/godtools/App/Share/Data/MobileContentAuthTokenRepository/Cache/Realm/RealmMobileContentAuthToken.swift
@@ -1,0 +1,20 @@
+//
+//  RealmMobileContentAuthToken.swift
+//  godtools
+//
+//  Created by Levi Eggert on 5/30/23.
+//  Copyright © 2023 Cru. All rights reserved.
+//
+
+import Foundation
+import RealmSwift
+
+class RealmMobileContentAuthToken: Object {
+    
+    @objc dynamic var expirationDate: Date?
+    @objc dynamic var userId: String = ""
+    
+    override static func primaryKey() -> String? {
+        return "userId"
+    }
+}

--- a/godtools/App/Share/Data/MobileContentAuthTokenRepository/Cache/Realm/RealmMobileContentAuthTokenCache.swift
+++ b/godtools/App/Share/Data/MobileContentAuthTokenRepository/Cache/Realm/RealmMobileContentAuthTokenCache.swift
@@ -1,0 +1,73 @@
+//
+//  RealmMobileContentAuthTokenCache.swift
+//  godtools
+//
+//  Created by Levi Eggert on 5/30/23.
+//  Copyright © 2023 Cru. All rights reserved.
+//
+
+import Foundation
+import RealmSwift
+
+class RealmMobileContentAuthTokenCache {
+    
+    private let realmDatabase: RealmDatabase
+    
+    init(realmDatabase: RealmDatabase) {
+        
+        self.realmDatabase = realmDatabase
+    }
+    
+    func getAuthTokenData(userId: String) -> RealmMobileContentAuthToken? {
+            
+        let realm: Realm = realmDatabase.openRealm()
+        
+        let realmAuthTokenData: RealmMobileContentAuthToken? = realm.object(ofType: RealmMobileContentAuthToken.self, forPrimaryKey: userId)
+        
+        return realmAuthTokenData
+    }
+    
+    func storeAuthTokenData(authTokenData: MobileContentAuthTokenDataModel) -> Result<Void, Error> {
+        
+        let realm: Realm = realmDatabase.openRealm()
+        
+        let realmAuthTokenData = RealmMobileContentAuthToken()
+        
+        realmAuthTokenData.expirationDate = authTokenData.expirationDate
+        realmAuthTokenData.userId = authTokenData.userId
+        
+        do {
+    
+            try realm.write {
+                realm.add(realmAuthTokenData, update: .all)
+            }
+            
+            return .success(())
+        }
+        catch let error {
+            
+            return .failure(error)
+        }
+    }
+    
+    func deleteAuthTokenData(userId: String) -> Result<Void, Error> {
+        
+        guard let realmAuthTokenData = getAuthTokenData(userId: userId) else {
+            return .success(())
+        }
+        
+        let realm: Realm = realmDatabase.openRealm()
+        
+        do {
+            
+            try realm.write {
+                realm.delete(realmAuthTokenData)
+            }
+            
+            return .success(())
+        }
+        catch let error {
+            return .failure(error)
+        }
+    }
+}

--- a/godtools/App/Share/Data/MobileContentAuthTokenRepository/MobileContentAuthTokenDataModel.swift
+++ b/godtools/App/Share/Data/MobileContentAuthTokenRepository/MobileContentAuthTokenDataModel.swift
@@ -10,14 +10,28 @@ import Foundation
 
 struct MobileContentAuthTokenDataModel {
     
+    let expirationDate: Date?
     let userId: String
     let token: String
+    
+    var isExpired: Bool {
+        
+        guard let expirationDate = self.expirationDate else {
+            return true
+        }
+                
+        let secondsTilExpiration: TimeInterval = Date().timeIntervalSince(expirationDate)
+        let isExpired: Bool = secondsTilExpiration >= 0
+        
+        return isExpired
+    }
 }
 
 extension MobileContentAuthTokenDataModel {
     
     init(decodable: MobileContentAuthTokenDecodable) {
         
+        self.expirationDate = decodable.expirationDate
         self.userId = decodable.userId
         self.token = decodable.token
     }

--- a/godtools/App/Share/Data/MobileContentAuthTokenRepository/MobileContentAuthTokenRepository.swift
+++ b/godtools/App/Share/Data/MobileContentAuthTokenRepository/MobileContentAuthTokenRepository.swift
@@ -44,12 +44,7 @@ class MobileContentAuthTokenRepository {
     
     func getCachedAuthTokenModel() -> MobileContentAuthTokenDataModel? {
         
-        guard
-            let userId = getUserId(),
-            let token = cache.getAuthToken(for: userId)
-        else { return nil }
-        
-        return MobileContentAuthTokenDataModel(userId: userId, token: token)
+        return cache.getAuthTokenData()
     }
     
     func getCachedAuthToken() -> String? {

--- a/godtools/App/Share/Data/RealmDatabase/Configuration/RealmDatabaseProductionConfiguration.swift
+++ b/godtools/App/Share/Data/RealmDatabase/Configuration/RealmDatabaseProductionConfiguration.swift
@@ -12,7 +12,7 @@ import RealmSwift
 class RealmDatabaseProductionConfiguration: RealmDatabaseConfiguration {
     
     private static let diskFileName: String = "godtools_realm"
-    private static let schemaVersion: UInt64 = 19
+    private static let schemaVersion: UInt64 = 20
     
     init() {
         


### PR DESCRIPTION
Updated the MobileContentAuthTokenCache to include the expiration date in the event we need to check if the mobile-content-api auth token has expired.
- Cache the auth token expiration date.
- Add isExpired to check if the auth token has expired.