### PR TITLE
GT-2102 Default to ApplicationLayout.direction.layoutDirection instead of .leftToRight

### DIFF
--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -463,6 +463,8 @@
 		4597101629CDE02400C47040 /* View+CornerRadius.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4597101529CDE02400C47040 /* View+CornerRadius.swift */; };
 		459A33FB29BFE46B00C49308 /* OnboardingQuickStartItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 459A33FA29BFE46B00C49308 /* OnboardingQuickStartItemView.swift */; };
 		459A668C289B0E3A00DACBF8 /* GetToolTranslationsFilesFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 459A668B289B0E3A00DACBF8 /* GetToolTranslationsFilesFilter.swift */; };
+		459B7E692ABA3A4A0088F44B /* LaunchEnvironmentKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45131A062AB498AD0085AF0D /* LaunchEnvironmentKey.swift */; };
+		459B7E6A2ABA3A510088F44B /* AccessibilityStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45131A0C2AB498AD0085AF0D /* AccessibilityStrings.swift */; };
 		459BD08A289AD4310075901B /* DetermineToolTranslationsToDownloadError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 459BD083289AD4310075901B /* DetermineToolTranslationsToDownloadError.swift */; };
 		459BD08B289AD4310075901B /* DetermineDeepLinkedToolTranslationsToDownload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 459BD084289AD4310075901B /* DetermineDeepLinkedToolTranslationsToDownload.swift */; };
 		459BD08C289AD4310075901B /* DetermineToolTranslationsToDownloadType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 459BD085289AD4310075901B /* DetermineToolTranslationsToDownloadType.swift */; };
@@ -8920,8 +8922,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				459B7E692ABA3A4A0088F44B /* LaunchEnvironmentKey.swift in Sources */,
 				45A415F42A99429C0030E2C7 /* XCUIApplication+Query.swift in Sources */,
 				45A415F32A99429C0030E2C7 /* OnboardingFlowTests.swift in Sources */,
+				459B7E6A2ABA3A510088F44B /* AccessibilityStrings.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/godtools/App/Features/Dashboard/Presentation/Dashboard/Subviews/DashboardTabBar/DashboardTabBarView.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Dashboard/Subviews/DashboardTabBar/DashboardTabBarView.swift
@@ -14,7 +14,7 @@ struct DashboardTabBarView: View {
     
     @ObservedObject private var viewModel: DashboardViewModel
             
-    init(layoutDirection: LayoutDirection = .leftToRight, viewModel: DashboardViewModel) {
+    init(layoutDirection: LayoutDirection = ApplicationLayout.direction.layoutDirection, viewModel: DashboardViewModel) {
         
         self.layoutDirection = layoutDirection
         self.viewModel = viewModel

--- a/godtools/App/Share/Application/ApplicationLayout/ApplicationLayout.swift
+++ b/godtools/App/Share/Application/ApplicationLayout/ApplicationLayout.swift
@@ -23,6 +23,6 @@ class ApplicationLayout {
         ApplicationLayout.direction = direction
         
         // Globablly set all UIKit UIView's to flip direction for language.  This appears to apply to UINavigationController navigation push and pop as well. ~Levi
-        UIView.appearance().semanticContentAttribute = direction.uiKit
+        UIView.appearance().semanticContentAttribute = direction.semanticContentAttribute
     }
 }

--- a/godtools/App/Share/Application/ApplicationLayout/ApplicationLayoutDirection.swift
+++ b/godtools/App/Share/Application/ApplicationLayout/ApplicationLayoutDirection.swift
@@ -15,7 +15,7 @@ enum ApplicationLayoutDirection {
     case leftToRight
     case rightToLeft
     
-    var swiftUI: LayoutDirection {
+    var layoutDirection: LayoutDirection {
         switch self {
         case .leftToRight:
             return .leftToRight
@@ -24,7 +24,7 @@ enum ApplicationLayoutDirection {
         }
     }
     
-    var uiKit: UISemanticContentAttribute {
+    var semanticContentAttribute: UISemanticContentAttribute {
         switch self {
         case .leftToRight:
             return .forceLeftToRight

--- a/godtools/App/Share/SwiftUI Views/PageControl/PageControl.swift
+++ b/godtools/App/Share/SwiftUI Views/PageControl/PageControl.swift
@@ -17,7 +17,7 @@ struct PageControl: View {
     
     @Binding private var currentPage: Int
     
-    init(layoutDirection: LayoutDirection = .leftToRight, numberOfPages: Int, attributes: PageControlAttributesType, currentPage: Binding<Int>) {
+    init(layoutDirection: LayoutDirection = ApplicationLayout.direction.layoutDirection, numberOfPages: Int, attributes: PageControlAttributesType, currentPage: Binding<Int>) {
         
         self.layoutDirection = layoutDirection
         self.numberOfPages = numberOfPages

--- a/godtools/App/Share/SwiftUI Views/PagedView/PagedView.swift
+++ b/godtools/App/Share/SwiftUI Views/PagedView/PagedView.swift
@@ -19,7 +19,7 @@ struct PagedView<Content: View>: View {
     
     @Binding private var currentPage: Int
     
-    init(layoutDirection: LayoutDirection = .leftToRight, numberOfPages: Int, currentPage: Binding<Int>, @ViewBuilder content: @escaping (_ page: Int) -> Content) {
+    init(layoutDirection: LayoutDirection = ApplicationLayout.direction.layoutDirection, numberOfPages: Int, currentPage: Binding<Int>, @ViewBuilder content: @escaping (_ page: Int) -> Content) {
         
         self.layoutDirection = layoutDirection
         self.numberOfPages = numberOfPages


### PR DESCRIPTION
Changes in this PR:

- Update PagedView, PageControl, and DashboardTabBarView to default to ApplicationLayout.direction.layoutDirection instead of leftToRight.  
- Changed naming in ApplicationLayoutDirection for swiftUI and uiKit directions to layoutDirection and semanticContentAttribute.