### PR TITLE
GT-2076 Remove check for localized string equaling key

### DIFF
--- a/godtools/App/Services/Localization/Bundle/LocalizableStringsBundle.swift
+++ b/godtools/App/Services/Localization/Bundle/LocalizableStringsBundle.swift
@@ -21,7 +21,7 @@ class LocalizableStringsBundle {
                 
         let localizedString: String = bundle.localizedString(forKey: key, value: nil, table: nil)
         
-        if localizedString.isEmpty || localizedString.lowercased() == key.lowercased() {
+        if localizedString.isEmpty {
             return nil
         }
         


### PR DESCRIPTION
Fixed issue where phrase was returning null if the phrase and key are equal.