### PR TITLE
GT-2102 fix tab view bug for iOS 16

### DIFF
--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		450F94DA27A1F0F6009DEA43 /* MobileContentCardCollectionPageCardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450F94D627A1F0F6009DEA43 /* MobileContentCardCollectionPageCardViewModel.swift */; };
 		450F94DB27A1F0F6009DEA43 /* MobileContentCardCollectionPageCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450F94D727A1F0F6009DEA43 /* MobileContentCardCollectionPageCardView.swift */; };
 		450F94DF27A1F38E009DEA43 /* MobileContentCardCollectionPageItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450F94DE27A1F38E009DEA43 /* MobileContentCardCollectionPageItemView.swift */; };
+		45131A012AB48B480085AF0D /* PagedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45131A002AB48B480085AF0D /* PagedView.swift */; };
 		4515D4042A2E73AB0001545D /* AuthenticationProviderInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4515D3FA2A2E73AB0001545D /* AuthenticationProviderInterface.swift */; };
 		4515D4052A2E73AB0001545D /* AuthenticationProviderProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4515D3FC2A2E73AB0001545D /* AuthenticationProviderProfile.swift */; };
 		4515D4072A2E73AB0001545D /* AuthenticationProviderResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4515D3FE2A2E73AB0001545D /* AuthenticationProviderResponse.swift */; };
@@ -1186,6 +1187,7 @@
 		450F94D627A1F0F6009DEA43 /* MobileContentCardCollectionPageCardViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MobileContentCardCollectionPageCardViewModel.swift; sourceTree = "<group>"; };
 		450F94D727A1F0F6009DEA43 /* MobileContentCardCollectionPageCardView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MobileContentCardCollectionPageCardView.swift; sourceTree = "<group>"; };
 		450F94DE27A1F38E009DEA43 /* MobileContentCardCollectionPageItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileContentCardCollectionPageItemView.swift; sourceTree = "<group>"; };
+		45131A002AB48B480085AF0D /* PagedView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PagedView.swift; sourceTree = "<group>"; };
 		4515D3FA2A2E73AB0001545D /* AuthenticationProviderInterface.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticationProviderInterface.swift; sourceTree = "<group>"; };
 		4515D3FC2A2E73AB0001545D /* AuthenticationProviderProfile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticationProviderProfile.swift; sourceTree = "<group>"; };
 		4515D3FE2A2E73AB0001545D /* AuthenticationProviderResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticationProviderResponse.swift; sourceTree = "<group>"; };
@@ -2704,6 +2706,14 @@
 				45BDA6392954FF08007E259B /* WebArchiveQueue */,
 			);
 			path = Data;
