### PR TITLE
GT-2061 add new menu design view model inputs

### DIFF
--- a/godtools/App/Features/Menu/Domain/UseCases/LogOutUserUseCase/LogOutUserUseCase.swift
+++ b/godtools/App/Features/Menu/Domain/UseCases/LogOutUserUseCase/LogOutUserUseCase.swift
@@ -22,7 +22,7 @@ class LogOutUserUseCase {
         self.mobileContentAuthTokenRepository = mobileContentAuthTokenRepository
     }
     
-    func logOutPublisher(fromViewController: UIViewController) -> AnyPublisher<Bool, Error> {
+    func logOutPublisher() -> AnyPublisher<Bool, Error> {
                 
         return userAuthentication.signOutPublisher()
             .flatMap({ (void: Void) -> AnyPublisher<Bool, Never> in

--- a/godtools/App/Features/Menu/Presentation/LegacyMenu/LegacyMenuViewModel.swift
+++ b/godtools/App/Features/Menu/Presentation/LegacyMenu/LegacyMenuViewModel.swift
@@ -305,7 +305,7 @@ extension LegacyMenuViewModel {
     
     func logoutTapped(fromViewController: UIViewController) {
         
-        logOutUserUseCase.logOutPublisher(fromViewController: fromViewController)
+        logOutUserUseCase.logOutPublisher()
             .receive(on: DispatchQueue.main)
             .sink(receiveCompletion: { _ in
                 

--- a/godtools/App/Features/Menu/Presentation/Menu/MenuView.swift
+++ b/godtools/App/Features/Menu/Presentation/Menu/MenuView.swift
@@ -29,74 +29,92 @@ struct MenuView: View {
                     
                     MenuSectionView(
                         sectionTitle: viewModel.getStartedSectionTitle,
-                        menuItems: [
+                        menuItemsViewBuilder: {
+                            
                             MenuItemView(imageAssetName: "school", title: viewModel.tutorialOptionTitle, tappedClosure: {
                                 
-                            }),
-                            MenuItemView(imageAssetName: "translate", title: viewModel.languageSettingsOptionTitle, tappedClosure: {
-
                             })
-                        ]
+                            
+                            MenuItemView(imageAssetName: "translate", title: viewModel.languageSettingsOptionTitle, tappedClosure: {
+                                
+                            })
+                        }
                     )
                     
                     MenuSectionView(
                         sectionTitle: viewModel.accountSectionTitle,
-                        menuItems: [
+                        menuItemsViewBuilder: {
+                            
                             MenuItemView(imageAssetName: "login", title: viewModel.loginOptionTitle, tappedClosure: {
                                 
-                            }),
+                            })
+                            
                             MenuItemView(imageAssetName: "person_add", title: viewModel.createAccountOptionTitle, tappedClosure: {
                                 
                             })
-                        ]
+                        }
                     )
                     
                     MenuSectionView(
-                        sectionTitle: viewModel.supportSectionTitle, menuItems: [
+                        sectionTitle: viewModel.supportSectionTitle,
+                        menuItemsViewBuilder: {
+                            
                             MenuItemView(imageAssetName: "send", title: viewModel.sendFeedbackOptionTitle, tappedClosure: {
                                 
-                            }),
+                            })
+                            
                             MenuItemView(imageAssetName: "bug_report", title: viewModel.reportABugOptionTitle, tappedClosure: {
                                 
-                            }),
+                            })
+                            
                             MenuItemView(imageAssetName: "live_help", title: viewModel.askAQuestionOptionTitle, tappedClosure: {
                                 
                             })
-                        ]
+                        }
                     )
                     
                     MenuSectionView(
-                        sectionTitle: viewModel.shareSectionTitle, menuItems: [
+                        sectionTitle: viewModel.shareSectionTitle,
+                        menuItemsViewBuilder: {
+                            
                             MenuItemView(imageAssetName: "rate_review", title: viewModel.leaveAReviewOptionTitle, tappedClosure: {
                                 
-                            }),
+                            })
+                            
                             MenuItemView(imageAssetName: "description", title: viewModel.shareAStoryWithUsOptionTitle, tappedClosure: {
                                 
-                            }),
+                            })
+                            
                             MenuItemView(imageAssetName: "share", title: viewModel.shareGodToolsOptionTitle, tappedClosure: {
                                 
                             })
-                        ]
+                        }
                     )
                     
                     MenuSectionView(
-                        sectionTitle: viewModel.aboutSectionTitle, menuItems: [
+                        sectionTitle: viewModel.aboutSectionTitle,
+                        menuItemsViewBuilder: {
+                            
                             MenuItemView(imageAssetName: "format_list_bulleted", title: viewModel.termsOfUseOptionTitle, tappedClosure: {
                                 
-                            }),
+                            })
+                            
                             MenuItemView(imageAssetName: "policy", title: viewModel.privacyPolicyOptionTitle, tappedClosure: {
                                 
-                            }),
+                            })
+                            
                             MenuItemView(imageAssetName: "copyright", title: viewModel.copyrightInfoOptionTitle, tappedClosure: {
                                 
                             })
