### PR TITLE
GT-2102 Fix back button showing on first page of tutorial

### DIFF
--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -1143,7 +1143,7 @@
 		45FE82562ACE5D8C00930C39 /* NavBarItemData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45FE824A2ACE5D8C00930C39 /* NavBarItemData.swift */; };
 		45FE82582ACE5D8C00930C39 /* NavBarItems.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45FE824C2ACE5D8C00930C39 /* NavBarItems.swift */; };
 		45FE82592ACE5D8C00930C39 /* NavBarItemControllerType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45FE824E2ACE5D8C00930C39 /* NavBarItemControllerType.swift */; };
-		45FE825A2ACE5D8C00930C39 /* NarBarItemController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45FE824F2ACE5D8C00930C39 /* NarBarItemController.swift */; };
+		45FE825A2ACE5D8C00930C39 /* NavBarItemController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45FE824F2ACE5D8C00930C39 /* NavBarItemController.swift */; };
 		45FE825B2ACE5D8C00930C39 /* AppLayoutDirectionNavBarItemController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45FE82502ACE5D8C00930C39 /* AppLayoutDirectionNavBarItemController.swift */; };
 		45FE825C2ACE5D8C00930C39 /* NavBarItemContentType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45FE82522ACE5D8C00930C39 /* NavBarItemContentType.swift */; };
 		45FE825D2ACE5D8C00930C39 /* NavBarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45FE82532ACE5D8C00930C39 /* NavBarItem.swift */; };
@@ -2338,7 +2338,7 @@
 		45FE824A2ACE5D8C00930C39 /* NavBarItemData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NavBarItemData.swift; sourceTree = "<group>"; };
 		45FE824C2ACE5D8C00930C39 /* NavBarItems.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NavBarItems.swift; sourceTree = "<group>"; };
 		45FE824E2ACE5D8C00930C39 /* NavBarItemControllerType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NavBarItemControllerType.swift; sourceTree = "<group>"; };
-		45FE824F2ACE5D8C00930C39 /* NarBarItemController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NarBarItemController.swift; sourceTree = "<group>"; };
+		45FE824F2ACE5D8C00930C39 /* NavBarItemController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NavBarItemController.swift; sourceTree = "<group>"; };
 		45FE82502ACE5D8C00930C39 /* AppLayoutDirectionNavBarItemController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppLayoutDirectionNavBarItemController.swift; sourceTree = "<group>"; };
 		45FE82522ACE5D8C00930C39 /* NavBarItemContentType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NavBarItemContentType.swift; sourceTree = "<group>"; };
 		45FE82532ACE5D8C00930C39 /* NavBarItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NavBarItem.swift; sourceTree = "<group>"; };
@@ -8510,7 +8510,7 @@
 			children = (
 				45C321A62ACE7A89003B4F2C /* AppInterfaceStringNavBarItemController.swift */,
 				45FE82502ACE5D8C00930C39 /* AppLayoutDirectionNavBarItemController.swift */,
-				45FE824F2ACE5D8C00930C39 /* NarBarItemController.swift */,
+				45FE824F2ACE5D8C00930C39 /* NavBarItemController.swift */,
 				45FE824E2ACE5D8C00930C39 /* NavBarItemControllerType.swift */,
 			);
 			path = NavBarItemController;
@@ -10542,7 +10542,7 @@
 				45131A0F2AB498AD0085AF0D /* FontLibrary.swift in Sources */,
 				D4B05FF929106462005852D0 /* MobileContentAuthTokenAPI.swift in Sources */,
 				D4B05FF529106212005852D0 /* MobileContentAuthTokenRepository.swift in Sources */,
-				45FE825A2ACE5D8C00930C39 /* NarBarItemController.swift in Sources */,
+				45FE825A2ACE5D8C00930C39 /* NavBarItemController.swift in Sources */,
 				45AE974F27C97A9500C2CB33 /* Hero+MobileContentRenderableModel.swift in Sources */,
 				45AE975727C97A9500C2CB33 /* Form+MobileContentRenderableModel.swift in Sources */,
 				D4B060042913096A005852D0 /* MobileContentAuthTokenKeychainAccessor.swift in Sources */,

