### PR TITLE
GT updates to user authentication provider

### DIFF
--- a/godtools/App/Features/Menu/Domain/UseCases/AuthenticateUserUseCase/AuthenticateUserUseCase.swift
+++ b/godtools/App/Features/Menu/Domain/UseCases/AuthenticateUserUseCase/AuthenticateUserUseCase.swift
@@ -61,7 +61,7 @@ class AuthenticateUserUseCase {
             
         case .renewAccessToken:
             
-            return userAuthentication.renewAccessTokenPublisher()
+            return userAuthentication.renewTokenPublisher()
                 .eraseToAnyPublisher()
         }
     }

--- a/godtools/App/Share/Data/MobileContentApiAuthSession/MobileContentApiAuthSession.swift
+++ b/godtools/App/Share/Data/MobileContentApiAuthSession/MobileContentApiAuthSession.swift
@@ -83,8 +83,16 @@ class MobileContentApiAuthSession {
                 return URLResponseError.otherError(error: error)
             }
             .flatMap { (authProviderResponse: AuthenticationProviderResponse) in
-                                
-                return self.mobileContentAuthTokenRepository.fetchRemoteAuthTokenPublisher(providerToken: authProviderResponse.getMobileContentAuthProviderToken(), createUser: createUser)
+                       
+                return authProviderResponse.getMobileContentAuthProviderToken().publisher
+                    .mapError {
+                        return URLResponseError.otherError(error: $0)
+                    }
+                    .eraseToAnyPublisher()
+            }
+            .flatMap { providerToken in
+                
+                return self.mobileContentAuthTokenRepository.fetchRemoteAuthTokenPublisher(providerToken: providerToken, createUser: createUser)
                    .eraseToAnyPublisher()
             }
             .flatMap { authTokenDataModel in

--- a/godtools/App/Share/Data/MobileContentApiAuthSession/MobileContentApiAuthSession.swift
+++ b/godtools/App/Share/Data/MobileContentApiAuthSession/MobileContentApiAuthSession.swift
@@ -78,7 +78,7 @@ class MobileContentApiAuthSession {
     
     private func fetchRemoteAuthToken(createUser: Bool = false) -> AnyPublisher<String, URLResponseError> {
                 
-        return userAuthentication.renewAccessTokenPublisher()
+        return userAuthentication.renewTokenPublisher()
             .mapError { error in
                 return URLResponseError.otherError(error: error)
             }

--- a/godtools/App/Share/Data/UserAuthentication/AuthenticationProvider/AuthenticationProviderInterface.swift
+++ b/godtools/App/Share/Data/UserAuthentication/AuthenticationProvider/AuthenticationProviderInterface.swift
@@ -14,7 +14,7 @@ protocol AuthenticationProviderInterface {
         
     func getPersistedResponse() -> AuthenticationProviderResponse?
     func authenticatePublisher(presentingViewController: UIViewController) -> AnyPublisher<AuthenticationProviderResponse, Error>
-    func renewAccessTokenPublisher() -> AnyPublisher<AuthenticationProviderResponse, Error>
+    func renewTokenPublisher() -> AnyPublisher<AuthenticationProviderResponse, Error>
     func signOutPublisher() -> AnyPublisher<Void, Error>
     func getAuthUserPublisher() -> AnyPublisher<AuthUserDomainModel?, Error>
 }

--- a/godtools/App/Share/Data/UserAuthentication/AuthenticationProvider/Providers/AppleAuthentication+AuthenticationProviderInterface.swift
+++ b/godtools/App/Share/Data/UserAuthentication/AuthenticationProvider/Providers/AppleAuthentication+AuthenticationProviderInterface.swift
@@ -20,7 +20,8 @@ extension AppleAuthentication: AuthenticationProviderInterface {
         }
         
         let response = AuthenticationProviderResponse(
-            accessToken: "",
+            accessToken: nil,
+            appleSignInAuthorizationCode: appleAuthResponse.authorizationCode,
             idToken: idToken,
             profile: AuthenticationProviderProfile(
                 email: appleAuthResponse.email,
@@ -28,7 +29,7 @@ extension AppleAuthentication: AuthenticationProviderInterface {
                 givenName: appleAuthResponse.fullName?.givenName
             ),
             providerType: .apple,
-            refreshToken: ""
+            refreshToken: nil
         )
         
         return .success(response)

--- a/godtools/App/Share/Data/UserAuthentication/AuthenticationProvider/Providers/AppleAuthentication+AuthenticationProviderInterface.swift
+++ b/godtools/App/Share/Data/UserAuthentication/AuthenticationProvider/Providers/AppleAuthentication+AuthenticationProviderInterface.swift
@@ -53,7 +53,7 @@ extension AppleAuthentication: AuthenticationProviderInterface {
             .eraseToAnyPublisher()
     }
     
-    func renewAccessTokenPublisher() -> AnyPublisher<AuthenticationProviderResponse, Error> {
+    func renewTokenPublisher() -> AnyPublisher<AuthenticationProviderResponse, Error> {
         
         // TODO: - implement in GT-2042
         

--- a/godtools/App/Share/Data/UserAuthentication/AuthenticationProvider/Providers/FacebookAuthentication+AuthenticationProviderInterface.swift
+++ b/godtools/App/Share/Data/UserAuthentication/AuthenticationProvider/Providers/FacebookAuthentication+AuthenticationProviderInterface.swift
@@ -62,7 +62,7 @@ extension FacebookAuthentication: AuthenticationProviderInterface {
             .eraseToAnyPublisher()
     }
     
-    func renewAccessTokenPublisher() -> AnyPublisher<AuthenticationProviderResponse, Error> {
+    func renewTokenPublisher() -> AnyPublisher<AuthenticationProviderResponse, Error> {
         
         return refreshCurrentAccessTokenPublisher()
             .flatMap({ (void: Void) -> AnyPublisher<AuthenticationProviderResponse, Error> in

--- a/godtools/App/Share/Data/UserAuthentication/AuthenticationProvider/Providers/FacebookAuthentication+AuthenticationProviderInterface.swift
+++ b/godtools/App/Share/Data/UserAuthentication/AuthenticationProvider/Providers/FacebookAuthentication+AuthenticationProviderInterface.swift
@@ -25,14 +25,15 @@ extension FacebookAuthentication: AuthenticationProviderInterface {
         
         let response = AuthenticationProviderResponse(
             accessToken: accessToken.tokenString,
-            idToken: "",
+            appleSignInAuthorizationCode: nil,
+            idToken: nil,
             profile: AuthenticationProviderProfile(
                 email: profile.email,
                 familyName: profile.lastName,
                 givenName: profile.firstName
             ),
             providerType: .facebook,
-            refreshToken: ""
+            refreshToken: nil
         )
         
         return .success(response)

--- a/godtools/App/Share/Data/UserAuthentication/AuthenticationProvider/Providers/GoogleAuthentication+AuthenticationProviderInterface.swift
+++ b/godtools/App/Share/Data/UserAuthentication/AuthenticationProvider/Providers/GoogleAuthentication+AuthenticationProviderInterface.swift
@@ -25,6 +25,7 @@ extension GoogleAuthentication: AuthenticationProviderInterface {
         
         let response = AuthenticationProviderResponse(
             accessToken: user.accessToken.tokenString,
+            appleSignInAuthorizationCode: nil,
             idToken: idToken,
             profile: AuthenticationProviderProfile(
                 email: user.profile?.email,
@@ -54,7 +55,7 @@ extension GoogleAuthentication: AuthenticationProviderInterface {
         
         return authenticatePublisher(from: presentingViewController)
             .flatMap({ (response: GoogleAuthenticationResponse) -> AnyPublisher<AuthenticationProviderResponse, Error> in
-                
+                                
                 return self.getResponseForPersistedData().publisher
                     .eraseToAnyPublisher()
             })

--- a/godtools/App/Share/Data/UserAuthentication/AuthenticationProvider/Providers/GoogleAuthentication+AuthenticationProviderInterface.swift
+++ b/godtools/App/Share/Data/UserAuthentication/AuthenticationProvider/Providers/GoogleAuthentication+AuthenticationProviderInterface.swift
@@ -62,7 +62,7 @@ extension GoogleAuthentication: AuthenticationProviderInterface {
             .eraseToAnyPublisher()
     }
     
-    func renewAccessTokenPublisher() -> AnyPublisher<AuthenticationProviderResponse, Error> {
+    func renewTokenPublisher() -> AnyPublisher<AuthenticationProviderResponse, Error> {
         
         return restorePreviousSignIn()
             .flatMap({ (response: GoogleAuthenticationResponse) -> AnyPublisher<AuthenticationProviderResponse, Error> in

--- a/godtools/App/Share/Data/UserAuthentication/AuthenticationProvider/Response/AuthenticationProviderResponse+MobileContentAuthProviderToken.swift
+++ b/godtools/App/Share/Data/UserAuthentication/AuthenticationProvider/Response/AuthenticationProviderResponse+MobileContentAuthProviderToken.swift
@@ -10,23 +10,38 @@ import Foundation
 
 extension AuthenticationProviderResponse {
     
-    func getMobileContentAuthProviderToken() -> MobileContentAuthProviderToken {
+    func getMobileContentAuthProviderToken() -> Result<MobileContentAuthProviderToken, Error> {
         
         return getMobileContentAuthProviderToken(providerType: providerType)
     }
     
-    private func getMobileContentAuthProviderToken(providerType: AuthenticationProviderType) -> MobileContentAuthProviderToken {
+    private func getMobileContentAuthProviderToken(providerType: AuthenticationProviderType) -> Result<MobileContentAuthProviderToken, Error> {
         
         switch providerType {
             
         case .apple:
-            return .apple(idToken: idToken, givenName: profile.givenName, familyName: profile.familyName)
             
+            guard let idToken = self.idToken, !idToken.isEmpty else {
+                return .failure(NSError.errorWithDescription(description: "Missing apple idToken."))
+            }
+            
+            return .success(.apple(idToken: idToken, givenName: profile.givenName, familyName: profile.familyName))
+                        
         case .facebook:
-            return .facebook(accessToken: accessToken)
+            
+            guard let accessToken = self.accessToken, !accessToken.isEmpty else {
+                return .failure(NSError.errorWithDescription(description: "Missing facebook accesstoken."))
+            }
+            
+            return .success(.facebook(accessToken: accessToken))
             
         case .google:
-            return .google(idToken: idToken)
+            
+            guard let idToken = self.idToken, !idToken.isEmpty else {
+                return .failure(NSError.errorWithDescription(description: "Missing google idToken."))
+            }
+            
+            return .success(.google(idToken: idToken))
         }
     }
 }

--- a/godtools/App/Share/Data/UserAuthentication/AuthenticationProvider/Response/AuthenticationProviderResponse.swift
+++ b/godtools/App/Share/Data/UserAuthentication/AuthenticationProvider/Response/AuthenticationProviderResponse.swift
@@ -10,9 +10,10 @@ import Foundation
 
 struct AuthenticationProviderResponse {
  
-    let accessToken: String
-    let idToken: String
+    let accessToken: String?
+    let appleSignInAuthorizationCode: String?
+    let idToken: String?
     let profile: AuthenticationProviderProfile
     let providerType: AuthenticationProviderType
-    let refreshToken: String
+    let refreshToken: String?
 }

--- a/godtools/App/Share/Data/UserAuthentication/UserAuthentication.swift
+++ b/godtools/App/Share/Data/UserAuthentication/UserAuthentication.swift
@@ -49,7 +49,7 @@ class UserAuthentication {
         return getLastAuthenticatedProvider()?.getPersistedResponse()
     }
     
-    func renewAccessTokenPublisher() -> AnyPublisher<AuthenticationProviderResponse, Error> {
+    func renewTokenPublisher() -> AnyPublisher<AuthenticationProviderResponse, Error> {
         
         guard let lastAuthenticatedProvider = getLastAuthenticatedProviderType() else {
             return Fail(error: NSError.errorWithDescription(description: "Last authenticated provider does not exist."))
@@ -59,7 +59,7 @@ class UserAuthentication {
         return getAuthenticationProvider(provider: lastAuthenticatedProvider)
             .flatMap({ (provider: AuthenticationProviderInterface) -> AnyPublisher<AuthenticationProviderResponse, Error> in
                 
-                return provider.renewAccessTokenPublisher()
+                return provider.renewTokenPublisher()
                     .eraseToAnyPublisher()
             })
             .eraseToAnyPublisher()


### PR DESCRIPTION
Hey @rachaelblue I made some more changes to UserAuthentication providers.  

- Changed AuthenticationProviderResponse identityToken, accessToken, refreshToken to be optional.  We aren't guaranteed to get an identity token, access token, or refresh token from our auth provider's and rather than include an empty string would prefer to include null.
- Changed the return type in Extension AuthenticationProviderResponse+MobileContentAuthProviderToken to return a Result type this way if identityToken, accessToken, refreshToken happen to be null or invalid we can return an Error here.
- Changed AuthenticationProviderInterface method name from renewAccessTokenPublisher() to renewTokenPublisher() since we are dealing with more than an access token with our auth providers.