### PR TITLE
GT-2052 ReceiveOnMain with Error

### DIFF
--- a/godtools/App/Features/Menu/Presentation/SocialSignIn/SocialSignInViewModel.swift
+++ b/godtools/App/Features/Menu/Presentation/SocialSignIn/SocialSignInViewModel.swift
@@ -66,7 +66,7 @@ class SocialSignInViewModel: ObservableObject {
             policy: .renewAccessTokenElseAskUserToAuthenticate(fromViewController: presentAuthViewController),
             createUser: authenticationType == .createAccount
         )
-        .receiveOnMain()
+        .receive(on: DispatchQueue.main)
         .sink { [weak self] subscriberCompletion in
             
             let authenticationError: Error?

--- a/godtools/App/Share/Common/SharedAppleExtensions/Combine/Publisher/Publisher+ReceiveOnMain.swift
+++ b/godtools/App/Share/Common/SharedAppleExtensions/Combine/Publisher/Publisher+ReceiveOnMain.swift
@@ -48,6 +48,7 @@ public extension Publisher {
                 
                 return Just(value)
                     .setFailureType(to: Self.Failure.self)
+                    .subscribe(on: DispatchQueue.main)
                     .receive(on: DispatchQueue.main)
                     .eraseToAnyPublisher()
                 

--- a/godtools/App/Share/Common/SharedAppleExtensions/Combine/Publisher/Publisher+ReceiveOnMain.swift
+++ b/godtools/App/Share/Common/SharedAppleExtensions/Combine/Publisher/Publisher+ReceiveOnMain.swift
@@ -48,7 +48,6 @@ public extension Publisher {
                 
                 return Just(value)
                     .setFailureType(to: Self.Failure.self)
-                    .subscribe(on: DispatchQueue.main)
                     .receive(on: DispatchQueue.main)
                     .eraseToAnyPublisher()
                 


### PR DESCRIPTION
If any sort of error occurs, a `flatMap` in a publisher chain won't execute unless the error is caught.  So, I added a `catch` that essentially allows us to ignore the error for a second in order to call `receiveOnMainIfNeeded`, and then re-propagates the existing error after we know we're on main.

Changed SocialSignInView to use `received(on:)` rather than the `receiveOnMain` extension.  Created a ticket to look into the favorite tools animation glitch again, which was the initial reason the extension was created: https://jira.cru.org/browse/GT-2054

(I removed the `subscribe(on:)` from the extension since it seemed risky.)