+			sourceTree = "<group>";
+		};
+		451319FF2AB48B480085AF0D /* PagedView */ = {
+			isa = PBXGroup;
+			children = (
+				45131A002AB48B480085AF0D /* PagedView.swift */,
+			);
+			path = PagedView;
 			sourceTree = "<group>";
 		};
 		451550EC2791E3DE00526CF2 /* DownloadTool */ = {
@@ -7971,6 +7981,7 @@
 				451CEDCA282C31AB006E5105 /* LazyHList */,
 				45E347862A49C0120014CCD1 /* OptionalImage */,
 				45C2AF332A813371004958AB /* PageControl */,
+				451319FF2AB48B480085AF0D /* PagedView */,
 				45E347842A49C0120014CCD1 /* ProgressBarView */,
 				45C0FADF2A8A7CFB009A7E71 /* PullToRefreshScrollView */,
 				45E3478B2A49C04B0014CCD1 /* RoundedCorner */,
@@ -9434,6 +9445,7 @@
 				45C152E22A448A6200F2A1E8 /* RemoveToolFromFavoritesUseCase.swift in Sources */,
 				4550BC702A33AC6D00256DEE /* HashableCurrentValueSubject.swift in Sources */,
 				45B212AC2922965F00C9A94D /* RealmDatabase.swift in Sources */,
+				45131A012AB48B480085AF0D /* PagedView.swift in Sources */,
 				45AD1BE425938A4F00A096A0 /* CustomViewBuilderType.swift in Sources */,
 				45C152A32A44896C00F2A1E8 /* ToolLanguageSegmentViewModel.swift in Sources */,
 				4573133F28C1821100481640 /* ToolDetailsVersionsCardView.swift in Sources */,

--- a/godtools/App/Features/Dashboard/Presentation/Dashboard/DashboardView.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Dashboard/DashboardView.swift
@@ -27,38 +27,26 @@ struct DashboardView: View {
             
             VStack(alignment: .center, spacing: 0) {
                 
-                TabView(selection: $viewModel.selectedTab) {
+                PagedView(numberOfPages: viewModel.numberOfTabs, currentPage: $viewModel.currentTab) { (index: Int) in
                     
-                    Group {
+                    switch viewModel.getTab(tabIndex: index) {
                         
-                        ForEach(viewModel.tabs) { (tab: DashboardTabTypeDomainModel) in
-                                                        
-                            switch tab {
-                                
-                            case .lessons:
-                                LessonsView(viewModel: viewModel.getLessonsViewModel())
-                                    .tag(tab)
-                                
-                            case .favorites:
-                                FavoritesView(viewModel: viewModel.getFavoritesViewModel())
-                                    .tag(tab)
-                                
-                            case .tools:
-                                ToolsView(viewModel: viewModel.getToolsViewModel())
-                                    .tag(tab)
-                            }
-                        }
+                    case .lessons:
+                        LessonsView(viewModel: viewModel.getLessonsViewModel())
+                        
+                    case .favorites:
+                        FavoritesView(viewModel: viewModel.getFavoritesViewModel())
+                        
+                    case .tools:
+                        ToolsView(viewModel: viewModel.getToolsViewModel())
                     }
                 }
-                .tabViewStyle(.page(indexDisplayMode: .never))
-                .animation(.easeOut, value: viewModel.selectedTab)
                 
                 DashboardTabBarView(
                     viewModel: viewModel
                 )
             }
         }
-        .flipsForRightToLeftLayoutDirection(true)
     }
 }
     
@@ -96,4 +84,3 @@ struct DashboardView_Previews: PreviewProvider {
         DashboardView(viewModel: DashboardView_Previews.getDashboardViewModel())
     }
 }
-