--- a/godtools/App/Features/Articles/Presentation/ArticlesWeb/ArticleWebView.swift
+++ b/godtools/App/Features/Articles/Presentation/ArticlesWeb/ArticleWebView.swift
@@ -60,7 +60,8 @@ class ArticleWebView: AppViewController {
         
         // right bar button items
         let shareButton: UIBarButtonItem = addBarButtonItem(
-            to: .right,
+            barPosition: .trailing,
+            index: nil,
             image: ImageCatalog.navShare.uiImage,
             color: .white,
             target: self,
@@ -70,7 +71,8 @@ class ArticleWebView: AppViewController {
         self.shareButton = shareButton
                 
         let debugButton: UIBarButtonItem = addBarButtonItem(
-            to: .right,
+            barPosition: .trailing,
+            index: nil,
             image: ImageCatalog.navDebug.uiImage,
             color: .white,
             target: self,
@@ -167,11 +169,11 @@ class ArticleWebView: AppViewController {
         removeRightBarButtonItems()
         
         if !viewModel.hidesShareButton.value, let shareButton = self.shareButton {
-            addBarButtonItem(item: shareButton, barPosition: .right)
+            addBarButtonItem(item: shareButton, barPosition: .trailing, index: nil)
         }
         
         if !viewModel.hidesDebugButton.value, let debugButton = self.debugButton {
-            addBarButtonItem(item: debugButton, barPosition: .right)
+            addBarButtonItem(item: debugButton, barPosition: .trailing, index: nil)
         }
     }
     

--- a/godtools/App/Features/Dashboard/Presentation/Tool/Subviews/ToolNavBar/ToolNavBarView.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Tool/Subviews/ToolNavBar/ToolNavBarView.swift
@@ -84,7 +84,8 @@ class ToolNavBarView: NSObject {
         )
 
         _ = parentViewController.addBarButtonItem(
-            to: .left,
+            barPosition: .leading,
+            index: nil,
             image: viewModel.backButtonImage,
             color: navBarControlColor,
             target: self,
@@ -92,7 +93,7 @@ class ToolNavBarView: NSObject {
         )
         
         _ = parentViewController.addBarButtonItem(
-            to: .right,
+            barPosition: .trailing,
             index: RightNavbarPosition.toolSettings.rawValue,
             image: ImageCatalog.navToolSettings.uiImage,
             color: navBarControlColor,
@@ -199,7 +200,7 @@ class ToolNavBarView: NSObject {
         else if !hidden && remoteShareActiveNavItem == nil {
             
             remoteShareActiveNavItem = parentViewController?.addAnimatedBarButtonItem(
-                to: .right,
+                barPosition: .trailing,
                 index: RightNavbarPosition.remoteShareActive.rawValue,
                 animationName: "remote_share_active"
             )

--- a/godtools/App/Features/DownloadTool/DownloadTool/DownloadToolView.swift
+++ b/godtools/App/Features/DownloadTool/DownloadTool/DownloadToolView.swift
@@ -38,7 +38,8 @@ class DownloadToolView: UIViewController {
         setupBinding()
         
         _ = addBarButtonItem(
-            to: .right,
+            barPosition: .trailing,
+            index: nil,
             image: ImageCatalog.navClose.uiImage,
             color: UIColor(red: 0.231, green: 0.643, blue: 0.859, alpha: 1),
             target: self,

--- a/godtools/App/Features/ToolSettings/Presentation/ShareToolScreenTutorial/ShareToolScreenTutorialView.swift
+++ b/godtools/App/Features/ToolSettings/Presentation/ShareToolScreenTutorial/ShareToolScreenTutorialView.swift
@@ -40,7 +40,8 @@ class ShareToolScreenTutorialView: UIViewController {
         setupBinding()
         
         closeButton = addBarButtonItem(
-            to: .left,
+            barPosition: .leading,
+            index: nil,
             image: ImageCatalog.navClose.uiImage,
             color: nil,
             target: self,
@@ -92,12 +93,13 @@ class ShareToolScreenTutorialView: UIViewController {
     
     private func setSkipButton(hidden: Bool) {
         
-        let buttonPosition: BarButtonItemBarPosition = .right
+        let buttonPosition: BarButtonItemBarPosition = .trailing
         
         if skipButton == nil && !hidden {
             
             skipButton = addBarButtonItem(
-                to: buttonPosition,
+                barPosition: buttonPosition,
+                index: nil,
                 title: viewModel.skipTitle,
                 style: .plain,
                 color: ColorPalette.gtBlue.uiColor,
@@ -106,7 +108,7 @@ class ShareToolScreenTutorialView: UIViewController {
             )
         }
         else if let skipButton = skipButton {
-            hidden ? removeBarButtonItem(item: skipButton) : addBarButtonItem(item: skipButton, barPosition: buttonPosition)
+            hidden ? removeBarButtonItem(item: skipButton) : addBarButtonItem(item: skipButton, barPosition: buttonPosition, index: nil)
         }
     }
     

--- a/godtools/App/Share/Common/SharedAppleExtensions/UIKit/UIViewController/UIBarButtonItem/BarButtonItemBarPosition.swift
+++ b/godtools/App/Share/Common/SharedAppleExtensions/UIKit/UIViewController/UIBarButtonItem/BarButtonItemBarPosition.swift
@@ -8,9 +8,8 @@
 
 import Foundation
 
-@available(*, deprecated) // TODO: Needs to be removed in GT-2154.  All navigation bar button item logic needs to be in Share/Views/Navigation/NavigationBar/* ~Levi
 public enum BarButtonItemBarPosition {
     
-    case left
-    case right
+    case leading
+    case trailing
 }

--- a/godtools/App/Share/Common/SharedAppleExtensions/UIKit/UIViewController/UIBarButtonItem/UIViewController+UIBarButtonItem.swift
+++ b/godtools/App/Share/Common/SharedAppleExtensions/UIKit/UIViewController/UIBarButtonItem/UIViewController+UIBarButtonItem.swift
@@ -8,10 +8,9 @@
 
 import UIKit
 
-@available(*, deprecated) // TODO: Needs to be removed in GT-2154.  All navigation bar button item logic needs to be in Share/Views/Navigation/NavigationBar/* ~Levi
 public extension UIViewController {
-  
-    func addBarButtonItem(to barPosition: BarButtonItemBarPosition, index: Int? = nil, title: String?, style: UIBarButtonItem.Style?, color: UIColor?, target: Any?, action: Selector?) -> UIBarButtonItem {
+    
+    func addBarButtonItem(barPosition: BarButtonItemBarPosition, index: Int?, title: String?, style: UIBarButtonItem.Style?, color: UIColor?, target: Any?, action: Selector?) -> UIBarButtonItem {
         
         let buttonStyle: UIBarButtonItem.Style = style ?? .plain
         
@@ -20,77 +19,39 @@ public extension UIViewController {
             item.tintColor = color
         }
         
-        switch barPosition {
-        case .left:
-            addLeftBarButtonItem(item: item, index: index)
-        case .right:
-            addRightBarButtonItem(item: item, index: index)
-        }
+        addBarButtonItem(item: item, barPosition: barPosition, index: index)
         
         return item
     }
     
-    func addBarButtonItem(to barPosition: BarButtonItemBarPosition, index: Int? = nil, image: UIImage?, color: UIColor?, target: Any?, action: Selector?) -> UIBarButtonItem {
+    func addBarButtonItem(barPosition: BarButtonItemBarPosition, index: Int?, image: UIImage?, color: UIColor?, target: Any?, action: Selector?) -> UIBarButtonItem {
         
         let item = UIBarButtonItem(image: image, style: .plain, target: target, action: action)
         if let color = color {
             item.tintColor = color
         }
         
-        switch barPosition {
-        case .left:
-            addLeftBarButtonItem(item: item, index: index)
-        case .right:
-            addRightBarButtonItem(item: item, index: index)
-        }
+        addBarButtonItem(item: item, barPosition: barPosition, index: index)
         
         return item
     }
-    
-    func addBarButtonItem(item: UIBarButtonItem, barPosition: BarButtonItemBarPosition, index: Int? = nil) {
-        switch barPosition {
-        case .left:
-            addLeftBarButtonItem(item: item, index: index)
-        case .right:
-            addRightBarButtonItem(item: item, index: index)
-        }
-    }
-    
-    private func addLeftBarButtonItem(item: UIBarButtonItem, index: Int?) {
-        if var leftItems = navigationItem.leftBarButtonItems {
-            if !leftItems.contains(item) {
-                if let index = index, index >= 0 && index < leftItems.count {
-                    leftItems.insert(item, at: index)
-                }
-                else {
-                    leftItems.append(item)
-                }
-                navigationItem.leftBarButtonItems = leftItems
-            }
-        }
-        else {
-            navigationItem.leftBarButtonItem = item
-        }
-    }
+}
 
-    private func addRightBarButtonItem(item: UIBarButtonItem, index: Int?) {
-        if var rightItems = navigationItem.rightBarButtonItems {
-            if !rightItems.contains(item) {
-                if let index = index, index >= 0 && index < rightItems.count {
-                    rightItems.insert(item, at: index)
-                }
-                else {
-                    rightItems.append(item)
-                }
-                navigationItem.rightBarButtonItems = rightItems
-            }
-        }
-        else {
-            navigationItem.rightBarButtonItem = item
-        }
+// MARK: - Retrieving Bar Items
+
+extension UIViewController {
+    
+    func containsBarButtonItem(item: UIBarButtonItem) -> Bool {
+        
+        return getAllBarButtonItems().contains(item)
     }
     
-    func getLeftBarButtonItems() -> [UIBarButtonItem] {
+    func getAllBarButtonItems() -> [UIBarButtonItem] {
+        
+        return getLeadingBarButtonItems() + getTrailingBarButtonItems()
+    }
+    
+    func getLeadingBarButtonItems() -> [UIBarButtonItem] {
         
         if let leadingItems = navigationItem.leftBarButtonItems, !leadingItems.isEmpty {
             return leadingItems
@@ -102,7 +63,7 @@ public extension UIViewController {
         return Array()
     }
     
-    func getRightBarButtonItems() -> [UIBarButtonItem] {
+    func getTrailingBarButtonItems() -> [UIBarButtonItem] {
         
         if let trailingItems = navigationItem.rightBarButtonItems, !trailingItems.isEmpty {
             return trailingItems
@@ -115,9 +76,75 @@ public extension UIViewController {
     }
 }
 
-// MARK: - Removing Button Items
+// MARK: - Adding Bar Items
 
-public extension UIViewController {
+extension UIViewController {
+    
+    func addBarButtonItem(item: UIBarButtonItem, barPosition: BarButtonItemBarPosition, index: Int?) {
+        
+        switch barPosition {
+        
+        case .leading:
+            addLeadingBarButtonItem(item: item, index: index)
+        
+        
+        case .trailing:
+            addTrailingBarButtonItem(item: item, index: index)
+        }
+    }
+    
+    func addLeadingBarButtonItem(item: UIBarButtonItem, index: Int?) {
+        
+        if var leadingItems = navigationItem.leftBarButtonItems, !leadingItems.isEmpty {
+            
+            if !leadingItems.contains(item) {
+                
+                if let index = index, index >= 0 && index < leadingItems.count {
+                    
+                    leadingItems.insert(item, at: index)
+                }
+                else {
+                    
+                    leadingItems.append(item)
+                }
+                
+                navigationItem.leftBarButtonItems = leadingItems
+            }
+        }
+        else {
+            
+            navigationItem.leftBarButtonItem = item
+        }
+    }
+
+    func addTrailingBarButtonItem(item: UIBarButtonItem, index: Int?) {
+        
+        if var trailingItems = navigationItem.rightBarButtonItems, !trailingItems.isEmpty {
+            
+            if !trailingItems.contains(item) {
+                
+                if let index = index, index >= 0 && index < trailingItems.count {
+                    
+                    trailingItems.insert(item, at: index)
+                }
+                else {
+                    
+                    trailingItems.append(item)
+                }
+                
+                navigationItem.rightBarButtonItems = trailingItems
+            }
+        }
+        else {
+            
+            navigationItem.rightBarButtonItem = item
+        }
+    }
+}
+
+// MARK: - Removing Bar Items
+
+extension UIViewController {
     
     func removeAllBarButtonItems() {
         

--- a/godtools/App/Share/Extensions/UIViewController+AppNavBackButton.swift
+++ b/godtools/App/Share/Extensions/UIViewController+AppNavBackButton.swift
@@ -14,9 +14,10 @@ extension UIViewController {
     func addDefaultNavBackItem(target: Any, action: Selector) -> UIBarButtonItem? {
             
         navigationItem.setHidesBackButton(true, animated: false)
-                
+                        
         return addBarButtonItem(
-            to: .left,
+            barPosition: .leading,
+            index: nil,
             image: ImageCatalog.navBack.uiImage,
             color: nil,
             target: target,

--- a/godtools/App/Share/Extensions/UIViewController+LottieNavItem.swift
+++ b/godtools/App/Share/Extensions/UIViewController+LottieNavItem.swift
@@ -11,7 +11,7 @@ import Lottie
 
 extension UIViewController {
   
-    func addAnimatedBarButtonItem(to barPosition: BarButtonItemBarPosition, index: Int? = nil, animationName: String) -> UIBarButtonItem {
+    func addAnimatedBarButtonItem(barPosition: BarButtonItemBarPosition, index: Int?, animationName: String) -> UIBarButtonItem {
         
         let animationView = LottieAnimationView()
         

--- a/godtools/App/Share/Views/LoadingView/LoadingView.swift
+++ b/godtools/App/Share/Views/LoadingView/LoadingView.swift
@@ -68,7 +68,7 @@ class LoadingView: UIViewController {
     
     private func setCloseButton(hidden: Bool) {
         
-        let position: BarButtonItemBarPosition = .right
+        let position: BarButtonItemBarPosition = .trailing
         
         if hidden, let closeButton = closeButton {
             
@@ -79,7 +79,7 @@ class LoadingView: UIViewController {
         else if !hidden && closeButton == nil {
             
             closeButton = addBarButtonItem(
-                to: position,
+                barPosition: position,
                 index: 0,
                 image: ImageCatalog.navClose.uiImage,
                 color: UIColor.black,

--- a/godtools/App/Share/Views/Navigation/NavigationBar/AppNavigationBar.swift
+++ b/godtools/App/Share/Views/Navigation/NavigationBar/AppNavigationBar.swift
@@ -6,22 +6,40 @@
 //  Copyright © 2023 Cru. All rights reserved.
 //
 
-import Foundation
+import UIKit
 
 class AppNavigationBar {
     
+    private(set) var navBarItems: NavBarItems?
+    
+    let backButton: AppBackBarItem?
     let leadingItems: [NavBarItem]
     let trailingItems: [NavBarItem]
-            
+    
     init(backButton: AppBackBarItem?, leadingItems: [NavBarItem], trailingItems: [NavBarItem]) {
         
-        if let backButton = backButton {
-            self.leadingItems = [backButton] + leadingItems
-        }
-        else {
-            self.leadingItems = leadingItems
+        self.backButton = backButton
+        self.leadingItems = leadingItems
+        self.trailingItems = trailingItems
+    }
+    
+    func configure(viewController: UIViewController) {
+        
+        guard navBarItems == nil else {
+            return
         }
         
-        self.trailingItems = trailingItems
+        var leadingItemsWithBackButton: [NavBarItem] = leadingItems
+        
+        if let backButton = self.backButton {
+            viewController.navigationItem.setHidesBackButton(true, animated: false)
+            leadingItemsWithBackButton.insert(backButton, at: 0)
+        }
+        
+        navBarItems = NavBarItems(
+            viewController: viewController,
+            leadingItems: leadingItemsWithBackButton,
+            trailingItems: trailingItems
+        )
     }
 }

--- a/godtools/App/Share/Views/Navigation/NavigationBar/NavBarItems/NavBarItemController/AppInterfaceStringNavBarItemController.swift
+++ b/godtools/App/Share/Views/Navigation/NavigationBar/NavBarItems/NavBarItemController/AppInterfaceStringNavBarItemController.swift
@@ -9,41 +9,38 @@
 import UIKit
 import Combine
 
-class AppInterfaceStringNavBarItemController: NarBarItemController {
+class AppInterfaceStringNavBarItemController: NavBarItemController {
         
     private let interfaceStringBarItem: AppInterfaceStringBarItem
     private let getInterfaceStringInAppLanguageUseCase: GetInterfaceStringInAppLanguageUseCase
-    private let toggleVisibility: AnyPublisher<Bool, Never>
     
+    private var currentInterfaceString: String?
     private var cancellables: Set<AnyCancellable> = Set()
     
     init(viewController: UIViewController, navBarItem: AppInterfaceStringBarItem, itemBarPosition: BarButtonItemBarPosition, itemIndex: Int, getInterfaceStringInAppLanguageUseCase: GetInterfaceStringInAppLanguageUseCase) {
                
         self.interfaceStringBarItem = navBarItem
         self.getInterfaceStringInAppLanguageUseCase = getInterfaceStringInAppLanguageUseCase
-        self.toggleVisibility = navBarItem.toggleVisibilityPublisher ?? CurrentValueSubject<Bool, Never>(false).eraseToAnyPublisher()
         
         super.init(
             viewController: viewController,
             navBarItem: navBarItem,
             itemBarPosition: itemBarPosition,
-            itemIndex: itemIndex,
-            shouldSinkToggleVisibility: false
+            itemIndex: itemIndex
         )
         
-        Publishers.CombineLatest(
-            toggleVisibility,
-            getInterfaceStringInAppLanguageUseCase.getStringPublisher(id: interfaceStringBarItem.localizedStringKey)
-        )
+        getInterfaceStringInAppLanguageUseCase.getStringPublisher(id: interfaceStringBarItem.localizedStringKey)
         .receive(on: DispatchQueue.main)
-        .sink{ [weak self] (hidden: Bool, interfaceString: String) in
+        .sink{ [weak self] (interfaceString: String) in
             
-            if hidden {
-                self?.setHidden(hidden: hidden)
+            let shouldRedraw: Bool = self?.currentInterfaceString != interfaceString
+            
+            if shouldRedraw, let newBarButtonItem = self?.interfaceStringBarItem.itemData.getNewBarButtonItem(contentType: .title(value: interfaceString)) {
+                
+                self?.reDrawBarButtonItem(barButtonItem: newBarButtonItem)
             }
-            else if let newBarButtonItem = self?.interfaceStringBarItem.itemData.getNewBarButtonItem(contentType: .title(value: interfaceString)) {
-                self?.setBarButtonItem(barButtonItem: newBarButtonItem)
-            }
+            
+            self?.currentInterfaceString = interfaceString
         }
         .store(in: &cancellables)
     }

--- a/godtools/App/Share/Views/Navigation/NavigationBar/NavBarItems/NavBarItems.swift
+++ b/godtools/App/Share/Views/Navigation/NavigationBar/NavBarItems/NavBarItems.swift
@@ -10,37 +10,37 @@ import UIKit
 
 class NavBarItems {
         
-    private let leadingItemControllers: [NarBarItemController]
-    private let trailingItemControllers: [NarBarItemController]
-            
+    private let leadingItemControllers: [NavBarItemController]
+    private let trailingItemControllers: [NavBarItemController]
+                
     init(viewController: UIViewController, leadingItems: [NavBarItem], trailingItems: [NavBarItem]) {
         
         leadingItemControllers = NavBarItems.getItemControllers(
             viewController: viewController,
             items: leadingItems,
-            itemBarPosition: .left
+            barPosition: .leading
         )
         
         trailingItemControllers = NavBarItems.getItemControllers(
             viewController: viewController,
             items: trailingItems,
-            itemBarPosition: .right
+            barPosition: .trailing
         )
     }
     
-    private static func getItemControllers(viewController: UIViewController, items: [NavBarItem], itemBarPosition: BarButtonItemBarPosition) -> [NarBarItemController] {
+    private static func getItemControllers(viewController: UIViewController, items: [NavBarItem], barPosition: BarButtonItemBarPosition) -> [NavBarItemController] {
         
-        var itemControllers: [NarBarItemController] = Array()
+        var itemControllers: [NavBarItemController] = Array()
         
         for index in 0 ..< items.count {
             
             let navBarItem: NavBarItem = items[index]
             
-            let controller = NarBarItemController.newNavBarItemController(
+            let controller = NavBarItemController.newNavBarItemController(
                 controllerType: navBarItem.controllerType,
                 viewController: viewController,
                 navBarItem: navBarItem,
-                itemBarPosition: itemBarPosition,
+                itemBarPosition: barPosition,
                 itemIndex: index
             )
             

--- a/godtools/App/Share/Views/Navigation/ViewControllers/AppHostingController.swift
+++ b/godtools/App/Share/Views/Navigation/ViewControllers/AppHostingController.swift
@@ -11,15 +11,15 @@ import SwiftUI
 
 class AppHostingController<Content: View>: UIHostingController<Content> {
         
-    private var navBarItems: NavBarItems?
+    private let navigationBar: AppNavigationBar?
     
     init(rootView: Content, navigationBar: AppNavigationBar?) {
         
+        self.navigationBar = navigationBar
+        
         super.init(rootView: rootView)
         
-        if let navigationBar = navigationBar {
-            navBarItems = NavBarItems(viewController: self, leadingItems: navigationBar.leadingItems, trailingItems: navigationBar.trailingItems)
-        }
+        navigationBar?.configure(viewController: self)
     }
     
     @MainActor required dynamic init?(coder aDecoder: NSCoder) {

--- a/godtools/App/Share/Views/Navigation/ViewControllers/AppViewController.swift
+++ b/godtools/App/Share/Views/Navigation/ViewControllers/AppViewController.swift
@@ -10,26 +10,24 @@ import UIKit
 
 class AppViewController: UIViewController {
     
-    private var navBarItems: NavBarItems?
+    private let navigationBar: AppNavigationBar?
     
     init(navigationBar: AppNavigationBar?) {
-                
+          
+        self.navigationBar = navigationBar
+        
         super.init(nibName: nil, bundle: nil)
         
-        configureNavigationBar(navigationBar: navigationBar)
+        navigationBar?.configure(viewController: self)
     }
     
     init(nibName: String?, bundle: Bundle?, navigationBar: AppNavigationBar?) {
         
+        self.navigationBar = navigationBar
+        
         super.init(nibName: nibName, bundle: bundle)
         
-        configureNavigationBar(navigationBar: navigationBar)
-    }
-    
-    private func configureNavigationBar(navigationBar: AppNavigationBar?) {
-        if let navigationBar = navigationBar {
-            navBarItems = NavBarItems(viewController: self, leadingItems: navigationBar.leadingItems, trailingItems: navigationBar.trailingItems)
-        }
+        navigationBar?.configure(viewController: self)
     }
     
     required init?(coder: NSCoder) {


### PR DESCRIPTION
- Fixed a bug where the back button toggle visibility wasn't working.  Needed to add some additional checks since when redrawing bar button items they need to be removed and added back to the navigation bar.
- Renamed the bar position from left and right to leading and trailing.
- Moved nav bar items configuration into AppNavigationBar.