### PR TITLE
GT Include serverClientId for Google Sign-In

### DIFF
--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -812,6 +812,8 @@
 		45D96093289B898D001A5A3E /* GetToolIsFavoritedUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D96092289B898D001A5A3E /* GetToolIsFavoritedUseCase.swift */; };
 		45DE9ACE287865DB004E3AE0 /* OptInOnboardingBannerEnabledCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45DE9ACD287865DB004E3AE0 /* OptInOnboardingBannerEnabledCache.swift */; };
 		45DEF22E2576A6A20007AC64 /* learn_to_share_tool_with_anyone.json in Resources */ = {isa = PBXBuildFile; fileRef = 45DEF22D2576A6A20007AC64 /* learn_to_share_tool_with_anyone.json */; };
+		45DF34522A28D41600BB717E /* AppBuild.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45DF34512A28D41500BB717E /* AppBuild.swift */; };
+		45DF34542A28D41E00BB717E /* AppEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45DF34532A28D41E00BB717E /* AppEnvironment.swift */; };
 		45E39EC327457856006A59E4 /* TutorialAssetContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E39EC227457856006A59E4 /* TutorialAssetContent.swift */; };
 		45E39EC927457A14006A59E4 /* AnimatedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E39EC527457A14006A59E4 /* AnimatedView.swift */; };
 		45E39ECA27457A14006A59E4 /* AnimatedViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E39EC627457A14006A59E4 /* AnimatedViewModel.swift */; };
@@ -820,7 +822,6 @@
 		45E39ED427457CB5006A59E4 /* MobileContentAnimationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E39ED127457CB5006A59E4 /* MobileContentAnimationViewModel.swift */; };
 		45E39ED927457D32006A59E4 /* LearnToShareToolAssetContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E39ED827457D32006A59E4 /* LearnToShareToolAssetContent.swift */; };
 		45E39EDC27457E0C006A59E4 /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = 45E39EDB27457E0C006A59E4 /* Lottie */; };
-		45E658E628F0760A00E90350 /* AppBuild.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E658E528F0760A00E90350 /* AppBuild.swift */; };
 		45E7D4C42977430A008C7503 /* ZipArchive in Frameworks */ = {isa = PBXBuildFile; productRef = 45E7D4C32977430A008C7503 /* ZipArchive */; };
 		45E8FAA42882FD4B00D7D569 /* SHA256FileModelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E8FA9E2882FD4B00D7D569 /* SHA256FileModelType.swift */; };
 		45E8FAA62882FD4B00D7D569 /* ResourcesSHA256FileCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E8FAA02882FD4B00D7D569 /* ResourcesSHA256FileCache.swift */; };
@@ -1896,6 +1897,8 @@
 		45DEF4B824DEF4E100996695 /* lv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = lv; path = lv.lproj/Localizable.strings; sourceTree = "<group>"; };
 		45DEF4BB24DEF6E700996695 /* th */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = th; path = th.lproj/Localizable.strings; sourceTree = "<group>"; };
 		45DEF4BC24DEF6FA00996695 /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/Localizable.strings; sourceTree = "<group>"; };
