### PR TITLE
GT Add class to disable GoogleTagManager console logging

### DIFF
--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -664,6 +664,7 @@
 		45BDA64C2954FF08007E259B /* WebArchiveOperationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45BDA6422954FF08007E259B /* WebArchiveOperationError.swift */; };
 		45BDA64D2954FF08007E259B /* WebArchiveOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45BDA6432954FF08007E259B /* WebArchiveOperation.swift */; };
 		45BDA64E2954FF08007E259B /* WebArchiveQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45BDA6442954FF08007E259B /* WebArchiveQueue.swift */; };
+		45BEDB712A98DBD9009C7664 /* DisableGoogleTagManagerLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45BEDB702A98DBD9009C7664 /* DisableGoogleTagManagerLogging.swift */; };
 		45BF2B9E27A9573F00D23EDA /* MobileContentPagesInitialPageRenderingType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45BF2B9D27A9573F00D23EDA /* MobileContentPagesInitialPageRenderingType.swift */; };
 		45BF6EBA27050A29003596A4 /* TransparentModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45BF6EB927050A29003596A4 /* TransparentModalView.swift */; };
 		45BF6EBC27050A3F003596A4 /* TransparentModalView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 45BF6EBB27050A3F003596A4 /* TransparentModalView.xib */; };