-                        ]
+                        }
                     )
                     
                     MenuSectionView(
-                        sectionTitle: viewModel.versionSectionTitle, menuItems: []
+                        sectionTitle: viewModel.versionSectionTitle,
+                        menuItemsViewBuilder: {
+                            
+                        }
                     )
-                    
                 }
                 .padding(EdgeInsets(top: 0, leading: MenuView.contentHorizontalPadding, bottom: 0, trailing: MenuView.contentHorizontalPadding))
             }

--- a/godtools/App/Features/Menu/Presentation/Menu/MenuView.swift
+++ b/godtools/App/Features/Menu/Presentation/Menu/MenuView.swift
@@ -33,10 +33,12 @@ struct MenuView: View {
                             
                             MenuItemView(imageAssetName: "school", title: viewModel.tutorialOptionTitle, tappedClosure: {
                                 
+                                viewModel.tutorialTapped()
                             })
                             
                             MenuItemView(imageAssetName: "translate", title: viewModel.languageSettingsOptionTitle, tappedClosure: {
                                 
+                                viewModel.languageSettingsTapped()
                             })
                         }
                     )
@@ -47,10 +49,12 @@ struct MenuView: View {
                             
                             MenuItemView(imageAssetName: "login", title: viewModel.loginOptionTitle, tappedClosure: {
                                 
+                                viewModel.loginTapped()
                             })
                             
                             MenuItemView(imageAssetName: "person_add", title: viewModel.createAccountOptionTitle, tappedClosure: {
                                 
+                                viewModel.createAccountTapped()
                             })
                         }
                     )
@@ -61,14 +65,17 @@ struct MenuView: View {
                             
                             MenuItemView(imageAssetName: "send", title: viewModel.sendFeedbackOptionTitle, tappedClosure: {
                                 
+                                viewModel.sendFeedbackTapped()
                             })
                             
                             MenuItemView(imageAssetName: "bug_report", title: viewModel.reportABugOptionTitle, tappedClosure: {
                                 
+                                viewModel.reportABugTapped()
                             })
                             
                             MenuItemView(imageAssetName: "live_help", title: viewModel.askAQuestionOptionTitle, tappedClosure: {
                                 
+                                viewModel.askAQuestionTapped()
                             })
                         }
                     )
@@ -79,14 +86,17 @@ struct MenuView: View {
                             
                             MenuItemView(imageAssetName: "rate_review", title: viewModel.leaveAReviewOptionTitle, tappedClosure: {
                                 
+                                viewModel.leaveAReviewTapped()
                             })
                             
                             MenuItemView(imageAssetName: "description", title: viewModel.shareAStoryWithUsOptionTitle, tappedClosure: {
                                 
+                                viewModel.shareAStoryWithUsTapped()
                             })
                             
                             MenuItemView(imageAssetName: "share", title: viewModel.shareGodToolsOptionTitle, tappedClosure: {
                                 
+                                viewModel.shareGodToolsTapped()
                             })
                         }
                     )
