### PR TITLE
Use the version of ruby specified in .ruby-version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,11 @@ jobs:
           distribution: 'adopt'
           java-version: '11'
 
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
 
@@ -56,9 +61,6 @@ jobs:
           path: ~/.konan
           key: ${{ runner.os }}-konan-${{ github.sha }}
           restore-keys: ${{ runner.os }}-konan-
-
-      - name: Bundle Install
-        run: bundle install
 
       - name: Pod install
         run: bundle exec pod install --repo-update

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -288,6 +288,7 @@ GEM
 
 PLATFORMS
   universal-darwin-22
+  x86_64-darwin-20
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
- Use setup-ruby GHA action to use the version of ruby specified in .ruby-version
- add GHA macos platform to lockfile