+		45DF34512A28D41500BB717E /* AppBuild.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppBuild.swift; sourceTree = "<group>"; };
+		45DF34532A28D41E00BB717E /* AppEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppEnvironment.swift; sourceTree = "<group>"; };
 		45E39EC227457856006A59E4 /* TutorialAssetContent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TutorialAssetContent.swift; sourceTree = "<group>"; };
 		45E39EC527457A14006A59E4 /* AnimatedView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimatedView.swift; sourceTree = "<group>"; };
 		45E39EC627457A14006A59E4 /* AnimatedViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimatedViewModel.swift; sourceTree = "<group>"; };
@@ -1903,7 +1906,6 @@
 		45E39ED027457CB5006A59E4 /* MobileContentAnimationView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MobileContentAnimationView.swift; sourceTree = "<group>"; };
 		45E39ED127457CB5006A59E4 /* MobileContentAnimationViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MobileContentAnimationViewModel.swift; sourceTree = "<group>"; };
 		45E39ED827457D32006A59E4 /* LearnToShareToolAssetContent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LearnToShareToolAssetContent.swift; sourceTree = "<group>"; };
-		45E658E528F0760A00E90350 /* AppBuild.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppBuild.swift; sourceTree = "<group>"; };
 		45E8FA9E2882FD4B00D7D569 /* SHA256FileModelType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SHA256FileModelType.swift; sourceTree = "<group>"; };
 		45E8FAA02882FD4B00D7D569 /* ResourcesSHA256FileCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResourcesSHA256FileCache.swift; sourceTree = "<group>"; };
 		45E8FAA12882FD4B00D7D569 /* RealmSHA256File.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RealmSHA256File.swift; sourceTree = "<group>"; };
@@ -4962,10 +4964,10 @@
 			isa = PBXGroup;
 			children = (
 				451C8B7A28AEDAC100E98AFA /* AppBackgroundState.swift */,
-				45E658E528F0760A00E90350 /* AppBuild.swift */,
 				45AD21602593A62800A096A0 /* AppDelegate.swift */,
 				45AD21612593A62800A096A0 /* AppDiContainer.swift */,
 				45B86B2A28F1CDAA00691F26 /* InfoPlist.swift */,
+				45DF34502A28D40700BB717E /* AppBuild */,
 				45D48C8729F81692004E92B1 /* AppConfig */,
 				45D63E4F288F67CD009B4610 /* DependencyContainer */,
 				45AD174D25938A4D00A096A0 /* Features */,
@@ -6271,6 +6273,15 @@
 				45D96092289B898D001A5A3E /* GetToolIsFavoritedUseCase.swift */,
 			);
 			path = GetToolIsFavoritedUseCase;
+			sourceTree = "<group>";
+		};
+		45DF34502A28D40700BB717E /* AppBuild */ = {
+			isa = PBXGroup;
+			children = (
+				45DF34512A28D41500BB717E /* AppBuild.swift */,
+				45DF34532A28D41E00BB717E /* AppEnvironment.swift */,
+			);
+			path = AppBuild;
 			sourceTree = "<group>";
 		};
 		45E39EC427457A14006A59E4 /* AnimatedView */ = {
@@ -8724,6 +8735,7 @@
 				453649EC295E0B3F00B5B354 /* LanguageSettingsFlowCompletedState.swift in Sources */,
 				453A9EED2A044D0C007BB892 /* MenuSection.swift in Sources */,
 				45FB1CC1295F4184002BACD9 /* UISemanticContentAttribute+LanguageDirectionDomainModel.swift in Sources */,
+				45DF34522A28D41600BB717E /* AppBuild.swift in Sources */,
 				453A9EE52A044D0C007BB892 /* LegacyMenuItemViewModel.swift in Sources */,
 				45AD1FBB25938A9800A096A0 /* TractRemoteShareSubscriberError.swift in Sources */,
 				D44F3AB1283678880008390D /* ToolCategoryButtonViewModel.swift in Sources */,
@@ -9233,7 +9245,6 @@
 				453A9EE92A044D0C007BB892 /* LegacyMenuSectionHeaderView.swift in Sources */,
 				4573133A28C1821100481640 /* ToolDetailsToggleFavoriteButton.swift in Sources */,
 				D455F3F429773C30009D5F93 /* UserActivityBadgeDomainModel.swift in Sources */,
-				45E658E628F0760A00E90350 /* AppBuild.swift in Sources */,
 				45EB4E762989C9D600231C67 /* Flow+VideoModal.swift in Sources */,
 				45EB9B8429F16CF200CA74A8 /* Image+OptionalUIImage.swift in Sources */,
 				45AE973D27C97A9400C2CB33 /* MultiplatformCard.swift in Sources */,
@@ -9271,6 +9282,7 @@
 				45AD1BA625938A4F00A096A0 /* FlowStep.swift in Sources */,
 				453A9EE42A044D0C007BB892 /* LegacyMenuItemView.swift in Sources */,
 				D4E243CE29EDCA5700EA4BB7 /* ReportABugWebContent.swift in Sources */,
+				45DF34542A28D41E00BB717E /* AppEnvironment.swift in Sources */,
 				D1E98EDD27974F0000D1B738 /* LessonEvaluationViewModelType.swift in Sources */,
 				45AD22A12593CE8900A096A0 /* ColorPalette.swift in Sources */,
 				45838F0329E847D4003B5578 /* ToolDetailsSectionDescriptionTextView.swift in Sources */,
@@ -10536,7 +10548,7 @@
 			repositoryURL = "https://github.com/CruGlobal/social-authentication-ios.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.2.0;
+				minimumVersion = 0.3.0;
 			};
 		};
 		45E39EDA27457E0C006A59E4 /* XCRemoteSwiftPackageReference "lottie-ios" */ = {

--- a/godtools.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/godtools.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -194,8 +194,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CruGlobal/social-authentication-ios.git",
       "state" : {
-        "revision" : "e523d28225aa74b5dbcc4fc02259316eb1e56093",
-        "version" : "0.2.2"
+        "revision" : "79591a8694bc95a7d29aaf039c93da379cf46d46",
+        "version" : "0.3.0"
       }
     },
     {

--- a/godtools/App/AppBuild/AppBuild.swift
+++ b/godtools/App/AppBuild/AppBuild.swift
@@ -20,6 +20,7 @@ class AppBuild {
     }
     
     let configuration: AppBuild.Configuration
+    let environment: AppEnvironment
     let isDebug: Bool
 
     init(infoPlist: InfoPlist) {
@@ -46,6 +47,18 @@ class AppBuild {
         }
         else {
             configuration =  .release
+        }
+        
+        switch configuration {
+            
+        case .analyticsLogging:
+            environment = .production
+        case .staging:
+            environment = .staging
+        case .production:
+            environment = .production
+        case .release:
+            environment = .production
         }
     }
 }

