### PR TITLE
GT-2103 Provide page position state when switching the page renderer

### DIFF
--- a/godtools/App/Features/Dashboard/Presentation/ChooseYourOwnAdventure/ChooseYourOwnAdventureViewModel.swift
+++ b/godtools/App/Features/Dashboard/Presentation/ChooseYourOwnAdventure/ChooseYourOwnAdventureViewModel.swift
@@ -99,6 +99,6 @@ extension ChooseYourOwnAdventureViewModel {
     func navLanguageTapped(index: Int) {
         
         let pageRenderer: MobileContentPageRenderer = renderer.value.pageRenderers[index]
-        setPageRenderer(pageRenderer: pageRenderer, navigationEvent: nil)
+        setPageRenderer(pageRenderer: pageRenderer, navigationEvent: nil, pagePositions: nil)
     }
 }

--- a/godtools/App/Features/Dashboard/Presentation/Tool/ToolViewModel.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Tool/ToolViewModel.swift
@@ -190,7 +190,7 @@ extension ToolViewModel {
     func navLanguageChanged(page: Int, pagePositions: ToolPagePositions) {
         
         if let pageRenderer = getPageRenderer(language: navBarViewModel.value.language) {
-            setPageRenderer(pageRenderer: pageRenderer, navigationEvent: nil)
+            setPageRenderer(pageRenderer: pageRenderer, navigationEvent: nil, pagePositions: pagePositions)
         }
         
         sendRemoteShareNavigationEvent(
@@ -262,6 +262,7 @@ extension ToolViewModel {
         }
         
         let navBarLanguageChanged: Bool = remoteShareLanguage.id != currentNavBarLanguage.id
+        let pagePositions: MobileContentViewPositionState? = ToolPagePositions(cardPosition: cardPosition)
         
         let navigationEvent = MobileContentPagesNavigationEvent(
             pageNavigation: PageNavigationCollectionViewNavigationModel(
@@ -271,15 +272,13 @@ extension ToolViewModel {
                 reloadCollectionViewDataNeeded: navBarLanguageChanged,
                 insertPages: nil
             ),
-            pagePositions: ToolPagePositions(
-                cardPosition: cardPosition
-            )
+            pagePositions: pagePositions
         )
                         
         if let remoteShareLanguageIndex = remoteShareLanguageIndex, navBarLanguageChanged {
             
             navBarViewModel.value.selectedLanguage.accept(value: remoteShareLanguageIndex)
-            super.setPageRenderer(pageRenderer: renderer.value.pageRenderers[remoteShareLanguageIndex], navigationEvent: nil)
+            super.setPageRenderer(pageRenderer: renderer.value.pageRenderers[remoteShareLanguageIndex], navigationEvent: nil, pagePositions: pagePositions)
         }
         else {
             

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/Pages/MobileContentPagesViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/Pages/MobileContentPagesViewModel.swift
@@ -107,7 +107,7 @@ class MobileContentPagesViewModel: NSObject {
         
         trainingTipsEnabled = enabled
         
-        setPageRenderer(pageRenderer: currentPageRenderer.value, navigationEvent: nil)
+        setPageRenderer(pageRenderer: currentPageRenderer.value, navigationEvent: nil, pagePositions: nil)
     }
     
     // MARK: - Renderer / Page Renderer
@@ -140,10 +140,10 @@ class MobileContentPagesViewModel: NSObject {
         
         self.renderer.send(renderer)
                 
-        setPageRenderer(pageRenderer: pageRenderer, navigationEvent: navigationEvent)
+        setPageRenderer(pageRenderer: pageRenderer, navigationEvent: navigationEvent, pagePositions: nil)
     }
     
-    func setPageRenderer(pageRenderer: MobileContentPageRenderer, navigationEvent: MobileContentPagesNavigationEvent?) {
+    func setPageRenderer(pageRenderer: MobileContentPageRenderer, navigationEvent: MobileContentPagesNavigationEvent?, pagePositions: MobileContentViewPositionState?) {
             
         countLanguageUsageIfLanguageChanged(updatedLanguage: pageRenderer.language)
         
@@ -180,7 +180,7 @@ class MobileContentPagesViewModel: NSObject {
                     reloadCollectionViewDataNeeded: true,
                     insertPages: nil
                 ),
-                pagePositions: nil
+                pagePositions: pagePositions
             )
         }
                 


### PR DESCRIPTION
This fixes an issue where tool cards are closing when toggling between the primary and parallel language in a tool during screen share.