@@ -97,14 +107,17 @@ struct MenuView: View {
                             
                             MenuItemView(imageAssetName: "format_list_bulleted", title: viewModel.termsOfUseOptionTitle, tappedClosure: {
                                 
+                                viewModel.termsOfUseTapped()
                             })
                             
                             MenuItemView(imageAssetName: "policy", title: viewModel.privacyPolicyOptionTitle, tappedClosure: {
                                 
+                                viewModel.privacyPolicyTapped()
                             })
                             
                             MenuItemView(imageAssetName: "copyright", title: viewModel.copyrightInfoOptionTitle, tappedClosure: {
                                 
+                                viewModel.copyrightInfoTapped()
                             })
                         }
                     )
@@ -122,5 +135,8 @@ struct MenuView: View {
         .navigationBarBackButtonHidden(true)
         .navigationTitle(viewModel.navTitle)
         .background(Color.white)
+        .onAppear {
+            viewModel.pageViewed()
+        }
     }
 }

--- a/godtools/App/Features/Menu/Presentation/Menu/Subviews/MenuSectionView.swift
+++ b/godtools/App/Features/Menu/Presentation/Menu/Subviews/MenuSectionView.swift
@@ -8,11 +8,17 @@
 
 import SwiftUI
 
-struct MenuSectionView: View {
+struct MenuSectionView<Content: View>: View {
         
     let sectionTitle: String
-    let menuItems: [MenuItemView]
+    let menuItemsViewBuilder: () -> Content
     
+    init(sectionTitle: String, @ViewBuilder menuItemsViewBuilder: @escaping () -> Content) {
+        
+        self.sectionTitle = sectionTitle
+        self.menuItemsViewBuilder = menuItemsViewBuilder
+    }
+        
     var body: some View {
         
         VStack(alignment: .leading, spacing: 0) {
@@ -25,20 +31,19 @@ struct MenuSectionView: View {
             
             VStack(alignment: .leading, spacing: 0) {
                 
-                ForEach(0 ..< menuItems.count, id: \.self) { index in
-                    
-                    menuItems[index]
-                }
-            }
-            
-            let hasMenuItems: Bool = menuItems.count > 0
-            
-            if hasMenuItems {
+                let menuItems = menuItemsViewBuilder()
                 
-                Rectangle()
-                    .fill(ColorPalette.gtLightestGrey.color)
-                    .frame(height: 1)
-                    .padding(EdgeInsets(top: MenuView.itemSpacing / 2, leading: 0, bottom: 0, trailing: 0))
+                menuItems
+                
+                let hasMenuItems: Bool = !(menuItems is EmptyView)
+                
+                if hasMenuItems {
+                    
+                    Rectangle()
+                        .fill(ColorPalette.gtLightestGrey.color)
+                        .frame(height: 1)
+                        .padding(EdgeInsets(top: MenuView.itemSpacing / 2, leading: 0, bottom: 0, trailing: 0))
+                }
             }
         }
     }

--- a/godtools/App/Flows/Menu/MenuFlow.swift
+++ b/godtools/App/Flows/Menu/MenuFlow.swift
@@ -251,7 +251,13 @@ class MenuFlow: Flow {
         
         let viewModel = MenuViewModel(
             flowDelegate: self,
-            localizationServices: localizationServices
+            localizationServices: localizationServices,
+            analytics: appDiContainer.dataLayer.getAnalytics(),
+            getSettingsPrimaryLanguageUseCase: appDiContainer.domainLayer.getSettingsPrimaryLanguageUseCase(),
+            getSettingsParallelLanguageUseCase: appDiContainer.domainLayer.getSettingsParallelLanguageUseCase(),
+            getOptInOnboardingTutorialAvailableUseCase: appDiContainer.getOptInOnboardingTutorialAvailableUseCase(),
+            disableOptInOnboardingBannerUseCase: appDiContainer.getDisableOptInOnboardingBannerUseCase(),
+            logOutUserUseCase: appDiContainer.domainLayer.getLogOutUserUseCase()
         )
         
         let view = MenuView(viewModel: viewModel)


### PR DESCRIPTION
This PR has the following changes:
- Add viewModel inputs to new menu viewModel design. (Copied over from LegacyMenuViewModel.swift).
- Update MenuSectionView to use ViewBuilder in order to toggle visibility of menu options