### PR TITLE
GT-2082 Make viewModels private and other various clean-up

### DIFF
--- a/godtools/App/Features/Dashboard/Presentation/Dashboard/DashboardTabBarView/DashboardTabBarView.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Dashboard/DashboardTabBarView/DashboardTabBarView.swift
@@ -10,7 +10,12 @@ import SwiftUI
 
 struct DashboardTabBarView: View {
     
-    @ObservedObject var viewModel: DashboardViewModel
+    @ObservedObject private var viewModel: DashboardViewModel
+    
+    init(viewModel: DashboardViewModel) {
+        
+        self.viewModel = viewModel
+    }
     
     var body: some View {
         

--- a/godtools/App/Features/Dashboard/Presentation/Dashboard/DashboardView.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Dashboard/DashboardView.swift
@@ -10,13 +10,13 @@ import SwiftUI
 
 struct DashboardView: View {
     
-    @ObservedObject var viewModel: DashboardViewModel
-    
     private static let marginMultiplier: CGFloat = 15/375
     
+    @ObservedObject private var viewModel: DashboardViewModel
+    
     init(viewModel: DashboardViewModel) {
+       
         self.viewModel = viewModel
-        
     }
     
     var body: some View {

--- a/godtools/App/Features/Dashboard/Presentation/Home/AllFavoriteToolsView/AllFavoriteToolsView.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Home/AllFavoriteToolsView/AllFavoriteToolsView.swift
@@ -9,12 +9,13 @@
 import SwiftUI
 
 struct AllFavoriteToolsView: View {
-    
-    // MARK: - Properties
-    
-    @ObservedObject var viewModel: AllFavoriteToolsViewModel
-    
-    // MARK: - Body
+        
+    @ObservedObject private var viewModel: AllFavoriteToolsViewModel
+        
+    init(viewModel: AllFavoriteToolsViewModel) {
+        
+        self.viewModel = viewModel
+    }
     
     var body: some View {
         

--- a/godtools/App/Features/Dashboard/Presentation/Home/AllFavoriteToolsView/AllFavoriteToolsViewModel.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Home/AllFavoriteToolsView/AllFavoriteToolsViewModel.swift
@@ -9,24 +9,12 @@
 import Foundation
 
 class AllFavoriteToolsViewModel: BaseFavoriteToolsViewModel {
-    
-    // MARK: - Properties
-    
-    private weak var flowDelegate: FlowDelegate?
+        
     private let analytics: AnalyticsContainer
-    
     private let removeToolFromFavoritesUseCase: RemoveToolFromFavoritesUseCase
     
-    override var tools: [ToolDomainModel] {
-        didSet {
-            if tools.isEmpty {
-                closePage()
-            }
-        }
-    }
-    
-    // MARK: - Init
-    
+    private weak var flowDelegate: FlowDelegate?
+        
     init(localizationServices: LocalizationServices, getAllFavoritedToolsUseCase: GetAllFavoritedToolsUseCase, getBannerImageUseCase: GetBannerImageUseCase, getLanguageAvailabilityUseCase: GetLanguageAvailabilityUseCase, getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase, getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase, getToolIsFavoritedUseCase: GetToolIsFavoritedUseCase, removeToolFromFavoritesUseCase: RemoveToolFromFavoritesUseCase, flowDelegate: FlowDelegate?, analytics: AnalyticsContainer) {
         
         self.flowDelegate = flowDelegate
@@ -34,10 +22,16 @@ class AllFavoriteToolsViewModel: BaseFavoriteToolsViewModel {
         
         self.removeToolFromFavoritesUseCase = removeToolFromFavoritesUseCase
         
-        super.init(localizationServices: localizationServices, getAllFavoritedToolsUseCase: getAllFavoritedToolsUseCase, getBannerImageUseCase: getBannerImageUseCase, getLanguageAvailabilityUseCase: getLanguageAvailabilityUseCase, getSettingsParallelLanguageUseCase: getSettingsParallelLanguageUseCase, getSettingsPrimaryLanguageUseCase: getSettingsPrimaryLanguageUseCase, getToolIsFavoritedUseCase: getToolIsFavoritedUseCase, toolCardViewModelDelegate: nil)
+        super.init(localizationServices: localizationServices, getAllFavoritedToolsUseCase: getAllFavoritedToolsUseCase, getBannerImageUseCase: getBannerImageUseCase, getLanguageAvailabilityUseCase: getLanguageAvailabilityUseCase, getSettingsParallelLanguageUseCase: getSettingsParallelLanguageUseCase, getSettingsPrimaryLanguageUseCase: getSettingsPrimaryLanguageUseCase, getToolIsFavoritedUseCase: getToolIsFavoritedUseCase, toolCardViewModelDelegate: nil, maxNumberOfCardsToShow: nil)
     }
-    
-    // MARK: - Overrides
+        
+    override var tools: [ToolDomainModel] {
+        didSet {
+            if tools.isEmpty {
+                closePage()
+            }
+        }
+    }
     
     override func cardViewModel(for tool: ToolDomainModel) -> BaseToolCardViewModel {
         return ToolCardViewModel(

--- a/godtools/App/Features/Dashboard/Presentation/Home/FavoriteToolsView/FavoriteToolsView.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Home/FavoriteToolsView/FavoriteToolsView.swift
@@ -9,14 +9,18 @@
 import SwiftUI
 
 struct FavoriteToolsView: View {
+        
+    private let width: CGFloat
+    private let leadingPadding: CGFloat
     
-    // MARK: - Properties
-    
-    @ObservedObject var viewModel: FavoriteToolsViewModel
-    let width: CGFloat
-    let leadingPadding: CGFloat
-    
-    // MARK: - Body
+    @ObservedObject private var viewModel: FavoriteToolsViewModel
+        
+    init(viewModel: FavoriteToolsViewModel, width: CGFloat, leadingPadding: CGFloat) {
+        
+        self.viewModel = viewModel
+        self.width = width
+        self.leadingPadding = leadingPadding
+    }
     
     var body: some View {
         VStack(alignment: .leading, spacing: 15) {

--- a/godtools/App/Features/Dashboard/Presentation/Home/FavoriteToolsView/Subviews/FavoriteToolsHeaderView.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Home/FavoriteToolsView/Subviews/FavoriteToolsHeaderView.swift
@@ -9,13 +9,16 @@
 import SwiftUI
 
 struct FavoriteToolsHeaderView: View {
+        
+    private let leadingPadding: CGFloat
     
-    // MARK: - Properties
+    @ObservedObject private var viewModel: FavoriteToolsViewModel
     
-    @ObservedObject var viewModel: FavoriteToolsViewModel
-    let leadingPadding: CGFloat
-    
-    // MARK: - Body
+    init(viewModel: FavoriteToolsViewModel, leadingPadding: CGFloat) {
+        
+        self.viewModel = viewModel
+        self.leadingPadding = leadingPadding
+    }
     
     var body: some View {
         HStack(alignment: .bottom) {

--- a/godtools/App/Features/Dashboard/Presentation/Home/FavoriteToolsView/Subviews/NoFavoriteToolsView.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Home/FavoriteToolsView/Subviews/NoFavoriteToolsView.swift
@@ -9,12 +9,13 @@
 import SwiftUI
 
 struct NoFavoriteToolsView: View {
-    
-    // MARK: - Properties
-    
-    @ObservedObject var viewModel: FavoriteToolsViewModel
-    
-    // MARK: - Body
+        
+    @ObservedObject private var viewModel: FavoriteToolsViewModel
+
+    init(viewModel: FavoriteToolsViewModel) {
+        
+        self.viewModel = viewModel
+    }
     
     var body: some View {
         ZStack {

--- a/godtools/App/Features/Dashboard/Presentation/Home/FavoriteToolsView/ViewModels/BaseFavoriteToolsViewModel.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Home/FavoriteToolsView/ViewModels/BaseFavoriteToolsViewModel.swift
@@ -16,9 +16,11 @@ class BaseFavoriteToolsViewModel: ToolCardProvider {
         case noTools
         case tools
     }
- 
-    // MARK: - Properties
     
+    private var cancellables = Set<AnyCancellable>()
+    
+    private weak var toolCardViewModelDelegate: ToolCardViewModelDelegate?
+     
     let localizationServices: LocalizationServices
     
     let getAllFavoritedToolsUseCase: GetAllFavoritedToolsUseCase
@@ -27,19 +29,11 @@ class BaseFavoriteToolsViewModel: ToolCardProvider {
     let getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase
     let getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase
     let getToolIsFavoritedUseCase: GetToolIsFavoritedUseCase
-    
-    weak var toolCardViewModelDelegate: ToolCardViewModelDelegate?
-    
-    private var cancellables = Set<AnyCancellable>()
-    
-    // MARK: - Published
-    
+        
     @Published var viewState: ViewState = .loading
     @Published var sectionTitle: String = ""
-    
-    // MARK: - Init
-    
-    init(localizationServices: LocalizationServices, getAllFavoritedToolsUseCase: GetAllFavoritedToolsUseCase, getBannerImageUseCase: GetBannerImageUseCase, getLanguageAvailabilityUseCase: GetLanguageAvailabilityUseCase, getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase, getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase, getToolIsFavoritedUseCase: GetToolIsFavoritedUseCase, toolCardViewModelDelegate: ToolCardViewModelDelegate?) {
+        
+    init(localizationServices: LocalizationServices, getAllFavoritedToolsUseCase: GetAllFavoritedToolsUseCase, getBannerImageUseCase: GetBannerImageUseCase, getLanguageAvailabilityUseCase: GetLanguageAvailabilityUseCase, getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase, getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase, getToolIsFavoritedUseCase: GetToolIsFavoritedUseCase, toolCardViewModelDelegate: ToolCardViewModelDelegate?, maxNumberOfCardsToShow: Int?) {
         self.localizationServices = localizationServices
         
         self.getAllFavoritedToolsUseCase = getAllFavoritedToolsUseCase
@@ -51,7 +45,7 @@ class BaseFavoriteToolsViewModel: ToolCardProvider {
         
         self.toolCardViewModelDelegate = toolCardViewModelDelegate
         
-        super.init()
+        super.init(maxNumberOfCardsToShow: maxNumberOfCardsToShow)
         
         setupBinding()
     }

--- a/godtools/App/Features/Dashboard/Presentation/Home/FavoriteToolsView/ViewModels/FavoriteToolsViewModel.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Home/FavoriteToolsView/ViewModels/FavoriteToolsViewModel.swift
@@ -15,31 +15,21 @@ protocol FavoriteToolsViewModelDelegate: ToolCardViewModelDelegate {
 }
 
 class FavoriteToolsViewModel: BaseFavoriteToolsViewModel {
- 
-    // MARK: - Constants
-    
-    private let maxNumberCardsShown = 5
-    
-    // MARK: - Properties
-    
+     
+    private let defaultMaxNumberOfCardsToShow: Int = 5
+        
     private weak var delegate: FavoriteToolsViewModelDelegate?
-    
-    // MARK: - Published
-    
+        
     @Published var viewAllButtonText: String = ""
     @Published var noFavoriteToolsTitle: String = ""
     @Published var noFavoriteToolsDescription: String = ""
     @Published var noFavoriteToolsButtonText: String = ""
-    
-    // MARK: - Init
-    
+        
     init(dataDownloader: InitialDataDownloader, localizationServices: LocalizationServices, getAllFavoritedToolsUseCase: GetAllFavoritedToolsUseCase, getBannerImageUseCase: GetBannerImageUseCase, getLanguageAvailabilityUseCase: GetLanguageAvailabilityUseCase, getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase, getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase, getToolIsFavoritedUseCase: GetToolIsFavoritedUseCase, delegate: FavoriteToolsViewModelDelegate?) {
         
         self.delegate = delegate
         
-        super.init(localizationServices: localizationServices, getAllFavoritedToolsUseCase: getAllFavoritedToolsUseCase, getBannerImageUseCase: getBannerImageUseCase, getLanguageAvailabilityUseCase: getLanguageAvailabilityUseCase, getSettingsParallelLanguageUseCase: getSettingsParallelLanguageUseCase, getSettingsPrimaryLanguageUseCase: getSettingsPrimaryLanguageUseCase, getToolIsFavoritedUseCase: getToolIsFavoritedUseCase, toolCardViewModelDelegate: delegate)
-        
-        maxNumberCardsToShow = maxNumberCardsShown
+        super.init(localizationServices: localizationServices, getAllFavoritedToolsUseCase: getAllFavoritedToolsUseCase, getBannerImageUseCase: getBannerImageUseCase, getLanguageAvailabilityUseCase: getLanguageAvailabilityUseCase, getSettingsParallelLanguageUseCase: getSettingsParallelLanguageUseCase, getSettingsPrimaryLanguageUseCase: getSettingsPrimaryLanguageUseCase, getToolIsFavoritedUseCase: getToolIsFavoritedUseCase, toolCardViewModelDelegate: delegate, maxNumberOfCardsToShow: defaultMaxNumberOfCardsToShow)
     }
     
     override func setText(for language: LanguageDomainModel?) {

--- a/godtools/App/Features/Dashboard/Presentation/Home/FavoritesContentView.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Home/FavoritesContentView.swift
@@ -9,13 +9,16 @@
 import SwiftUI
 
 struct FavoritesContentView: View {
+        
+    private let leadingTrailingPadding: CGFloat
     
-    // MARK: - Properties
+    @ObservedObject private var viewModel: FavoritesContentViewModel
     
-    @ObservedObject var viewModel: FavoritesContentViewModel
-    let leadingTrailingPadding: CGFloat
-    
-    // MARK: - Body
+    init(viewModel: FavoritesContentViewModel, leadingTrailingPadding: CGFloat) {
+        
+        self.viewModel = viewModel
+        self.leadingTrailingPadding = leadingTrailingPadding
+    }
     
     var body: some View {
         

--- a/godtools/App/Features/Dashboard/Presentation/Home/FavoritesContentViewModel.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Home/FavoritesContentViewModel.swift
@@ -14,10 +14,7 @@ protocol FavoritesContentViewModelDelegate: AnyObject {
 }
 
 class FavoritesContentViewModel: ObservableObject {
-    
-    // MARK: - Properties
-        
-    private weak var flowDelegate: FlowDelegate?
+            
     private let dataDownloader: InitialDataDownloader
     private let localizationServices: LocalizationServices
     private let analytics: AnalyticsContainer
@@ -36,6 +33,8 @@ class FavoritesContentViewModel: ObservableObject {
     private let removeToolFromFavoritesUseCase: RemoveToolFromFavoritesUseCase
     
     private var cancellables = Set<AnyCancellable>()
+    
+    private weak var flowDelegate: FlowDelegate?
         
     private(set) lazy var featuredLessonCardsViewModel: FeaturedLessonCardsViewModel = {
         return FeaturedLessonCardsViewModel(
@@ -62,14 +61,10 @@ class FavoritesContentViewModel: ObservableObject {
             delegate: self
         )
     }()
-    
-    // MARK: - Published
-    
+        
     @Published var pageTitle: String = ""
     @Published var hideTutorialBanner: Bool = true
     @Published var isLoading: Bool = true
-
-    // MARK: - Init
     
     init(flowDelegate: FlowDelegate, dataDownloader: InitialDataDownloader, localizationServices: LocalizationServices, analytics: AnalyticsContainer, translationsRepository: TranslationsRepository, disableOptInOnboardingBannerUseCase: DisableOptInOnboardingBannerUseCase, getAllFavoritedToolsUseCase: GetAllFavoritedToolsUseCase, getBannerImageUseCase: GetBannerImageUseCase, getFeaturedLessonsUseCase: GetFeaturedLessonsUseCase, getLanguageAvailabilityUseCase: GetLanguageAvailabilityUseCase, getOptInOnboardingBannerEnabledUseCase: GetOptInOnboardingBannerEnabledUseCase, getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase, getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase, getToolIsFavoritedUseCase: GetToolIsFavoritedUseCase, removeToolFromFavoritesUseCase: RemoveToolFromFavoritesUseCase) {
         self.flowDelegate = flowDelegate

--- a/godtools/App/Features/Dashboard/Presentation/Home/FeaturedLessonsView/FeaturedLessonCardsView.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Home/FeaturedLessonsView/FeaturedLessonCardsView.swift
@@ -9,14 +9,18 @@
 import SwiftUI
 
 struct FeaturedLessonCardsView: View {
+        
+    private let width: CGFloat
+    private let leadingPadding: CGFloat
     
-    // MARK: - Properties
+    @ObservedObject private var viewModel: FeaturedLessonCardsViewModel
     
-    @ObservedObject var viewModel: FeaturedLessonCardsViewModel
-    let width: CGFloat
-    let leadingPadding: CGFloat
-    
-    // MARK: - Body
+    init(viewModel: FeaturedLessonCardsViewModel, width: CGFloat, leadingPadding: CGFloat) {
+        
+        self.viewModel = viewModel
+        self.width = width
+        self.leadingPadding = leadingPadding
+    }
     
     var body: some View {
         

--- a/godtools/App/Features/Dashboard/Presentation/Home/FeaturedLessonsView/FeaturedLessonCardsViewModel.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Home/FeaturedLessonsView/FeaturedLessonCardsViewModel.swift
@@ -11,28 +11,22 @@ import SwiftUI
 import Combine
 
 class FeaturedLessonCardsViewModel: ObservableObject {
-    
-    // MARK: - Properties
-    
+        
     private let dataDownloader: InitialDataDownloader
     private let localizationServices: LocalizationServices
-    
     private let getBannerImageUseCase: GetBannerImageUseCase
     private let getFeaturedLessonsUseCase: GetFeaturedLessonsUseCase
     private let getLanguageAvailabilityUseCase: GetLanguageAvailabilityUseCase
     private let getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase
     private let translationsRepository: TranslationsRepository
     
-    private weak var delegate: LessonCardDelegate?
     private var cancellables = Set<AnyCancellable>()
     
-    // MARK: - Published
-    
+    private weak var delegate: LessonCardDelegate?
+        
     @Published var sectionTitle: String = ""
     @Published var lessons: [LessonDomainModel] = []
-    
-    // MARK: - Init
-    
+        
     init(dataDownloader: InitialDataDownloader, localizationServices: LocalizationServices, getBannerImageUseCase: GetBannerImageUseCase, getFeaturedLessonsUseCase: GetFeaturedLessonsUseCase, getLanguageAvailabilityUseCase: GetLanguageAvailabilityUseCase, getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase, translationsRepository: TranslationsRepository, delegate: LessonCardDelegate?) {
         self.dataDownloader = dataDownloader
         self.localizationServices = localizationServices

--- a/godtools/App/Features/Dashboard/Presentation/Home/OpenTutorialBannerView/OpenTutorialBannerView.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Home/OpenTutorialBannerView/OpenTutorialBannerView.swift
@@ -9,12 +9,13 @@
 import SwiftUI
 
 struct OpenTutorialBannerView: View {
+        
+    @ObservedObject private var viewModel: OpenTutorialBannerViewModel
     
-    // MARK: - Properties
-    
-    @ObservedObject var viewModel: OpenTutorialBannerViewModel
-    
-    // MARK: - Body
+    init(viewModel: OpenTutorialBannerViewModel) {
+        
+        self.viewModel = viewModel
+    }
     
     var body: some View {
         

--- a/godtools/App/Features/Dashboard/Presentation/Home/OpenTutorialBannerView/OpenTutorialBannerViewModel.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Home/OpenTutorialBannerView/OpenTutorialBannerViewModel.swift
@@ -14,9 +14,7 @@ protocol OpenTutorialBannerViewModelDelegate: AnyObject {
 }
 
 class OpenTutorialBannerViewModel: ObservableObject {
-    
-    // MARK: - Properties
-    
+        
     private let localizationServices: LocalizationServices
     private let getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase
     private let getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase
@@ -24,14 +22,10 @@ class OpenTutorialBannerViewModel: ObservableObject {
     
     private weak var flowDelegate: FlowDelegate?
     private weak var delegate: OpenTutorialBannerViewModelDelegate?
-    
-    // MARK: - Published
-    
+        
     @Published var showTutorialText: String
     @Published var openTutorialButtonText: String
-    
-    // MARK: - Init
-    
+        
     init(flowDelegate: FlowDelegate?, localizationServices: LocalizationServices, getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase, getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase, analytics: AnalyticsContainer, delegate: OpenTutorialBannerViewModelDelegate?) {
         
         self.flowDelegate = flowDelegate

--- a/godtools/App/Features/Dashboard/Presentation/Lessons/LessonsView.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Lessons/LessonsView.swift
@@ -9,13 +9,16 @@
 import SwiftUI
 
 struct LessonsView: View {
+        
+    @ObservedObject private var viewModel: LessonsViewModel
     
-    // MARK: - Properties
-    
-    @ObservedObject var viewModel: LessonsViewModel
     let leadingTrailingPadding: CGFloat
     
-    // MARK: - Body
+    init(viewModel: LessonsViewModel, leadingTrailingPadding: CGFloat) {
+        
+        self.viewModel = viewModel
+        self.leadingTrailingPadding = leadingTrailingPadding
+    }
     
     var body: some View {
         

--- a/godtools/App/Features/Dashboard/Presentation/Lessons/LessonsViewModel.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Lessons/LessonsViewModel.swift
@@ -10,14 +10,10 @@ import Foundation
 import Combine
 
 class LessonsViewModel: ObservableObject {
-    
-    // MARK: - Properties
-    
-    private weak var flowDelegate: FlowDelegate?
+        
     private let dataDownloader: InitialDataDownloader
     private let localizationServices: LocalizationServices
     private let analytics: AnalyticsContainer
-    
     private let getBannerImageUseCase: GetBannerImageUseCase
     private let getLanguageAvailabilityUseCase: GetLanguageAvailabilityUseCase
     private let getLessonsUseCase: GetLessonsUseCase
@@ -27,15 +23,13 @@ class LessonsViewModel: ObservableObject {
     
     private var cancellables = Set<AnyCancellable>()
     
-    // MARK: - Published
+    private weak var flowDelegate: FlowDelegate?
     
     @Published var isLoading: Bool = false
     @Published var sectionTitle: String = ""
     @Published var subtitle: String = ""
     @Published var lessons: [LessonDomainModel] = []
-    
-    // MARK: - Init
-    
+        
     init(flowDelegate: FlowDelegate, dataDownloader: InitialDataDownloader, localizationServices: LocalizationServices, analytics: AnalyticsContainer, getBannerImageUseCase: GetBannerImageUseCase, getLanguageAvailabilityUseCase: GetLanguageAvailabilityUseCase, getLessonsUseCase: GetLessonsUseCase, getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase, getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase, translationsRepository: TranslationsRepository) {
         self.flowDelegate = flowDelegate
         self.dataDownloader = dataDownloader

--- a/godtools/App/Features/Dashboard/Presentation/Tools/AllToolsContentView.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Tools/AllToolsContentView.swift
@@ -9,15 +9,16 @@
 import SwiftUI
 
 struct AllToolsContentView: View {
+        
+    private let leadingTrailingPadding: CGFloat
+        
+    @ObservedObject private var viewModel: AllToolsContentViewModel
     
-    // MARK: - Properties
-    
-    @ObservedObject var viewModel: AllToolsContentViewModel
-    let leadingTrailingPadding: CGFloat
-    
-    // MARK: - Init
-    
-    // MARK: - Body
+    init(viewModel: AllToolsContentViewModel, leadingTrailingPadding: CGFloat) {
+        
+        self.viewModel = viewModel
+        self.leadingTrailingPadding = leadingTrailingPadding
+    }
     
     var body: some View {
         VStack(spacing: 0) {

--- a/godtools/App/Features/Dashboard/Presentation/Tools/AllToolsContentViewModel.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Tools/AllToolsContentViewModel.swift
@@ -10,10 +10,7 @@ import Foundation
 import Combine
 
 class AllToolsContentViewModel: ObservableObject {
-    
-    // MARK: - Properties
-        
-    private weak var flowDelegate: FlowDelegate?
+            
     private let dataDownloader: InitialDataDownloader
     private let localizationServices: LocalizationServices
     private let favoritingToolMessageCache: FavoritingToolMessageCache
@@ -28,6 +25,8 @@ class AllToolsContentViewModel: ObservableObject {
     private let getToolCategoriesUseCase: GetToolCategoriesUseCase
     private let getToolIsFavoritedUseCase: GetToolIsFavoritedUseCase
     private let toggleToolFavoritedUseCase: ToggleToolFavoritedUseCase
+    
+    private weak var flowDelegate: FlowDelegate?
         
     private(set) lazy var spotlightViewModel: ToolSpotlightViewModel = {
         ToolSpotlightViewModel(
@@ -62,14 +61,10 @@ class AllToolsContentViewModel: ObservableObject {
             delegate: self
         )
     }()
-    
-    // MARK: - Published
-    
+        
     @Published var isLoading: Bool = false
     @Published var hideFavoritingToolBanner: Bool
-    
-    // MARK: - Init
-    
+        
     init(flowDelegate: FlowDelegate, dataDownloader: InitialDataDownloader, localizationServices: LocalizationServices, favoritingToolMessageCache: FavoritingToolMessageCache, analytics: AnalyticsContainer, getAllToolsUseCase: GetAllToolsUseCase, getBannerImageUseCase: GetBannerImageUseCase, getLanguageAvailabilityUseCase: GetLanguageAvailabilityUseCase, getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase, getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase, getSpotlightToolsUseCase: GetSpotlightToolsUseCase, getToolCategoriesUseCase: GetToolCategoriesUseCase, getToolIsFavoritedUseCase: GetToolIsFavoritedUseCase, toggleToolFavoritedUseCase: ToggleToolFavoritedUseCase) {
         self.flowDelegate = flowDelegate
         self.dataDownloader = dataDownloader

--- a/godtools/App/Features/Dashboard/Presentation/Tools/AllToolsList.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Tools/AllToolsList.swift
@@ -10,13 +10,17 @@ import SwiftUI
 
 struct AllToolsList: View {
     
-    // MARK: - Properties
+    private let width: CGFloat
+    private let leadingTrailingPadding: CGFloat
+       
+    @ObservedObject private var viewModel: AllToolsContentViewModel
     
-    @ObservedObject var viewModel: AllToolsContentViewModel
-    let width: CGFloat
-    let leadingTrailingPadding: CGFloat
-    
-    // MARK: - Body
+    init(viewModel: AllToolsContentViewModel, width: CGFloat, leadingTrailingPadding: CGFloat) {
+        
+        self.viewModel = viewModel
+        self.width = width
+        self.leadingTrailingPadding = leadingTrailingPadding
+    }
     
     var body: some View {
         
@@ -38,8 +42,6 @@ struct AllToolsList: View {
         .padding(.bottom, 26)
     }
 }
-
-// MARK: - Preview
 
 struct AllToolsList_Previews: PreviewProvider {
     static var previews: some View {

--- a/godtools/App/Features/Dashboard/Presentation/Tools/FavoritingToolBannerView/FavoritingToolBannerView.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Tools/FavoritingToolBannerView/FavoritingToolBannerView.swift
@@ -9,12 +9,13 @@
 import SwiftUI
 
 struct FavoritingToolBannerView: View {
+        
+    @ObservedObject private var viewModel: FavoritingToolBannerViewModel
     
-    // MARK: - Properties
-    
-    @ObservedObject var viewModel: FavoritingToolBannerViewModel
-    
-    // MARK: - Body
+    init(viewModel: FavoritingToolBannerViewModel) {
+        
+        self.viewModel = viewModel
+    }
     
     var body: some View {
         

--- a/godtools/App/Features/Dashboard/Presentation/Tools/FavoritingToolBannerView/ViewModel/FavoritingToolBannerViewModel.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Tools/FavoritingToolBannerView/ViewModel/FavoritingToolBannerViewModel.swift
@@ -13,18 +13,13 @@ protocol FavoritingToolBannerViewModelDelegate: AnyObject {
 }
 
 class FavoritingToolBannerViewModel: ObservableObject {
-    
-    // MARK: - Properties
-    
+        
     private let localizationServices: LocalizationServices
+    
     private weak var delegate: FavoritingToolBannerViewModelDelegate?
-    
-    // MARK: - Published
-    
+        
     @Published var message: String
-    
-    // MARK: - Init
-    
+        
     init(localizationServices: LocalizationServices, delegate: FavoritingToolBannerViewModelDelegate?) {
         self.localizationServices = localizationServices
         self.delegate = delegate

--- a/godtools/App/Features/Dashboard/Presentation/Tools/ToolCardsView/ToolCardView/SubViews/ToolCardNavButtonView.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Tools/ToolCardsView/ToolCardView/SubViews/ToolCardNavButtonView.swift
@@ -9,24 +9,23 @@
 import SwiftUI
 
 struct ToolCardNavButtonView: View {
-    
-    // MARK: - Properties
-    
-    @ObservedObject var viewModel: BaseToolCardViewModel
+        
     private let buttonWidth: CGFloat
     private let buttonSpacing: CGFloat
     
-    init(sizeToFit width: CGFloat, leadingPadding: CGFloat, buttonSpacing: CGFloat, viewModel: BaseToolCardViewModel) {
+    @ObservedObject private var viewModel: BaseToolCardViewModel
+    
+    init(viewModel: BaseToolCardViewModel, sizeToFit width: CGFloat, leadingPadding: CGFloat, buttonSpacing: CGFloat) {
+        
         let whiteSpaceAroundButtons = 2 * leadingPadding + buttonSpacing
         let buttonWidth = (width - whiteSpaceAroundButtons)/2
         
+        self.viewModel = viewModel
         self.buttonWidth = buttonWidth
         self.buttonSpacing = buttonSpacing
         self.viewModel = viewModel
     }
-    
-    // MARK: - Body
-    
+        
     var body: some View {
         HStack(spacing: buttonSpacing) {
             
@@ -57,7 +56,7 @@ struct ToolCardNavButtonView_Previews: PreviewProvider {
             delegate: nil
         )
         
-        ToolCardNavButtonView(sizeToFit: 200, leadingPadding: 20, buttonSpacing: 4, viewModel: viewModel)
+        ToolCardNavButtonView(viewModel: viewModel, sizeToFit: 200, leadingPadding: 20, buttonSpacing: 4)
             .previewLayout(.sizeThatFits)
     }
 }

--- a/godtools/App/Features/Dashboard/Presentation/Tools/ToolCardsView/ToolCardView/SubViews/ToolCardVerticalTextView.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Tools/ToolCardsView/ToolCardView/SubViews/ToolCardVerticalTextView.swift
@@ -9,15 +9,19 @@
 import SwiftUI
 
 struct ToolCardVerticalTextView: View {
+        
+    private let cardType: ToolCardType
+    private let cardWidth: CGFloat
     
-    // MARK: - Properties
+    @ObservedObject private var viewModel: BaseToolCardViewModel
     
-    @ObservedObject var viewModel: BaseToolCardViewModel
-    let cardType: ToolCardType
-    let cardWidth: CGFloat
-    
-    // MARK: - Body
-    
+    init(viewModel: BaseToolCardViewModel, cardType: ToolCardType, cardWidth: CGFloat) {
+        
+        self.viewModel = viewModel
+        self.cardType = cardType
+        self.cardWidth = cardWidth
+    }
+        
     var body: some View {
         VStack(alignment: .leading, spacing: 3) {
             

--- a/godtools/App/Features/Dashboard/Presentation/Tools/ToolCardsView/ToolCardView/ToolCardView.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Tools/ToolCardsView/ToolCardView/ToolCardView.swift
@@ -9,14 +9,17 @@
 import SwiftUI
 
 struct ToolCardView: View {
+
+    private enum Sizes {
+        static let cornerRadius: CGFloat = 6
+        static let leadingPadding: CGFloat = 15
+        static let navButtonWidthMultiplier: CGFloat = 192/335
+    }
     
-    // MARK: - Properties
+    private let cardType: ToolCardType
+    private let cardWidth: CGFloat
     
-    @ObservedObject var viewModel: BaseToolCardViewModel
-    let cardType: ToolCardType
-    let cardWidth: CGFloat
-    
-    var whiteSpaceHeight: CGFloat? {
+    private var whiteSpaceHeight: CGFloat? {
         switch cardType {
         case .standard, .standardWithNavButtons:
             return nil
@@ -27,15 +30,14 @@ struct ToolCardView: View {
         }
     }
     
-    // MARK: - Constants
+    @ObservedObject private var viewModel: BaseToolCardViewModel
     
-    private enum Sizes {
-        static let cornerRadius: CGFloat = 6
-        static let leadingPadding: CGFloat = 15
-        static let navButtonWidthMultiplier: CGFloat = 192/335
+    init(viewModel: BaseToolCardViewModel, cardType: ToolCardType, cardWidth: CGFloat) {
+        
+        self.viewModel = viewModel
+        self.cardType = cardType
+        self.cardWidth = cardWidth
     }
-    
-    // MARK: - Body
     
     var body: some View {
         ZStack(alignment: .top) {
@@ -64,7 +66,7 @@ struct ToolCardView: View {
                             if cardType == .squareWithNavButtons {
                                 Spacer(minLength: 0)
                                 
-                                ToolCardNavButtonView(sizeToFit: cardWidth, leadingPadding: Sizes.leadingPadding, buttonSpacing: 4, viewModel: viewModel)
+                                ToolCardNavButtonView(viewModel: viewModel, sizeToFit: cardWidth, leadingPadding: Sizes.leadingPadding, buttonSpacing: 4)
                             }
                         }
                         .padding(.leading, Sizes.leadingPadding)
@@ -80,7 +82,7 @@ struct ToolCardView: View {
                     }
                     
                     if cardType == .standardWithNavButtons {
-                        ToolCardNavButtonView(sizeToFit: cardWidth * Sizes.navButtonWidthMultiplier, leadingPadding: 0, buttonSpacing: 8, viewModel: viewModel)
+                        ToolCardNavButtonView(viewModel: viewModel, sizeToFit: cardWidth * Sizes.navButtonWidthMultiplier, leadingPadding: 0, buttonSpacing: 8)
                             .padding(.trailing, 14)
                     }
                 }

--- a/godtools/App/Features/Dashboard/Presentation/Tools/ToolCardsView/ToolCardView/ViewModels/ToolCardViewModel.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Tools/ToolCardsView/ToolCardView/ViewModels/ToolCardViewModel.swift
@@ -18,12 +18,8 @@ protocol ToolCardViewModelDelegate: AnyObject {
 }
 
 class ToolCardViewModel: BaseToolCardViewModel {
-    
-    // MARK: - Properties
-    
-    let tool: ToolDomainModel
+        
     private let localizationServices: LocalizationServices
-    
     private let getBannerImageUseCase: GetBannerImageUseCase
     private let getLanguageAvailabilityUseCase: GetLanguageAvailabilityUseCase
     private let getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase
@@ -32,9 +28,9 @@ class ToolCardViewModel: BaseToolCardViewModel {
     private weak var delegate: ToolCardViewModelDelegate?
         
     private var cancellables = Set<AnyCancellable>()
-        
-    // MARK: - Init
     
+    let tool: ToolDomainModel
+            
     init(tool: ToolDomainModel, localizationServices: LocalizationServices, getBannerImageUseCase: GetBannerImageUseCase, getLanguageAvailabilityUseCase: GetLanguageAvailabilityUseCase, getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase, getToolIsFavoritedUseCase: GetToolIsFavoritedUseCase, delegate: ToolCardViewModelDelegate?) {
         
         self.tool = tool

--- a/godtools/App/Features/Dashboard/Presentation/Tools/ToolCardsView/ToolCardsView.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Tools/ToolCardsView/ToolCardsView.swift
@@ -9,15 +9,20 @@
 import SwiftUI
 
 struct ToolCardsView: View {
+        
+    private let cardType: ToolCardType
+    private let width: CGFloat
+    private let leadingPadding: CGFloat
+        
+    @ObservedObject private var viewModel: ToolCardProvider
     
-    // MARK: - Properties
-    
-    @ObservedObject var viewModel: ToolCardProvider
-    let cardType: ToolCardType
-    let width: CGFloat
-    let leadingPadding: CGFloat
-    
-    // MARK: - Body
+    init(viewModel: ToolCardProvider, cardType: ToolCardType, width: CGFloat, leadingPadding: CGFloat) {
+        
+        self.viewModel = viewModel
+        self.cardType = cardType
+        self.width = width
+        self.leadingPadding = leadingPadding
+    }
     
     var body: some View {
         

--- a/godtools/App/Features/Dashboard/Presentation/Tools/ToolCardsView/ToolCardsViewModel.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Tools/ToolCardsView/ToolCardsViewModel.swift
@@ -14,25 +14,20 @@ protocol ToolCardsViewModelDelegate: ToolCardViewModelDelegate {
 }
 
 class ToolCardsViewModel: ToolCardProvider {
-    
-    // MARK: - Properties
-    
+        
     private let dataDownloader: InitialDataDownloader
     private let localizationServices: LocalizationServices
-    
     private let getAllToolsUseCase: GetAllToolsUseCase
     private let getBannerImageUseCase: GetBannerImageUseCase
     private let getLanguageAvailabilityUseCase: GetLanguageAvailabilityUseCase
     private let getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase
     private let getToolIsFavoritedUseCase: GetToolIsFavoritedUseCase
-    
-    private weak var delegate: ToolCardsViewModelDelegate?
-    private var cancellables = Set<AnyCancellable>()
-    
     private let categoryFilterValuePublisher = CurrentValueSubject<String?, Never>(nil)
     
-    // MARK: - Init
+    private var cancellables = Set<AnyCancellable>()
     
+    private weak var delegate: ToolCardsViewModelDelegate?
+        
     init(dataDownloader: InitialDataDownloader, localizationServices: LocalizationServices, getAllToolsUseCase: GetAllToolsUseCase, getBannerImageUseCase: GetBannerImageUseCase,  getLanguageAvailabilityUseCase: GetLanguageAvailabilityUseCase, getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase, getToolIsFavoritedUseCase: GetToolIsFavoritedUseCase, delegate: ToolCardsViewModelDelegate?) {
         self.dataDownloader = dataDownloader
         self.localizationServices = localizationServices
@@ -45,7 +40,7 @@ class ToolCardsViewModel: ToolCardProvider {
         
         self.delegate = delegate
         
-        super.init()
+        super.init(maxNumberOfCardsToShow: nil)
         
         setupBinding()
     }

--- a/godtools/App/Features/Dashboard/Presentation/Tools/ToolCategoriesView/ToolCategoriesView.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Tools/ToolCategoriesView/ToolCategoriesView.swift
@@ -10,13 +10,16 @@ import SwiftUI
 
 struct ToolCategoriesView: View {
     
-    // MARK: - Properties
+    private let leadingPadding: CGFloat
     
-    @ObservedObject var viewModel: ToolCategoriesViewModel
-    let leadingPadding: CGFloat
+    @ObservedObject private var viewModel: ToolCategoriesViewModel
     
-    // MARK: - Body
-    
+    init(viewModel: ToolCategoriesViewModel, leadingPadding: CGFloat) {
+        
+        self.viewModel = viewModel
+        self.leadingPadding = leadingPadding
+    }
+        
     var body: some View {
         VStack(alignment: .leading) {
             

--- a/godtools/App/Features/Dashboard/Presentation/Tools/ToolCategoriesView/ToolCategoriesViewModel.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Tools/ToolCategoriesView/ToolCategoriesViewModel.swift
@@ -14,25 +14,19 @@ protocol ToolCategoriesViewModelDelegate: AnyObject {
 }
 
 class ToolCategoriesViewModel: ObservableObject {
-    
-    // MARK: - Properties
-    
+        
     private let localizationServices: LocalizationServices
-    
     private let getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase
     private let getToolCategoriesUseCase: GetToolCategoriesUseCase
     
-    private weak var delegate: ToolCategoriesViewModelDelegate?
     private var cancellables = Set<AnyCancellable>()
-        
-    // MARK: - Published
     
+    private weak var delegate: ToolCategoriesViewModelDelegate?
+            
     @Published var categoryTitleText: String = ""
     @Published var buttonViewModels = [ToolCategoryButtonViewModel]()
     @Published var selectedCategoryId: String? = nil
-    
-    // MARK: - Init
-    
+        
     init(localizationServices: LocalizationServices, getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase, getToolCategoriesUseCase: GetToolCategoriesUseCase, delegate: ToolCategoriesViewModelDelegate?) {
         self.localizationServices = localizationServices
         

--- a/godtools/App/Features/Dashboard/Presentation/Tools/ToolCategoriesView/ToolCategoryButtonView/ToolCategoryButtonView.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Tools/ToolCategoriesView/ToolCategoryButtonView/ToolCategoryButtonView.swift
@@ -9,12 +9,13 @@
 import SwiftUI
 
 struct ToolCategoryButtonView: View {
+        
+    @ObservedObject private var viewModel: ToolCategoryButtonViewModel
     
-    // MARK: - Properties
-    
-    @ObservedObject var viewModel: ToolCategoryButtonViewModel
-    
-    // MARK: - Body
+    init(viewModel: ToolCategoryButtonViewModel) {
+        
+        self.viewModel = viewModel
+    }
     
     var body: some View {
         ZStack(alignment: .topLeading) {

--- a/godtools/App/Features/Dashboard/Presentation/Tools/ToolCategoriesView/ToolCategoryButtonView/ViewModels/ToolCategoryButtonViewModel.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Tools/ToolCategoriesView/ToolCategoryButtonView/ViewModels/ToolCategoryButtonViewModel.swift
@@ -9,19 +9,13 @@
 import Foundation
 
 class ToolCategoryButtonViewModel: ObservableObject {
-    
-    // MARK: - Properties
-    
+        
     let category: ToolCategoryDomainModel
-
-    // MARK: - Published
     
     @Published var categoryText: String = ""
     @Published var greyOutText: Bool = false
     @Published var showBorder: Bool = false
-        
-    // MARK: - Init
-    
+            
     init(category: ToolCategoryDomainModel, selectedCategoryId: String?) {
         self.category = category
         

--- a/godtools/App/Features/Dashboard/Presentation/Tools/ToolSpotlightView/Subviews/SpotlightTitleView.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Tools/ToolSpotlightView/Subviews/SpotlightTitleView.swift
@@ -9,14 +9,10 @@
 import SwiftUI
 
 struct SpotlightTitleView: View {
-    
-    // MARK: - Properties
-    
+        
     let title: String
     let subtitle: String
-    
-    // MARK: - Body
-    
+        
     var body: some View {
         VStack(alignment: .leading, spacing: 3) {
             

--- a/godtools/App/Features/Dashboard/Presentation/Tools/ToolSpotlightView/ToolSpotlightView.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Tools/ToolSpotlightView/ToolSpotlightView.swift
@@ -9,15 +9,19 @@
 import SwiftUI
 
 struct ToolSpotlightView: View {
+        
+    private let width: CGFloat
+    private let leadingPadding: CGFloat
     
-    // MARK: - Properties
+    @ObservedObject private var viewModel: ToolSpotlightViewModel
     
-    @ObservedObject var viewModel: ToolSpotlightViewModel
-    let width: CGFloat
-    let leadingPadding: CGFloat
-    
-    // MARK: - Body
-    
+    init(viewModel: ToolSpotlightViewModel, width: CGFloat, leadingPadding: CGFloat) {
+        
+        self.viewModel = viewModel
+        self.width = width
+        self.leadingPadding = leadingPadding
+    }
+        
     var body: some View {
         
         if viewModel.tools.isEmpty == false {

--- a/godtools/App/Features/Dashboard/Presentation/Tools/ToolSpotlightView/ViewModels/ToolSpotlightViewModel.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Tools/ToolSpotlightView/ViewModels/ToolSpotlightViewModel.swift
@@ -14,12 +14,9 @@ protocol ToolSpotlightViewModelDelegate: AnyObject {
 }
 
 class ToolSpotlightViewModel: ToolCardProvider {
-    
-    // MARK: - Properties
-    
+        
     private let dataDownloader: InitialDataDownloader
     private let localizationServices: LocalizationServices
-    
     private let getBannerImageUseCase: GetBannerImageUseCase
     private let getLanguageAvailabilityUseCase: GetLanguageAvailabilityUseCase
     private let getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase
@@ -27,17 +24,13 @@ class ToolSpotlightViewModel: ToolCardProvider {
     private let getSpotlightToolsUseCase: GetSpotlightToolsUseCase
     private let getToolIsFavoritedUseCase: GetToolIsFavoritedUseCase
     
-    private weak var delegate: ToolSpotlightViewModelDelegate?
-    
     private var cancellables = Set<AnyCancellable>()
     
-    // MARK: - Published
-    
+    private weak var delegate: ToolSpotlightViewModelDelegate?
+        
     @Published var spotlightTitle: String = ""
     @Published var spotlightSubtitle: String = ""
-    
-    // MARK: - Init
-    
+        
     init(dataDownloader: InitialDataDownloader, localizationServices: LocalizationServices, getBannerImageUseCase: GetBannerImageUseCase, getLanguageAvailabilityUseCase: GetLanguageAvailabilityUseCase, getSettingsParallelLanguageUseCase: GetSettingsParallelLanguageUseCase, getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase, getSpotlightToolsUseCase: GetSpotlightToolsUseCase, getToolIsFavoritedUseCase: GetToolIsFavoritedUseCase, delegate: ToolSpotlightViewModelDelegate?) {
         self.dataDownloader = dataDownloader
         self.localizationServices = localizationServices
@@ -51,7 +44,7 @@ class ToolSpotlightViewModel: ToolCardProvider {
         
         self.delegate = delegate
         
-        super.init()
+        super.init(maxNumberOfCardsToShow: nil)
         
         setupBinding()
     }

--- a/godtools/App/Features/Menu/Presentation/Account/AccountView.swift
+++ b/godtools/App/Features/Menu/Presentation/Account/AccountView.swift
@@ -10,8 +10,13 @@ import SwiftUI
 
 struct AccountView: View {
     
-    @ObservedObject var viewModel: AccountViewModel
+    @ObservedObject private var viewModel: AccountViewModel
         
+    init(viewModel: AccountViewModel) {
+        
+        self.viewModel = viewModel
+    }
+    
     var body: some View {
         
         GeometryReader { geometry in

--- a/godtools/App/Features/Menu/Presentation/Account/Subviews/AccountActivityView/AccountActivityView.swift
+++ b/godtools/App/Features/Menu/Presentation/Account/Subviews/AccountActivityView/AccountActivityView.swift
@@ -10,9 +10,15 @@ import SwiftUI
 
 struct AccountActivityView: View {
         
-    @ObservedObject var viewModel: AccountViewModel
+    @ObservedObject private var viewModel: AccountViewModel
     
     let sectionFrameWidth: CGFloat
+    
+    init(viewModel: AccountViewModel, sectionFrameWidth: CGFloat) {
+        
+        self.viewModel = viewModel
+        self.sectionFrameWidth = sectionFrameWidth
+    }
     
     var body: some View {
         

--- a/godtools/App/Features/Menu/Presentation/Account/Subviews/AccountGlobalActivity/AccountGlobalActivity.swift
+++ b/godtools/App/Features/Menu/Presentation/Account/Subviews/AccountGlobalActivity/AccountGlobalActivity.swift
@@ -12,9 +12,15 @@ struct AccountGlobalActivity: View {
     
     private let itemSpacing: CGFloat = 20
     
-    @ObservedObject var viewModel: AccountViewModel
+    @ObservedObject private var viewModel: AccountViewModel
     
     let sectionFrameWidth: CGFloat
+    
+    init(viewModel: AccountViewModel, sectionFrameWidth: CGFloat) {
+        
+        self.viewModel = viewModel
+        self.sectionFrameWidth = sectionFrameWidth
+    }
     
     var body: some View {
         

--- a/godtools/App/Features/Menu/Presentation/Account/Subviews/AccountGlobalActivity/Subviews/AccountGlobalActivityAnalyticsItemView.swift
+++ b/godtools/App/Features/Menu/Presentation/Account/Subviews/AccountGlobalActivity/Subviews/AccountGlobalActivityAnalyticsItemView.swift
@@ -12,7 +12,12 @@ struct AccountGlobalActivityAnalyticsItemView: View {
     
     private let cornerRadius: CGFloat = 10
     
-    @ObservedObject var viewModel: AccountGlobalActivityAnalyticsItemViewModel
+    @ObservedObject private var viewModel: AccountGlobalActivityAnalyticsItemViewModel
+    
+    init(viewModel: AccountGlobalActivityAnalyticsItemViewModel) {
+        
+        self.viewModel = viewModel
+    }
     
     var body: some View {
         

--- a/godtools/App/Features/Menu/Presentation/Account/Subviews/AccountSections/AccountSectionsView.swift
+++ b/godtools/App/Features/Menu/Presentation/Account/Subviews/AccountSections/AccountSectionsView.swift
@@ -18,9 +18,15 @@ struct AccountSectionsView: View {
     
     @State private var selectedSegmentIndex: Int = 0
     
-    @ObservedObject var viewModel: AccountViewModel
+    @ObservedObject private var viewModel: AccountViewModel
     
     let geometry: GeometryProxy
+    
+    init(viewModel: AccountViewModel, geometry: GeometryProxy) {
+        
+        self.viewModel = viewModel
+        self.geometry = geometry
+    }
     
     var body: some View {
         

--- a/godtools/App/Features/Menu/Presentation/Account/Subviews/AccountUserDetails/AccountUserDetailsView.swift
+++ b/godtools/App/Features/Menu/Presentation/Account/Subviews/AccountUserDetails/AccountUserDetailsView.swift
@@ -10,7 +10,12 @@ import SwiftUI
 
 struct AccountUserDetailsView: View {
     
-    @ObservedObject var viewModel: AccountViewModel
+    @ObservedObject private var viewModel: AccountViewModel
+    
+    init(viewModel: AccountViewModel) {
+        
+        self.viewModel = viewModel
+    }
     
     var body: some View {
         

--- a/godtools/App/Features/Onboarding/Presentation/OnboardingQuickStart/OnboardingQuickStartView.swift
+++ b/godtools/App/Features/Onboarding/Presentation/OnboardingQuickStart/OnboardingQuickStartView.swift
@@ -14,7 +14,12 @@ struct OnboardingQuickStartView: View {
     private let itemSpacing: CGFloat = 10
     private let itemHorizontalPadding: CGFloat = 30
     
-    @ObservedObject var viewModel: OnboardingQuickStartViewModel
+    @ObservedObject private var viewModel: OnboardingQuickStartViewModel
+    
+    init(viewModel: OnboardingQuickStartViewModel) {
+        
+        self.viewModel = viewModel
+    }
     
     var body: some View {
          

--- a/godtools/App/Features/Onboarding/Presentation/OnboardingQuickStart/Subviews/OnboardingQuickStartItem/OnboardingQuickStartItemView.swift
+++ b/godtools/App/Features/Onboarding/Presentation/OnboardingQuickStart/Subviews/OnboardingQuickStartItem/OnboardingQuickStartItemView.swift
@@ -12,10 +12,17 @@ struct OnboardingQuickStartItemView: View {
     
     private let backgroundColor: Color = Color.getColorWithRGB(red: 244, green: 244, blue: 244, opacity: 1)
     
-    @ObservedObject var viewModel: OnboardingQuickStartItemViewModel
+    @ObservedObject private var viewModel: OnboardingQuickStartItemViewModel
     
     let geometry: GeometryProxy
     let itemTappedClosure: (() -> Void)
+    
+    init(viewModel: OnboardingQuickStartItemViewModel, geometry: GeometryProxy, itemTappedClosure: @escaping (() -> Void)) {
+        
+        self.viewModel = viewModel
+        self.geometry = geometry
+        self.itemTappedClosure = itemTappedClosure
+    }
     
     var body: some View {
         

--- a/godtools/App/Features/Onboarding/Presentation/OnboardingTutorial/OnboardingTutorialView.swift
+++ b/godtools/App/Features/Onboarding/Presentation/OnboardingTutorial/OnboardingTutorialView.swift
@@ -10,7 +10,12 @@ import SwiftUI
 
 struct OnboardingTutorialView: View {
         
-    @ObservedObject var viewModel: OnboardingTutorialViewModel
+    @ObservedObject private var viewModel: OnboardingTutorialViewModel
+    
+    init(viewModel: OnboardingTutorialViewModel) {
+        
+        self.viewModel = viewModel
+    }
     
     var body: some View {
         

--- a/godtools/App/Features/Onboarding/Presentation/OnboardingTutorial/Subviews/OnboardingTutorialMedia/OnboardingTutorialMediaView.swift
+++ b/godtools/App/Features/Onboarding/Presentation/OnboardingTutorial/Subviews/OnboardingTutorialMedia/OnboardingTutorialMediaView.swift
@@ -12,9 +12,15 @@ struct OnboardingTutorialMediaView: View {
         
     private let animationAspectRatio: CGSize = CGSize(width: 154, height: 139)
     
-    @ObservedObject var viewModel: OnboardingTutorialMediaViewModel
+    @ObservedObject private var viewModel: OnboardingTutorialMediaViewModel
         
     let geometry: GeometryProxy
+    
+    init(viewModel: OnboardingTutorialMediaViewModel, geometry: GeometryProxy) {
+        
+        self.viewModel = viewModel
+        self.geometry = geometry
+    }
     
     var body: some View {
         

--- a/godtools/App/Features/Onboarding/Presentation/OnboardingTutorial/Subviews/OnboardingTutorialReadyForEveryConversation/OnboardingTutorialReadyForEveryConversationView.swift
+++ b/godtools/App/Features/Onboarding/Presentation/OnboardingTutorial/Subviews/OnboardingTutorialReadyForEveryConversation/OnboardingTutorialReadyForEveryConversationView.swift
@@ -12,10 +12,17 @@ struct OnboardingTutorialReadyForEveryConversationView: View {
     
     private let logoAspectRatio: CGSize = CGSize(width: 221, height: 131)
     
-    @ObservedObject var viewModel: OnboardingTutorialReadyForEveryConversationViewModel
+    @ObservedObject private var viewModel: OnboardingTutorialReadyForEveryConversationViewModel
     
     let geometry: GeometryProxy
     let watchVideoTappedClosure: (() -> Void)
+    
+    init(viewModel: OnboardingTutorialReadyForEveryConversationViewModel, geometry: GeometryProxy, watchVideoTappedClosure: @escaping (() -> Void)) {
+        
+        self.viewModel = viewModel
+        self.geometry = geometry
+        self.watchVideoTappedClosure = watchVideoTappedClosure
+    }
     
     var body: some View {
         

--- a/godtools/App/Features/ToolDetails/Presentation/ToolDetails/Subviews/ToolDetailsMediaView.swift
+++ b/godtools/App/Features/ToolDetails/Presentation/ToolDetails/Subviews/ToolDetailsMediaView.swift
@@ -15,7 +15,7 @@ struct ToolDetailsMediaView: View {
     
     @State private var videoPlayerState: VideoViewPlayerState = .stopped
     
-    @ObservedObject var viewModel: ToolDetailsViewModel
+    @ObservedObject private var viewModel: ToolDetailsViewModel
         
     init(viewModel: ToolDetailsViewModel, width: CGFloat) {
         

--- a/godtools/App/Features/ToolDetails/Presentation/ToolDetails/Subviews/ToolDetailsPrimaryButtonsView.swift
+++ b/godtools/App/Features/ToolDetails/Presentation/ToolDetails/Subviews/ToolDetailsPrimaryButtonsView.swift
@@ -13,9 +13,15 @@ struct ToolDetailsPrimaryButtonsView: View {
     private let primaryButtonHeight: CGFloat = 55
     private let primaryButtonCornerRadius: CGFloat = 8
     
-    @ObservedObject var viewModel: ToolDetailsViewModel
+    @ObservedObject private var viewModel: ToolDetailsViewModel
        
     let primaryButtonWidth: CGFloat
+    
+    init(viewModel: ToolDetailsViewModel, primaryButtonWidth: CGFloat) {
+        
+        self.viewModel = viewModel
+        self.primaryButtonWidth = primaryButtonWidth
+    }
     
     var body: some View {
         

--- a/godtools/App/Features/ToolDetails/Presentation/ToolDetails/Subviews/ToolDetailsTitleHeaderView.swift
+++ b/godtools/App/Features/ToolDetails/Presentation/ToolDetails/Subviews/ToolDetailsTitleHeaderView.swift
@@ -10,7 +10,12 @@ import SwiftUI
 
 struct ToolDetailsTitleHeaderView: View {
     
-    @ObservedObject var viewModel: ToolDetailsViewModel
+    @ObservedObject private var viewModel: ToolDetailsViewModel
+    
+    init(viewModel: ToolDetailsViewModel) {
+        
+        self.viewModel = viewModel
+    }
     
     var body: some View {
         

--- a/godtools/App/Features/ToolDetails/Presentation/ToolDetails/Subviews/ToolDetailsToggleFavoriteButton.swift
+++ b/godtools/App/Features/ToolDetails/Presentation/ToolDetails/Subviews/ToolDetailsToggleFavoriteButton.swift
@@ -9,8 +9,6 @@
 import SwiftUI
 
 struct ToolDetailsToggleFavoriteButton: View {
-        
-    @ObservedObject var viewModel: ToolDetailsViewModel
     
     private let iconName: String
     private let title: String
@@ -18,6 +16,8 @@ struct ToolDetailsToggleFavoriteButton: View {
     private let width: CGFloat
     private let height: CGFloat
     private let cornerRadius: CGFloat
+    
+    @ObservedObject private var viewModel: ToolDetailsViewModel
         
     init(viewModel: ToolDetailsViewModel, width: CGFloat, height: CGFloat, cornerRadius: CGFloat) {
         

--- a/godtools/App/Features/ToolDetails/Presentation/ToolDetails/Subviews/VersionsCard/ToolDetailsVersionsCardView.swift
+++ b/godtools/App/Features/ToolDetails/Presentation/ToolDetails/Subviews/VersionsCard/ToolDetailsVersionsCardView.swift
@@ -12,10 +12,16 @@ struct ToolDetailsVersionsCardView: View {
     
     private let bannerHeight: CGFloat = 87
     
-    @ObservedObject var viewModel: ToolDetailsVersionsCardViewModel
+    @ObservedObject private var viewModel: ToolDetailsVersionsCardViewModel
     
     let width: CGFloat
         
+    init(viewModel: ToolDetailsVersionsCardViewModel, width: CGFloat) {
+        
+        self.viewModel = viewModel
+        self.width = width
+    }
+    
     var body: some View {
         
         ZStack {

--- a/godtools/App/Features/ToolDetails/Presentation/ToolDetails/ToolDetailsView.swift
+++ b/godtools/App/Features/ToolDetails/Presentation/ToolDetails/ToolDetailsView.swift
@@ -10,15 +10,20 @@ import SwiftUI
 
 struct ToolDetailsView: View {
     
-    static let sectionDescriptionTextInsets: EdgeInsets = EdgeInsets(top: 0, leading: 30, bottom: 0, trailing: 30)
-    
     private static let headerViewId: String = "HeaderViewId"
+    
+    static let sectionDescriptionTextInsets: EdgeInsets = EdgeInsets(top: 0, leading: 30, bottom: 0, trailing: 30)
     
     private let contentInsets: EdgeInsets = EdgeInsets(top: 0, leading: 40, bottom: 0, trailing: 40)
     
     @State private var selectedSegmentIndex: Int = 0
     
-    @ObservedObject var viewModel: ToolDetailsViewModel
+    @ObservedObject private var viewModel: ToolDetailsViewModel
+    
+    init(viewModel: ToolDetailsViewModel) {
+        
+        self.viewModel = viewModel
+    }
     
     var body: some View {
         

--- a/godtools/App/Features/ToolSettings/Presentation/LanguagesList/LanguagesListView.swift
+++ b/godtools/App/Features/ToolSettings/Presentation/LanguagesList/LanguagesListView.swift
@@ -10,7 +10,12 @@ import SwiftUI
 
 struct LanguagesListView: View {
         
-    @ObservedObject var viewModel: LanguagesListViewModel
+    @ObservedObject private var viewModel: LanguagesListViewModel
+    
+    init(viewModel: LanguagesListViewModel) {
+        
+        self.viewModel = viewModel
+    }
     
     var body: some View {
         

--- a/godtools/App/Features/ToolSettings/Presentation/LanguagesList/Subviews/LanguagesListItemView.swift
+++ b/godtools/App/Features/ToolSettings/Presentation/LanguagesList/Subviews/LanguagesListItemView.swift
@@ -13,7 +13,12 @@ struct LanguagesListItemView: View {
     private let highlightColor: Color = Color(.sRGB, red: 209 / 256, green: 238 / 256, blue: 213 / 256, opacity: 1)
     private let verticalSpacing: CGFloat = 15
     
-    @ObservedObject var viewModel: BaseLanguagesListItemViewModel
+    @ObservedObject private var viewModel: BaseLanguagesListItemViewModel
+    
+    init(viewModel: BaseLanguagesListItemViewModel) {
+        
+        self.viewModel = viewModel
+    }
     
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {

--- a/godtools/App/Features/ToolSettings/Presentation/ReviewShareShareable/ReviewShareShareableView.swift
+++ b/godtools/App/Features/ToolSettings/Presentation/ReviewShareShareable/ReviewShareShareableView.swift
@@ -14,7 +14,12 @@ struct ReviewShareShareableView: View {
     private let maxPreviewImageSize: CGFloat = 250
     private let bottomSpacing: CGFloat = 50
     
-    @ObservedObject var viewModel: ReviewShareShareableViewModel
+    @ObservedObject private var viewModel: ReviewShareShareableViewModel
+    
+    init(viewModel: ReviewShareShareableViewModel) {
+        
+        self.viewModel = viewModel
+    }
     
     var body: some View {
         

--- a/godtools/App/Features/ToolSettings/Presentation/ToolSettings/Subviews/ToolSettingsChooseLanguage/ToolSettingsChooseLanguageView.swift
+++ b/godtools/App/Features/ToolSettings/Presentation/ToolSettings/Subviews/ToolSettingsChooseLanguage/ToolSettingsChooseLanguageView.swift
@@ -11,11 +11,19 @@ struct ToolSettingsChooseLanguageView: View {
     
     private let languageDropDownHeight: CGFloat = 52
     
-    @ObservedObject var viewModel: ToolSettingsViewModel
+    @ObservedObject private var viewModel: ToolSettingsViewModel
     
     let geometryProxy: GeometryProxy
     let leadingInset: CGFloat
     let trailingInset: CGFloat
+    
+    init(viewModel: ToolSettingsViewModel, geometryProxy: GeometryProxy, leadingInset: CGFloat, trailingInset: CGFloat) {
+        
+        self.viewModel = viewModel
+        self.geometryProxy = geometryProxy
+        self.leadingInset = leadingInset
+        self.trailingInset = trailingInset
+    }
         
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {

--- a/godtools/App/Features/ToolSettings/Presentation/ToolSettings/Subviews/ToolSettingsOptions/ToolSettingsOptionsView.swift
+++ b/godtools/App/Features/ToolSettings/Presentation/ToolSettings/Subviews/ToolSettingsOptions/ToolSettingsOptionsView.swift
@@ -9,10 +9,17 @@ import SwiftUI
 
 struct ToolSettingsOptionsView: View {
             
-    @ObservedObject var viewModel: ToolSettingsViewModel
+    @ObservedObject private var viewModel: ToolSettingsViewModel
     
     let leadingInset: CGFloat
     let trailingInset: CGFloat
+    
+    init(viewModel: ToolSettingsViewModel, leadingInset: CGFloat, trailingInset: CGFloat) {
+        
+        self.viewModel = viewModel
+        self.leadingInset = leadingInset
+        self.trailingInset = trailingInset
+    }
     
     var body: some View {
         

--- a/godtools/App/Features/ToolSettings/Presentation/ToolSettings/Subviews/ToolSettingsShareables/ToolSettingsShareableItemView.swift
+++ b/godtools/App/Features/ToolSettings/Presentation/ToolSettings/Subviews/ToolSettingsShareables/ToolSettingsShareableItemView.swift
@@ -11,7 +11,12 @@ struct ToolSettingsShareableItemView: View {
     
     private let itemSize: CGSize = CGSize(width: 112, height: 112)
     
-    @ObservedObject var viewModel: ToolSettingsShareableItemViewModel
+    @ObservedObject private var viewModel: ToolSettingsShareableItemViewModel
+    
+    init(viewModel: ToolSettingsShareableItemViewModel) {
+        
+        self.viewModel = viewModel
+    }
     
     var body: some View {
         

--- a/godtools/App/Features/ToolSettings/Presentation/ToolSettings/Subviews/ToolSettingsShareables/ToolSettingsShareablesView.swift
+++ b/godtools/App/Features/ToolSettings/Presentation/ToolSettings/Subviews/ToolSettingsShareables/ToolSettingsShareablesView.swift
@@ -11,10 +11,17 @@ struct ToolSettingsShareablesView: View {
     
     private let relatedContentSize: CGSize = CGSize(width: 112, height: 112)
     
-    @ObservedObject var viewModel: ToolSettingsViewModel
+    @ObservedObject private var viewModel: ToolSettingsViewModel
     
     let leadingInset: CGFloat
     let trailingInset: CGFloat
+    
+    init(viewModel: ToolSettingsViewModel, leadingInset: CGFloat, trailingInset: CGFloat) {
+        
+        self.viewModel = viewModel
+        self.leadingInset = leadingInset
+        self.trailingInset = trailingInset
+    }
         
     var body: some View {
         

--- a/godtools/App/Features/ToolSettings/Presentation/ToolSettings/Subviews/ToolSettingsTopBarView/ToolSettingsTopBarView.swift
+++ b/godtools/App/Features/ToolSettings/Presentation/ToolSettings/Subviews/ToolSettingsTopBarView/ToolSettingsTopBarView.swift
@@ -9,10 +9,17 @@ import SwiftUI
 
 struct ToolSettingsTopBarView: View {
         
-    @ObservedObject var viewModel: ToolSettingsViewModel
+    @ObservedObject private var viewModel: ToolSettingsViewModel
     
     let leadingInset: CGFloat
     let trailingInset: CGFloat
+    
+    init(viewModel: ToolSettingsViewModel, leadingInset: CGFloat, trailingInset: CGFloat) {
+        
+        self.viewModel = viewModel
+        self.leadingInset = leadingInset
+        self.trailingInset = trailingInset
+    }
     
     var body: some View {
         HStack {

--- a/godtools/App/Features/ToolSettings/Presentation/ToolSettings/ToolSettingsView.swift
+++ b/godtools/App/Features/ToolSettings/Presentation/ToolSettings/ToolSettingsView.swift
@@ -9,11 +9,16 @@ import SwiftUI
 
 struct ToolSettingsView: View {
     
-    @ObservedObject var viewModel: ToolSettingsViewModel
-    
     private let contentInsets: EdgeInsets = EdgeInsets(top: 20, leading: 20, bottom: 0, trailing: 20)
     private let separatorLineSpacing: CGFloat = 20
     private let bottomSpace: CGFloat = 15
+    
+    @ObservedObject private var viewModel: ToolSettingsViewModel
+    
+    init(viewModel: ToolSettingsViewModel) {
+        
+        self.viewModel = viewModel
+    }
     
     var body: some View {
         GeometryReader { geometry in

--- a/godtools/App/Flows/App/AppFlow.swift
+++ b/godtools/App/Flows/App/AppFlow.swift
@@ -13,7 +13,7 @@ import Combine
 
 class AppFlow: NSObject, ToolNavigationFlow, Flow {
     
-    private static let defaultStartingDashboardTab: DashboardTabTypeDomainModel = .favorites
+    private static let defaultStartingDashboardTab: DashboardTabTypeDomainModel = .lessons
     
     private let dataDownloader: InitialDataDownloader
     private let followUpsService: FollowUpsService

--- a/godtools/App/Share/Domain/ViewModels/ToolCardProvider.swift
+++ b/godtools/App/Share/Domain/ViewModels/ToolCardProvider.swift
@@ -9,21 +9,22 @@
 import Foundation
 
 class ToolCardProvider: NSObject, ObservableObject {
-    
-    // MARK: - Properties
-    
-    var maxNumberCardsToShow: Int? = nil
-    
-    // MARK: - Published
-    
+
+    let maxNumberOfCardsToShow: Int?
+        
     @Published var tools: [ToolDomainModel] = []
-    
-    // MARK: - Public
+        
+    init(maxNumberOfCardsToShow: Int?) {
+        
+        self.maxNumberOfCardsToShow = maxNumberOfCardsToShow
+    }
     
     func cardViewModel(for tool: ToolDomainModel) -> BaseToolCardViewModel {
         assertionFailure("This method should be overriden in the subclass")
         return BaseToolCardViewModel()
     }
     
-    func toolTapped(_ tool: ToolDomainModel) {}
+    func toolTapped(_ tool: ToolDomainModel) {
+        
+    }
 }

--- a/godtools/App/Share/SwiftUI Views/BannerView/BannerView.swift
+++ b/godtools/App/Share/SwiftUI Views/BannerView/BannerView.swift
@@ -9,14 +9,10 @@
 import SwiftUI
 
 struct BannerView<Content: View>: View {
-    
-    // MARK: - Properties
-    
+        
     let content: () -> Content
     let closeButtonTapHandler: () -> Void
-    
-    // MARK: - Body
-    
+        
     var body: some View {
         ZStack(alignment: .topTrailing) {
             ColorPalette.banner.color

--- a/godtools/App/Share/SwiftUI Views/FullScreenVideoView/FullScreenVideoView.swift
+++ b/godtools/App/Share/SwiftUI Views/FullScreenVideoView/FullScreenVideoView.swift
@@ -12,9 +12,15 @@ struct FullScreenVideoView: View {
     
     @State private var videoPlayerState: VideoViewPlayerState = .stopped
     
-    @ObservedObject var viewModel: FullScreenVideoViewModel
+    @ObservedObject private var viewModel: FullScreenVideoViewModel
     
     let backgroundColor: Color
+    
+    init(viewModel: FullScreenVideoViewModel, backgroundColor: Color) {
+        
+        self.viewModel = viewModel
+        self.backgroundColor = backgroundColor
+    }
     
     var body: some View {
         

--- a/godtools/App/Share/SwiftUI Views/LessonCardView/LessonCardView.swift
+++ b/godtools/App/Share/SwiftUI Views/LessonCardView/LessonCardView.swift
@@ -9,20 +9,21 @@
 import SwiftUI
 
 struct LessonCardView: View {
-    
-    // MARK: - Properties
-    
-    @ObservedObject var viewModel: BaseLessonCardViewModel
-    let cardWidth: CGFloat
-    
-    // MARK: - Constants
-    
+        
     private enum Sizes {
         static let cornerRadius: CGFloat = 6
         static let leadingPadding: CGFloat = 15
     }
     
-    // MARK: - Body
+    private let cardWidth: CGFloat
+        
+    @ObservedObject private var viewModel: BaseLessonCardViewModel
+    
+    init(viewModel: BaseLessonCardViewModel, cardWidth: CGFloat) {
+        
+        self.viewModel = viewModel
+        self.cardWidth = cardWidth
+    }
     
     var body: some View {
         ZStack(alignment: .top) {

--- a/godtools/App/Share/SwiftUI Views/LessonCardView/ViewModels/LessonCardViewModel.swift
+++ b/godtools/App/Share/SwiftUI Views/LessonCardView/ViewModels/LessonCardViewModel.swift
@@ -14,22 +14,18 @@ protocol LessonCardDelegate: AnyObject {
 }
 
 class LessonCardViewModel: BaseLessonCardViewModel {
-    
-    // MARK: - Properties
-    
-    let lesson: LessonDomainModel
-    let dataDownloader: InitialDataDownloader
-    
+        
     private let translationsRepository: TranslationsRepository
     private let getBannerImageUseCase: GetBannerImageUseCase
     private let getLanguageAvailabilityUseCase: GetLanguageAvailabilityUseCase
     private let getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase
     
-    private weak var delegate: LessonCardDelegate?
-    
     private var cancellables = Set<AnyCancellable>()
     
-    // MARK: - Init
+    private weak var delegate: LessonCardDelegate?
+    
+    let lesson: LessonDomainModel
+    let dataDownloader: InitialDataDownloader
     
     init(lesson: LessonDomainModel, dataDownloader: InitialDataDownloader, translationsRepository: TranslationsRepository, getBannerImageUseCase: GetBannerImageUseCase, getLanguageAvailabilityUseCase: GetLanguageAvailabilityUseCase, getSettingsPrimaryLanguageUseCase: GetSettingsPrimaryLanguageUseCase, delegate: LessonCardDelegate?) {
         self.lesson = lesson
@@ -46,15 +42,11 @@ class LessonCardViewModel: BaseLessonCardViewModel {
         
         setup()
     }
-
-    // MARK: - Overrides
     
     override func lessonCardTapped() {
         delegate?.lessonCardTapped(lesson: lesson)
     }
 }
-
-// MARK: - Private
 
 extension LessonCardViewModel {
     

--- a/godtools/App/Share/SwiftUI Views/ResourceCard Subviews/ResourceCardBannerImageView.swift
+++ b/godtools/App/Share/SwiftUI Views/ResourceCard Subviews/ResourceCardBannerImageView.swift
@@ -9,16 +9,7 @@
 import SwiftUI
 
 struct ResourceCardBannerImageView: View {
-    
-    // MARK: - Properties
-    
-    let bannerImage: Image?
-    let isSquareLayout: Bool
-    let cardWidth: CGFloat
-    let cornerRadius: CGFloat
-    
-    // MARK: - Constants
-    
+
     private enum Sizes {
         enum Standard {
             static let cardWidth: CGFloat = 335
@@ -32,7 +23,10 @@ struct ResourceCardBannerImageView: View {
         }
     }
     
-    // MARK: - Body
+    let bannerImage: Image?
+    let isSquareLayout: Bool
+    let cardWidth: CGFloat
+    let cornerRadius: CGFloat
     
     var body: some View {
         let bannerImageAspectRatio = isSquareLayout ? Sizes.Square.bannerImageAspectRatio : Sizes.Standard.bannerImageAspectRatio

--- a/godtools/App/Share/SwiftUI Views/RoundedCardBackgroundView/RoundedCardBackgroundView.swift
+++ b/godtools/App/Share/SwiftUI Views/RoundedCardBackgroundView/RoundedCardBackgroundView.swift
@@ -9,14 +9,16 @@
 import SwiftUI
 
 struct RoundedCardBackgroundView: View {
+        
+    let cornerRadius: CGFloat
+    let fillColor: Color
     
-    // MARK: - Properties
-    
-    var cornerRadius: CGFloat = 6
-    var fillColor: Color = .white
-    
-    // MARK: - Body
-    
+    init(cornerRadius: CGFloat = 6, fillColor: Color = .white) {
+        
+        self.cornerRadius = cornerRadius
+        self.fillColor = fillColor
+    }
+        
     var body: some View {
         RoundedRectangle(cornerRadius: cornerRadius, style: .circular)
             .fill(fillColor)

--- a/godtools/App/Share/SwiftUI Views/ToolCardsCarouselView/ToolCardsCarouselView.swift
+++ b/godtools/App/Share/SwiftUI Views/ToolCardsCarouselView/ToolCardsCarouselView.swift
@@ -9,28 +9,32 @@
 import SwiftUI
 
 struct ToolCardsCarouselView: View {
-    
-    // MARK: - Properties
-    
-    @ObservedObject var viewModel: ToolCardProvider
-    let cardType: ToolCardType
-    let width: CGFloat
-    let leadingTrailingPadding: CGFloat
-    
-    // MARK: - Constants
-    
+        
     private enum Sizes {
         static let spotlightCardWidthMultiplier: CGFloat = 200/375
     }
     
-    // MARK: - Body
+    private let cardType: ToolCardType
+    private let width: CGFloat
+    private let leadingTrailingPadding: CGFloat
+    
+    @ObservedObject private var viewModel: ToolCardProvider
+    
+    init(viewModel: ToolCardProvider, cardType: ToolCardType, width: CGFloat, leadingTrailingPadding: CGFloat) {
+        
+        self.viewModel = viewModel
+        self.cardType = cardType
+        self.width = width
+        self.leadingTrailingPadding = leadingTrailingPadding
+    }
     
     var body: some View {
         
         ScrollView(.horizontal, showsIndicators: false) {
             
             HStack(spacing: 15) {
-                if let maxNumberCardsToShow = viewModel.maxNumberCardsToShow, viewModel.tools.count > maxNumberCardsToShow {
+                
+                if let maxNumberCardsToShow = viewModel.maxNumberOfCardsToShow, viewModel.tools.count > maxNumberCardsToShow {
                     
                     ForEach(viewModel.tools[0..<maxNumberCardsToShow]) { tool in
                         


### PR DESCRIPTION
- Updated viewModels references to be private
- Removed MARKS for Init, Body, Properties, Constants as those seemed too generic/general.
- Restructured some of the class level constants and properties to follow the ReadMe.