### PR TITLE
GT-2102 Fix TabView bug in iOS 16 when device is in right to left language (Arabic)

### DIFF
--- a/godtools/App/Features/Dashboard/Presentation/Dashboard/DashboardView.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Dashboard/DashboardView.swift
@@ -58,6 +58,7 @@ struct DashboardView: View {
                 )
             }
         }
+        .flipsForRightToLeftLayoutDirection(true)
     }
 }
     

--- a/godtools/App/Features/LearnToShareTool/Presentation/LearnToShareTool/LearnToShareToolView.swift
+++ b/godtools/App/Features/LearnToShareTool/Presentation/LearnToShareTool/LearnToShareToolView.swift
@@ -56,5 +56,6 @@ struct LearnToShareToolView: View {
                 .padding(EdgeInsets(top: 20, leading: 0, bottom: 10, trailing: 0))
             }
         }
+        .flipsForRightToLeftLayoutDirection(true)
     }
 }

--- a/godtools/App/Features/Menu/Presentation/Tutorial/TutorialView.swift
+++ b/godtools/App/Features/Menu/Presentation/Tutorial/TutorialView.swift
@@ -49,12 +49,12 @@ struct TutorialView: View {
                 }
                 .tabViewStyle(.page(indexDisplayMode: .never))
                 .animation(.easeOut, value: viewModel.currentPage)
-                                                
+                
                 GTBlueButton(title: viewModel.continueTitle, font: FontLibrary.sfProTextRegular.font(size: 18), width: geometry.size.width - (continueButtonHorizontalPadding * 2), height: continueButtonHeight) {
                     
                     viewModel.continueTapped()
                 }
-                            
+                
                 PageControl(
                     numberOfPages: viewModel.numberOfPages,
                     attributes: pageControlAttributes,
@@ -64,5 +64,6 @@ struct TutorialView: View {
             }
             .frame(maxWidth: .infinity)
         }
+        .flipsForRightToLeftLayoutDirection(true)
     }
 }

--- a/godtools/App/Features/Onboarding/Presentation/OnboardingTutorial/OnboardingTutorialView.swift
+++ b/godtools/App/Features/Onboarding/Presentation/OnboardingTutorial/OnboardingTutorialView.swift
@@ -79,5 +79,6 @@ struct OnboardingTutorialView: View {
             }
             .frame(maxWidth: .infinity)
         }
+        .flipsForRightToLeftLayoutDirection(true)
     }
 }

--- a/godtools/App/Share/SwiftUI Views/PageControl/PageControl.swift
+++ b/godtools/App/Share/SwiftUI Views/PageControl/PageControl.swift
@@ -60,6 +60,7 @@ struct PageControl: View {
                 .fill(.clear)
                 .frame(width: 1, height: 10)
         }
+        .flipsForRightToLeftLayoutDirection(true)
     }
     
     private func scrollToPreviousPage() {


### PR DESCRIPTION
This PR fixes a bug in SwiftUI's TabView that occurred only in iOS 16.  iOS 15 there is no issue.  When the device is in a right to left language such as Arabic and scrolling through a TabView, the pager tied to the TabView would end up displaying the incorrect page index.  It would be mirrored, or flipped.  Adding this modifer fixes that (https://developer.apple.com/documentation/swiftui/view/flipsforrighttoleftlayoutdirection(_:)) In reading the documentation there it says that is enabled by default.  However, doesn't seem to be the case when using a TabView in iOS 16.