--- a/godtools/App/Features/Dashboard/Presentation/Dashboard/Subviews/DashboardTabBar/DashboardTabBarView.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Dashboard/Subviews/DashboardTabBar/DashboardTabBarView.swift
@@ -10,10 +10,13 @@ import SwiftUI
 
 struct DashboardTabBarView: View {
         
+    private let layoutDirection: LayoutDirection
+    
     @ObservedObject private var viewModel: DashboardViewModel
+            
+    init(layoutDirection: LayoutDirection = .leftToRight, viewModel: DashboardViewModel) {
         
-    init(viewModel: DashboardViewModel) {
-        
+        self.layoutDirection = layoutDirection
         self.viewModel = viewModel
     }
     
@@ -23,17 +26,27 @@ struct DashboardTabBarView: View {
             
             HStack(alignment: .center, spacing: 0) {
                 
-                ForEach(viewModel.tabs) { (tab: DashboardTabTypeDomainModel) in
+                if layoutDirection == .rightToLeft {
                     
-                    DashboardTabBarItemView(
-                        viewModel: viewModel.getTabBarItemViewModel(tab: tab),
-                        selectedTab: $viewModel.selectedTab,
-                        tappedClosure: {
-                            
-                            viewModel.tabTapped(tab: tab)
-                        }
-                    )
-                    .frame(maxWidth: .infinity)
+                    ForEach((0 ..< viewModel.numberOfTabs).reversed(), id: \.self) { (index: Int) in
+                                            
+                        DashboardTabBarItemView(
+                            viewModel: viewModel.getTabBarItemViewModel(tabIndex: index),
+                            currentTab: $viewModel.currentTab
+                        )
+                        .frame(maxWidth: .infinity)
+                    }
+                }
+                else {
+                    
+                    ForEach(0 ..< viewModel.numberOfTabs, id: \.self) { (index: Int) in
+                        
+                        DashboardTabBarItemView(
+                            viewModel: viewModel.getTabBarItemViewModel(tabIndex: index),
+                            currentTab: $viewModel.currentTab
+                        )
+                        .frame(maxWidth: .infinity)
+                    }
                 }
             }
         }
@@ -45,6 +58,7 @@ struct DashboardTabBarView: View {
                 .edgesIgnoringSafeArea(.bottom)
                 .shadow(color: .black.opacity(0.25), radius: 3, y: -2.5)
         )
+        .environment(\.layoutDirection, .leftToRight)
     }
 }
 

--- a/godtools/App/Features/Dashboard/Presentation/Dashboard/Subviews/DashboardTabBar/Subviews/DashboardTabBarItem/DashboardTabBarItemView.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Dashboard/Subviews/DashboardTabBar/Subviews/DashboardTabBarItem/DashboardTabBarItemView.swift
@@ -12,21 +12,19 @@ struct DashboardTabBarItemView: View {
     
     private let unSelectedColor = Color(red: 170 / 255, green: 170 / 255, blue: 170 / 255)
     private let selectedColor = ColorPalette.gtBlue.color
-    private let tappedClosure: (() -> Void)?
         
     private var viewModel: DashboardTabBarItemViewModel
     
-    @Binding private var selectedTab: DashboardTabTypeDomainModel
+    @Binding private var currentTab: Int
     
-    init(viewModel: DashboardTabBarItemViewModel, selectedTab: Binding<DashboardTabTypeDomainModel>, tappedClosure: (() -> Void)?) {
+    init(viewModel: DashboardTabBarItemViewModel, currentTab: Binding<Int>) {
         
         self.viewModel = viewModel
-        self._selectedTab = selectedTab
-        self.tappedClosure = tappedClosure
+        self._currentTab = currentTab
     }
     
     private var isSelected: Bool {
-        return selectedTab == viewModel.tab
+        return currentTab == viewModel.tabIndex
     }
      
     var body: some View {
@@ -44,21 +42,20 @@ struct DashboardTabBarItemView: View {
             }
         }
         .onTapGesture {
-            tappedClosure?()
+            currentTab = viewModel.tabIndex
         }
     }
 }
 
 struct DashboardTabBarItemView_Preview: PreviewProvider {
     
-    @State private static var selectedTab: DashboardTabTypeDomainModel = .lessons
+    @State private static var currentTab: Int = 0
     
     static var previews: some View {
         
         DashboardTabBarItemView(
-            viewModel: DashboardTabBarItemViewModel(tab: .lessons, title: "Lessons", imageName: ""),
-            selectedTab: $selectedTab,
-            tappedClosure: nil
+            viewModel: DashboardTabBarItemViewModel(tabIndex: 0, title: "Lessons", imageName: ""),
+            currentTab: $currentTab
         )
     }
 }

--- a/godtools/App/Features/Dashboard/Presentation/Dashboard/Subviews/DashboardTabBar/Subviews/DashboardTabBarItem/DashboardTabBarItemViewModel.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Dashboard/Subviews/DashboardTabBar/Subviews/DashboardTabBarItem/DashboardTabBarItemViewModel.swift
@@ -10,13 +10,13 @@ import Foundation
 
 class DashboardTabBarItemViewModel {
     
-    let tab: DashboardTabTypeDomainModel
+    let tabIndex: Int
     let title: String
     let imageName: String
     
-    init(tab: DashboardTabTypeDomainModel, title: String, imageName: String) {
+    init(tabIndex: Int, title: String, imageName: String) {
         
-        self.tab = tab
+        self.tabIndex = tabIndex
         self.title = title
         self.imageName = imageName
     }

--- a/godtools/App/Features/LearnToShareTool/Presentation/LearnToShareTool/LearnToShareToolView.swift
+++ b/godtools/App/Features/LearnToShareTool/Presentation/LearnToShareTool/LearnToShareToolView.swift
@@ -26,22 +26,13 @@ struct LearnToShareToolView: View {
             
             VStack(spacing: 0) {
                 
-                TabView(selection: $viewModel.currentPage) {
+                PagedView(numberOfPages: viewModel.numberOfLearnToShareToolItems, currentPage: $viewModel.currentPage) { page in
                     
-                    Group {
-                        
-                        ForEach(0 ..< viewModel.numberOfLearnToShareToolItems, id: \.self) { index in
-                            
-                            LearnToShareToolItemView(
-                                viewModel: viewModel.getLearnToShareToolItemViewModel(index: index),
-                                geometry: geometry
-                            )
-                            .tag(index)
-                        }
-                    }
+                    LearnToShareToolItemView(
+                        viewModel: viewModel.getLearnToShareToolItemViewModel(index: page),
+                        geometry: geometry
+                    )
                 }
-                .tabViewStyle(.page(indexDisplayMode: .never))
-                .animation(.easeOut, value: viewModel.currentPage)
                 
                 GTBlueButton(title: viewModel.continueTitle, font: FontLibrary.sfProTextRegular.font(size: 18), width: geometry.size.width - (continueButtonPadding * 2), height: 50) {
                     
@@ -56,6 +47,5 @@ struct LearnToShareToolView: View {
                 .padding(EdgeInsets(top: 20, leading: 0, bottom: 10, trailing: 0))
             }
         }
-        .flipsForRightToLeftLayoutDirection(true)
     }
 }

--- a/godtools/App/Features/Menu/Presentation/Tutorial/TutorialView.swift
+++ b/godtools/App/Features/Menu/Presentation/Tutorial/TutorialView.swift
@@ -29,26 +29,16 @@ struct TutorialView: View {
                 
                 FixedVerticalSpacer(height: 50)
                 
-                TabView(selection: $viewModel.currentPage) {
+                PagedView(numberOfPages: viewModel.numberOfPages, currentPage: $viewModel.currentPage) { page in
                     
-                    Group {
-                        
-                        ForEach(0 ..< viewModel.numberOfPages, id: \.self) { index in
-                            
-                            TutorialItemView(
-                                viewModel: viewModel.tutorialPageWillAppear(tutorialItemIndex: index),
-                                geometry: geometry,
-                                videoPlayingClosure: {
-                                    viewModel.tutorialVideoPlayTapped(tutorialItemIndex: index)
-                                }
-                            )
-                            .tag(index)
-                            
+                    TutorialItemView(
+                        viewModel: viewModel.tutorialPageWillAppear(tutorialItemIndex: page),
+                        geometry: geometry,
+                        videoPlayingClosure: {
+                            viewModel.tutorialVideoPlayTapped(tutorialItemIndex: page)
                         }
-                    }
+                    )
                 }
-                .tabViewStyle(.page(indexDisplayMode: .never))
-                .animation(.easeOut, value: viewModel.currentPage)
                 
                 GTBlueButton(title: viewModel.continueTitle, font: FontLibrary.sfProTextRegular.font(size: 18), width: geometry.size.width - (continueButtonHorizontalPadding * 2), height: continueButtonHeight) {
                     

--- a/godtools/App/Features/Onboarding/Presentation/OnboardingTutorial/OnboardingTutorialView.swift
+++ b/godtools/App/Features/Onboarding/Presentation/OnboardingTutorial/OnboardingTutorialView.swift
@@ -9,7 +9,7 @@
 import SwiftUI
 
 struct OnboardingTutorialView: View {
-        
+            
     @ObservedObject private var viewModel: OnboardingTutorialViewModel
     
     init(viewModel: OnboardingTutorialViewModel) {
@@ -22,52 +22,44 @@ struct OnboardingTutorialView: View {
         GeometryReader { geometry in
             
             VStack(alignment: .center, spacing: 0) {
-                                
-                TabView(selection: $viewModel.currentPage) {
-
-                    Group {
+                   
+                PagedView(numberOfPages: viewModel.pages.count, currentPage: $viewModel.currentPage) { (page: Int) in
+                    
+                    switch viewModel.pages[page] {
                         
-                        ForEach((0 ..< viewModel.pages.count), id: \.self) { index in
-                            
-                            switch viewModel.pages[index] {
-                                
-                            case .readyForEveryConversation:
-                               
-                                OnboardingTutorialReadyForEveryConversationView(
-                                    viewModel: viewModel.getOnboardingTutorialReadyForEveryConversationViewModel(),
-                                    geometry: geometry,
-                                    watchVideoTappedClosure: {
-                                        viewModel.watchReadyForEveryConversationVideoTapped()
-                                    }
-                                )
-                                
-                            case .talkAboutGodWithAnyone:
-                                
-                                OnboardingTutorialMediaView(
-                                    viewModel: viewModel.getOnboardingTutorialTalkAboutGodWithAnyoneViewModel(),
-                                    geometry: geometry
-                                )
-                                
-                            case .prepareForTheMomentsThatMatter:
-                                
-                                OnboardingTutorialMediaView(
-                                    viewModel: viewModel.getOnboardingTutorialPrepareForTheMomentsThatMatterViewModel(),
-                                    geometry: geometry
-                                )
-                                
-                            case .helpSomeoneDiscoverJesus:
-                                
-                                OnboardingTutorialMediaView(
-                                    viewModel: viewModel.getOnboardingTutorialHelpSomeoneDiscoverJesusViewModel(),
-                                    geometry: geometry
-                                )
+                    case .readyForEveryConversation:
+                       
+                        OnboardingTutorialReadyForEveryConversationView(
+                            viewModel: viewModel.getOnboardingTutorialReadyForEveryConversationViewModel(),
+                            geometry: geometry,
+                            watchVideoTappedClosure: {
+                                viewModel.watchReadyForEveryConversationVideoTapped()
                             }
-                        }
+                        )
+                        
+                    case .talkAboutGodWithAnyone:
+                        
+                        OnboardingTutorialMediaView(
+                            viewModel: viewModel.getOnboardingTutorialTalkAboutGodWithAnyoneViewModel(),
+                            geometry: geometry
+                        )
+                        
+                    case .prepareForTheMomentsThatMatter:
+                        
+                        OnboardingTutorialMediaView(
+                            viewModel: viewModel.getOnboardingTutorialPrepareForTheMomentsThatMatterViewModel(),
+                            geometry: geometry
+                        )
+                        
+                    case .helpSomeoneDiscoverJesus:
+                        
+                        OnboardingTutorialMediaView(
+                            viewModel: viewModel.getOnboardingTutorialHelpSomeoneDiscoverJesusViewModel(),
+                            geometry: geometry
+                        )
                     }
                 }
-                .tabViewStyle(.page(indexDisplayMode: .never))
-                .animation(.easeOut, value: viewModel.currentPage)
-                     
+                
                 OnboardingTutorialPrimaryButton(geometry: geometry, title: viewModel.continueButtonTitle) {
                     viewModel.continueTapped()
                 }

--- a/godtools/App/Share/SwiftUI Views/PageControl/PageControl.swift
+++ b/godtools/App/Share/SwiftUI Views/PageControl/PageControl.swift
@@ -11,14 +11,15 @@ import SwiftUI
 struct PageControl: View {
     
     private let backgroundColor: Color = Color.white
+    private let layoutDirection: LayoutDirection
+    private let numberOfPages: Int
+    private let attributes: PageControlAttributesType
     
-    let numberOfPages: Int
-    let attributes: PageControlAttributesType
+    @Binding private var currentPage: Int
     
-    @Binding var currentPage: Int
-    
-    init(numberOfPages: Int, attributes: PageControlAttributesType, currentPage: Binding<Int>) {
+    init(layoutDirection: LayoutDirection = .leftToRight, numberOfPages: Int, attributes: PageControlAttributesType, currentPage: Binding<Int>) {
         
+        self.layoutDirection = layoutDirection
         self.numberOfPages = numberOfPages
         self.attributes = attributes
         self._currentPage = currentPage
@@ -41,8 +42,29 @@ struct PageControl: View {
                         scrollToPreviousPage()
                     }
                 
-                ForEach((0 ..< numberOfPages), id: \.self) { index in
-                    PageControlButton(page: index, attributes: attributes, currentPage: $currentPage)
+                if layoutDirection == .rightToLeft {
+                    
+                    ForEach((0 ..< numberOfPages).reversed(), id: \.self) { index in
+                                            
+                        PageControlButton(
+                            layoutDirection: layoutDirection,
+                            page: index,
+                            attributes: attributes,
+                            currentPage: $currentPage
+                        )
+                    }
+                }
+                else {
+                    
+                    ForEach(0 ..< numberOfPages, id: \.self) { index in
+                        
+                        PageControlButton(
+                            layoutDirection: layoutDirection,
+                            page: index,
+                            attributes: attributes,
+                            currentPage: $currentPage
+                        )
+                    }
                 }
                 
                 Rectangle()
@@ -60,7 +82,7 @@ struct PageControl: View {
                 .fill(.clear)
                 .frame(width: 1, height: 10)
         }
-        .flipsForRightToLeftLayoutDirection(true)
+        .environment(\.layoutDirection, .leftToRight)
     }
     
     private func scrollToPreviousPage() {
@@ -90,6 +112,6 @@ struct PageControl_Previews: PreviewProvider {
         
         let attributes = PageControlAttributes(deselectedColor: .gray, selectedColor: .blue, circleSize: 10, circleSpacing: 20)
         
-        PageControl(numberOfPages: 3, attributes: attributes, currentPage: $currentPage)
+        PageControl(layoutDirection: .leftToRight, numberOfPages: 3, attributes: attributes, currentPage: $currentPage)
     }
 }

--- a/godtools/App/Share/SwiftUI Views/PageControl/PageControlButton.swift
+++ b/godtools/App/Share/SwiftUI Views/PageControl/PageControlButton.swift
@@ -10,13 +10,15 @@ import SwiftUI
 
 struct PageControlButton: View {
     
-    let page: Int
-    let attributes: PageControlAttributesType
+    private let layoutDirection: LayoutDirection
+    private let page: Int
+    private let attributes: PageControlAttributesType
     
-    @Binding var currentPage: Int
+    @Binding private var currentPage: Int
     
-    init(page: Int, attributes: PageControlAttributesType, currentPage: Binding<Int>) {
+    init(layoutDirection: LayoutDirection, page: Int, attributes: PageControlAttributesType, currentPage: Binding<Int>) {
         
+        self.layoutDirection = layoutDirection
         self.page = page
         self.attributes = attributes
         self._currentPage = currentPage
@@ -56,6 +58,6 @@ struct PageControlButton_Previews: PreviewProvider {
         
         let attributes = PageControlAttributes(deselectedColor: .gray, selectedColor: .blue, circleSize: 10, circleSpacing: 20)
         
-        PageControlButton(page: 0, attributes: attributes, currentPage: $currentPage)
+        PageControlButton(layoutDirection: .leftToRight, page: 0, attributes: attributes, currentPage: $currentPage)
     }
 }

--- a/godtools/App/Share/SwiftUI Views/PagedView/PagedView.swift
+++ b/godtools/App/Share/SwiftUI Views/PagedView/PagedView.swift
@@ -1,0 +1,85 @@
+//
+//  PagedView.swift
+//  godtools
+//
+//  Created by Levi Eggert on 9/13/23.
+//  Copyright © 2023 Cru. All rights reserved.
+//
+
+import SwiftUI
+
+// NOTE: This view is a wrapper around TabView and was created to fix a bug specifically to iOS 16 where a TabView page index would get reversed when the device settings is using a right to left language.
+// This would cause the TabBar tied to the TabView to reverse as well and navigation was also reversed when tapping Tabs to navigate the TabView. ~Levi
+
+struct PagedView<Content: View>: View {
+    
+    private let layoutDirection: LayoutDirection
+    private let numberOfPages: Int
+    private let content: (_ page: Int) -> Content
+    
+    @Binding private var currentPage: Int
+    
+    init(layoutDirection: LayoutDirection = .leftToRight, numberOfPages: Int, currentPage: Binding<Int>, @ViewBuilder content: @escaping (_ page: Int) -> Content) {
+        
+        self.layoutDirection = layoutDirection
+        self.numberOfPages = numberOfPages
+        self._currentPage = currentPage
+        self.content = content
+    }
+    
+    var body: some View {
+     
+        VStack(spacing: 0) {
+            
+            TabView(selection: $currentPage) {
+                
+                Group {
+                    
+                    if layoutDirection == .rightToLeft {
+                        
+                        ForEach((0 ..< numberOfPages).reversed(), id: \.self) { index in
+                            
+                            content(index)
+                                .environment(\.layoutDirection, layoutDirection)
+                                .tag(index)
+                        }
+                    }
+                    else {
+                        
+                        ForEach(0 ..< numberOfPages, id: \.self) { index in
+                            
+                            content(index)
+                                .environment(\.layoutDirection, layoutDirection)
+                                .tag(index)
+                        }
+                    }
+                }
+            }
+            .environment(\.layoutDirection, .leftToRight)
+            .tabViewStyle(.page(indexDisplayMode: .never))
+            .animation(.easeOut, value: currentPage)
+        }
+    }
+}
+
+struct PagedView_Previews: PreviewProvider {
+       
+    @State private static var currentPage: Int = 1
+    
+    static var previews: some View {
+                
+        PagedView(layoutDirection: .leftToRight, numberOfPages: 5, currentPage: $currentPage) { page in
+            
+            ZStack(alignment: .center) {
+                
+                Rectangle()
+                    .fill(Color.red)
+                    .frame(width: 100, height: 100)
+                
+                Text("Item: \(page)")
+                    .foregroundColor(Color.black)
+            }
+            .frame(width: 100, height: 100)
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes iOS 16 bugs with the TabView when in a right to left language.  Ended up having to force a TabView and any accompanying TabBarView or PageControl that controls the TabView to always be in a left to right environment.  Then manually adjust them for right to left languages. 

As of this PR only left to right languages will be supported on PagedView.  Once we start implementing the new App Language feature these will be able to support right to left.  Will create a PR pointing to the app-languages-feature to address that.  

- Add PagedView which wraps a TabView and forced the environment to left to right and manually adjust for right to left languages.
- Updated PageControl to always be in a left to right environment and manually adjust for right to left languages.
- Updated DashboardTabBarView to always be in a left to right environment and manually adjust for right to left languages.
- Updated any remaining views using a TabView to use PagedView instead.
- Removed all flipsForRightToLeftLayoutDirection modifiers.  