@@ -1753,6 +1754,7 @@
 		45BDA6422954FF08007E259B /* WebArchiveOperationError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebArchiveOperationError.swift; sourceTree = "<group>"; };
 		45BDA6432954FF08007E259B /* WebArchiveOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebArchiveOperation.swift; sourceTree = "<group>"; };
 		45BDA6442954FF08007E259B /* WebArchiveQueue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebArchiveQueue.swift; sourceTree = "<group>"; };
+		45BEDB702A98DBD9009C7664 /* DisableGoogleTagManagerLogging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisableGoogleTagManagerLogging.swift; sourceTree = "<group>"; };
 		45BF2B9D27A9573F00D23EDA /* MobileContentPagesInitialPageRenderingType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileContentPagesInitialPageRenderingType.swift; sourceTree = "<group>"; };
 		45BF6EB927050A29003596A4 /* TransparentModalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransparentModalView.swift; sourceTree = "<group>"; };
 		45BF6EBB27050A3F003596A4 /* TransparentModalView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TransparentModalView.xib; sourceTree = "<group>"; };
@@ -5291,6 +5293,7 @@
 		45AD203625938AC200A096A0 /* Google */ = {
 			isa = PBXGroup;
 			children = (
+				45BEDB702A98DBD9009C7664 /* DisableGoogleTagManagerLogging.swift */,
 				45AD203725938AC300A096A0 /* GoogleAdwordsAnalytics.swift */,
 			);
 			path = Google;
@@ -8911,6 +8914,7 @@
 				455F04792A000D6100536CB9 /* LastAuthenticatedProviderCache.swift in Sources */,
 				D4BC79E429AE995A0040651B /* GetTrainingTipCompletedUseCase.swift in Sources */,
 				45E347802A49BFEB0014CCD1 /* GTWhiteButton.swift in Sources */,
+				45BEDB712A98DBD9009C7664 /* DisableGoogleTagManagerLogging.swift in Sources */,
 				45D63E74288F698C009B4610 /* LanguageModelType.swift in Sources */,
 				45E347792A49BFD00014CCD1 /* CloseButton.swift in Sources */,
 				45FE5990298A9D760030C080 /* VideoViewConfiguration.swift in Sources */,

--- a/godtools/App/AppDelegate.swift
+++ b/godtools/App/AppDelegate.swift
@@ -55,6 +55,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
             
+        DisableGoogleTagManagerLogging.disable()
+        
         let appConfig: AppConfig = appDiContainer.dataLayer.getAppConfig()
         
         if appBuild.configuration == .analyticsLogging {

--- a/godtools/App/Services/Analytics/Firebase/FirebaseAnalytics.swift
+++ b/godtools/App/Services/Analytics/Firebase/FirebaseAnalytics.swift
@@ -9,6 +9,7 @@
 import Foundation
 import FirebaseAnalytics
 import GoogleAnalytics
+import FirebaseCore
 
 class FirebaseAnalytics {
     
@@ -31,6 +32,10 @@ class FirebaseAnalytics {
         }
         
         isConfigured = true
+        
+        if !loggingEnabled {
+            FirebaseCore.FirebaseConfiguration.shared.setLoggerLevel(.min)
+        }
         
         // gai
         if let gai = GAI.sharedInstance() {

--- a/godtools/App/Services/Analytics/Google/DisableGoogleTagManagerLogging.swift
+++ b/godtools/App/Services/Analytics/Google/DisableGoogleTagManagerLogging.swift
@@ -1,0 +1,38 @@
+//
+//  DisableGoogleTagManagerLogging.swift
+//  godtools
+//
+//  Created by Levi Eggert on 8/25/23.
+//  Copyright © 2023 Cru. All rights reserved.
+//
+
+import Foundation
+
+// NOTE: This class has been added to disable GoogleTagManager logging to the Xcode console.
+// Found solution here (https://stackoverflow.com/questions/45347538/how-to-disable-google-tag-manager-console-logging)
+// This was added 8/25/2023, GoogleTagManager version 7.4.3.
+// ~Levi
+
+class DisableGoogleTagManagerLogging {
+    
+    static func disable() {
+        
+        let tagClass: AnyClass? = NSClassFromString("TAGLogger")
+
+        let originalSelector = NSSelectorFromString("info:")
+        let detourSelector = #selector(DisableGoogleTagManagerLogging.detour_info(message:))
+
+        guard let originalMethod = class_getClassMethod(tagClass, originalSelector), let detourMethod = class_getClassMethod(DisableGoogleTagManagerLogging.self, detourSelector) else {
+            return
+        }
+
+        class_addMethod(tagClass, detourSelector, method_getImplementation(detourMethod), method_getTypeEncoding(detourMethod))
+       
+        method_exchangeImplementations(originalMethod, detourMethod)
+    }
+
+    @objc static func detour_info(message: String) {
+        
+        return
+    }
+}


### PR DESCRIPTION
Should no longer be getting these messages in the Xcode console.

```
2023-08-25 09:10:50.892022-0400 godtools[13920:113784] GoogleTagManager info: Sending universal analytics hit: {
    "&ate" = 0;
    "&cd" = Lessons;
    "&cd1" = ar;
    "&cd21" = "GTM-547468H";
    "&cd22" = 25;
    "&cd24" = "GodTools App";
    "&cd26" = 1692966941;
    "&cd3" = home;
    "&cd31" = "Not Logged In";
    "&cd4" = "";
    "&cd40" = undefined;
    "&cd41" = undefined;
    "&cd42" = undefined;
    "&cd43" = undefined;
    "&cd44" = undefined;
    "&cd45" = undefined;
    "&cd51" = app;
    "&cd52" = "screen_view";
    "&cd53" = 2;
    "&cd55" = true;
    "&idfa" = "00000000-0000-0000-0000-000000000000";
    "&t" = screenview;
    "&tid" = "UA-181145622-99";
    "&uid" = undefined;
}
2023-08-25 09:10:50.896199-0400 godtools[13920:113784] GoogleTagManager info: Processing logged event: iam_mytools with parameters: {
    "_si" = 318037695940588321;
    "_sn" = Favorites;
    "cru_appname" = "GodTools App";
    "cru_contentlanguage" = ar;
    "cru_previousscreenname" = Favorites;
    "cru_sitesection" = "";
    "cru_sitesubsection" = "";
    "screen_name" = "";
}
2023-08-25 09:10:50.926619-0400 godtools[13920:113784] GoogleTagManager info: Processing logged event: _vs with parameters: {
    "_mst" = 1;
    "_o" = app;
    "_pi" = 318037695940588320;
    "_pn" = Lessons;
    "_si" = 318037695940588321;
    "_sn" = Favorites;
    "cru_appname" = "GodTools App";
    "cru_contentlanguage" = ar;
    "cru_previousscreenname" = Lessons;
    "cru_sitesection" = home;
    "cru_sitesubsection" = "";
}```