### PR TITLE
GT-2081 fix tool and lesson counters

### DIFF
--- a/godtools/App/Features/Dashboard/Presentation/Lesson/LessonViewModel.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Lesson/LessonViewModel.swift
@@ -7,12 +7,10 @@
 //
 
 import UIKit
-import Combine
 
 class LessonViewModel: MobileContentPagesViewModel {
     
     private weak var flowDelegate: FlowDelegate?
-    private var cancellables = Set<AnyCancellable>()
     
     let progress: ObservableValue<AnimatableValue<CGFloat>> = ObservableValue(value: AnimatableValue(value: 0, animated: false))
     
@@ -27,18 +25,6 @@ class LessonViewModel: MobileContentPagesViewModel {
         super.handleDismissToolEvent()
         
         closeTapped()
-    }
-    
-    override func viewDidFinishLayout(window: UIViewController, safeArea: UIEdgeInsets) {
-        super.viewDidFinishLayout(window: window, safeArea: safeArea)
-        
-        incrementUserCounterUseCase.incrementUserCounter(for: .lessonOpen(tool: resource.id))
-            .sink { _ in
-                
-            } receiveValue: { _ in
-                
-            }
-            .store(in: &cancellables)
     }
     
     private func updateProgress(page: Int) {

--- a/godtools/App/Features/Dashboard/Presentation/Tool/ToolViewModel.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Tool/ToolViewModel.swift
@@ -8,7 +8,6 @@
 
 import UIKit
 import GodToolsToolParser
-import Combine
 
 class ToolViewModel: MobileContentPagesViewModel {
     
@@ -23,7 +22,6 @@ class ToolViewModel: MobileContentPagesViewModel {
     private let liveShareStream: String?
     
     private weak var flowDelegate: FlowDelegate?
-    private var cancellables = Set<AnyCancellable>()
     
     let navBarViewModel: ObservableValue<ToolNavBarViewModel>
     let didSubscribeForRemoteSharePublishing: ObservableValue<Bool> = ObservableValue(value: false)
@@ -130,14 +128,6 @@ class ToolViewModel: MobileContentPagesViewModel {
         
         toolOpenedAnalytics.trackFirstToolOpenedIfNeeded(resource: resource)
         toolOpenedAnalytics.trackToolOpened(resource: resource)
-        
-        incrementUserCounterUseCase.incrementUserCounter(for: .toolOpen(tool: resource.id))
-            .sink { _ in
-                
-            } receiveValue: { _ in
-                
-            }
-            .store(in: &cancellables)
     }
     
     override func setRenderer(renderer: MobileContentRenderer, pageRendererIndex: Int?, navigationEvent: MobileContentPagesNavigationEvent?) {

--- a/godtools/App/Flows/Article/ArticleFlow.swift
+++ b/godtools/App/Flows/Article/ArticleFlow.swift
@@ -35,6 +35,7 @@ class ArticleFlow: Flow {
             localizationServices: appDiContainer.dataLayer.getLocalizationServices(),
             getSettingsPrimaryLanguageUseCase: appDiContainer.domainLayer.getSettingsPrimaryLanguageUseCase(),
             getSettingsParallelLanguageUseCase: appDiContainer.domainLayer.getSettingsParallelLanguageUseCase(),
+            incrementUserCounterUseCase: appDiContainer.domainLayer.getIncrementUserCounterUseCase(),
             analytics: appDiContainer.dataLayer.getAnalytics()
         )
         

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/Pages/MobileContentPagesViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/Pages/MobileContentPagesViewModel.swift
@@ -69,6 +69,8 @@ class MobileContentPagesViewModel: NSObject {
         self.window = window
         self.safeArea = safeArea
         
+        incrementToolOpenUserCounter()
+        
         setRenderer(renderer: renderer.value, pageRendererIndex: nil, navigationEvent: nil)
     }
     
@@ -723,6 +725,33 @@ extension MobileContentPagesViewModel {
     
     private func languageUsageAlreadyCountedThisSession(localeId: String) -> Bool {
         return languagelocaleIdUsed.contains(localeId)
+    }
+    
+    private func incrementToolOpenUserCounter() {
+        
+        let toolOpenInteraction: IncrementUserCounterUseCase.UserCounterInteraction?
+        
+        if resource.isToolType {
+            toolOpenInteraction = .toolOpen(tool: resource.id)
+        }
+        else if resource.isLessonType {
+            toolOpenInteraction = .lessonOpen(tool: resource.id)
+        }
+        else {
+            toolOpenInteraction = nil
+        }
+        
+        guard let toolOpenInteraction = toolOpenInteraction else {
+            return
+        }
+        
+        incrementUserCounterUseCase.incrementUserCounter(for: toolOpenInteraction)
+            .sink { _ in
+                
+            } receiveValue: { _ in
+                
+            }
+            .store(in: &cancellables)
     }
     
     private func trackLanguageUsageCountedThisSession(localeId: String) {


### PR DESCRIPTION
This PR fixes counters for the following:
- Track lesson completion counter once per session (lesson open).
- Add article tool open counting.
- Moved lesson and tool open counting into base viewModel and check resource type when it comes to incrementing a tract vs lesson.