### PR TITLE
GT-2054 add animation modifier to banner image view

### DIFF
--- a/godtools/App/Features/Dashboard/Presentation/Tools/ToolCardsView/ToolCardView/ViewModels/ToolCardViewModel.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Tools/ToolCardsView/ToolCardView/ViewModels/ToolCardViewModel.swift
@@ -81,9 +81,9 @@ extension ToolCardViewModel {
     }
     
     private func setupBinding() {
-                
+        
         getBannerImageUseCase.getBannerImagePublisher(for: tool.bannerImageId)
-            .receiveOnMain()
+            .receive(on: DispatchQueue.main)            
             .assign(to: \.bannerImage, on: self)
             .store(in: &cancellables)
         

--- a/godtools/App/Share/SwiftUI Views/ResourceCard Subviews/ResourceCardBannerImageView.swift
+++ b/godtools/App/Share/SwiftUI Views/ResourceCard Subviews/ResourceCardBannerImageView.swift
@@ -39,6 +39,7 @@ struct ResourceCardBannerImageView: View {
         
         OptionalImage(image: bannerImage, width: cardWidth, height: cardWidth / bannerImageAspectRatio)
             .cornerRadius(cornerRadius, corners: [.topLeft, .topRight])
+            .animation(.default)
     }
 }
 


### PR DESCRIPTION
Created two follow-up tickets too:
1. to remove the `receiveOnMain` extension (https://jira.cru.org/browse/GT-2056)
2. to investigate using a local image cache (https://jira.cru.org/browse/GT-2055)