--- a/godtools/App/AppBuild/AppEnvironment.swift
+++ b/godtools/App/AppBuild/AppEnvironment.swift
@@ -1,0 +1,15 @@
+//
+//  AppEnvironment.swift
+//  godtools
+//
+//  Created by Levi Eggert on 6/1/23.
+//  Copyright © 2023 Cru. All rights reserved.
+//
+
+import Foundation
+
+enum AppEnvironment {
+    
+    case staging
+    case production
+}

--- a/godtools/App/AppConfig/AppConfig.swift
+++ b/godtools/App/AppConfig/AppConfig.swift
@@ -10,11 +10,12 @@ import Foundation
 import SocialAuthentication
 
 class AppConfig {
-    
+        
     private let appBuild: AppBuild
     
     let appleAppId: String = "542773210"
     let facebookConfig: FacebookConfiguration
+    let googleAuthenticationConfiguration: GoogleAuthenticationConfiguration
     
     init(appBuild: AppBuild) {
         
@@ -29,6 +30,27 @@ class AppConfig {
             isAdvertiserIDCollectionEnabled: false,
             isSKAdNetworkReportEnabled: false
         )
+        
+        googleAuthenticationConfiguration = AppConfig.getGoogleAuthenticationConfiguration(environment: appBuild.environment)
+    }
+    
+    private static func getGoogleAuthenticationConfiguration(environment: AppEnvironment) -> GoogleAuthenticationConfiguration {
+                        
+        let clientId: String
+        let serverClientId: String
+        
+        switch environment {
+        
+        case .staging:
+            clientId = "71275134527-st5s63prkvuh46t7ohb1gmhq39qokh78.apps.googleusercontent.com"
+            serverClientId = "71275134527-nvu2ehje1j6g459ofg5aldn1n21fadpg.apps.googleusercontent.com"
+            
+        case .production:
+            clientId = "71275134527-4stabhk838h3jpkt9mfrt1r8tisaj9r1.apps.googleusercontent.com"
+            serverClientId = "71275134527-h5adpeeefcevhhhng1ggi5ngn6ko6d3k.apps.googleusercontent.com"
+        }
+        
+        return GoogleAuthenticationConfiguration(clientId: clientId, serverClientId: serverClientId, hostedDomain: nil, openIDRealm: nil)
     }
     
     var appsFlyerConfiguration: AppsFlyerConfiguration {
@@ -42,19 +64,12 @@ class AppConfig {
     
     var mobileContentApiBaseUrl: String {
         
-        let stagingUrl: String = "https://mobile-content-api-stage.cru.org"
-        let productionUrl: String = "https://mobile-content-api.cru.org"
+        switch appBuild.environment {
         
-        switch appBuild.configuration {
-            
-        case .analyticsLogging:
-            return productionUrl
         case .staging:
-            return stagingUrl
+            return "https://mobile-content-api-stage.cru.org"
         case .production:
-            return productionUrl
-        case .release:
-            return productionUrl
+            return "https://mobile-content-api.cru.org"
         }
     }
     
@@ -77,19 +92,12 @@ class AppConfig {
     
     var firebaseGoogleServiceFileName: String {
         
-        let debugFileName: String = "GoogleService-Info-Debug"
-        let productionFileName: String = "GoogleService-Info"
+        switch appBuild.environment {
         
-        switch appBuild.configuration {
-            
-        case .analyticsLogging:
-            return productionFileName
         case .staging:
-            return debugFileName
+            return "GoogleService-Info-Debug"
         case .production:
-            return productionFileName
-        case .release:
-            return productionFileName
+            return "GoogleService-Info"
         }
     }
 }

--- a/godtools/App/DependencyContainer/AppDataLayerDependencies.swift
+++ b/godtools/App/DependencyContainer/AppDataLayerDependencies.swift
@@ -44,6 +44,12 @@ class AppDataLayerDependencies {
         return sharedAppConfig
     }
     
+    func getAppleAuthentication() -> AppleAuthentication {
+        return AppleAuthentication(
+            appleUserPersistentStore: AppleUserPersistentStore()
+        )
+    }
+    
     func getArticleAemRepository() -> ArticleAemRepository {
         return ArticleAemRepository(
             downloader: ArticleAemDownloader(
@@ -143,9 +149,7 @@ class AppDataLayerDependencies {
     func getGoogleAuthentication() -> GoogleAuthentication {
         
         return GoogleAuthentication(
-            configuration: GoogleAuthenticationConfiguration(
-                clientId: "71275134527-st5s63prkvuh46t7ohb1gmhq39qokh78.apps.googleusercontent.com"
-            )
+            configuration: sharedAppConfig.googleAuthenticationConfiguration
         )
     }
     
@@ -297,6 +301,7 @@ class AppDataLayerDependencies {
     func getUserAuthentication() -> UserAuthentication {
         return UserAuthentication(
             authenticationProviders: [
+                .apple: getAppleAuthentication(),
                 .facebook: getFacebookAuthentication(),
                 .google: getGoogleAuthentication()
             ],

--- a/godtools/Info.plist
+++ b/godtools/Info.plist
@@ -70,7 +70,17 @@
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
 			<key>CFBundleURLName</key>
-			<string>google_sign_in_reverse_client_id</string>
+			<string>google_sign_in_production_reverse_client_id</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>com.googleusercontent.apps.71275134527-4stabhk838h3jpkt9mfrt1r8tisaj9r1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>google_sign_in_staging_reverse_client_id</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>com.googleusercontent.apps.71275134527-st5s63prkvuh46t7ohb1gmhq39qokh78</string>


### PR DESCRIPTION
This PR contains the following changes:

- Adding AppEnvironment enum for staging and production.
- In AppBuild.swift set environment based on the build configuration.
- AppConfig.swift will now configure values based on the environment rather than configuration to reduce any inconsistencies between staging and production.
- Added staging and production clientId and serverClientId for Google SignIn.
- Added staging reverse client id for Google SignIn.
- Added AppleAuthentication as a provider to UserAuthentication.swift. 