### PR TITLE
GT add onboarding flow ui tests

### DIFF
--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -901,6 +901,7 @@
 		45C2AF582A8192BB004958AB /* TutorialItemViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45C2AF562A8192BB004958AB /* TutorialItemViewModel.swift */; };
 		45C2AF592A8192BB004958AB /* TutorialItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45C2AF572A8192BB004958AB /* TutorialItemView.swift */; };
 		45C321A72ACE7A89003B4F2C /* AppInterfaceStringNavBarItemController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45C321A62ACE7A89003B4F2C /* AppInterfaceStringNavBarItemController.swift */; };
+		45C5DDCE2AE6BF1300C70BBA /* AccessibilityScreenElementView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45C5DDCD2AE6BF1300C70BBA /* AccessibilityScreenElementView.swift */; };
 		45C883522A93DD5E00F33E6D /* DashboardPresentationLayerDependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45C883512A93DD5E00F33E6D /* DashboardPresentationLayerDependencies.swift */; };
 		45C8835D2A93EDDF00F33E6D /* DashboardTabBarItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45C8835C2A93EDDF00F33E6D /* DashboardTabBarItemView.swift */; };
 		45C8835F2A93EE9C00F33E6D /* DashboardTabBarItemViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45C8835E2A93EE9C00F33E6D /* DashboardTabBarItemViewModel.swift */; };
@@ -910,6 +911,9 @@
 		45CF09702784B910007F13D3 /* RequestOperation in Frameworks */ = {isa = PBXBuildFile; productRef = 45CF096F2784B910007F13D3 /* RequestOperation */; };
 		45CF8FEF2A0EC76400802A88 /* ArticleWebViewState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45CF8FEE2A0EC76400802A88 /* ArticleWebViewState.swift */; };
 		45D1202829FABD5E00523FBA /* AuthUserDomainModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D1202729FABD5E00523FBA /* AuthUserDomainModel.swift */; };
+		45D318F12AE6F9D300D74A87 /* LanguageCodeDomainModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4585BF5D2AC38D1B00A6D720 /* LanguageCodeDomainModel.swift */; };
+		45D318F42AE6FDB100D74A87 /* OnboardingQuickStartSupportedLanguagesRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D318F32AE6FDB100D74A87 /* OnboardingQuickStartSupportedLanguagesRepository.swift */; };
+		45D318F72AE6FDD000D74A87 /* OnboardingQuickStartSupportedLanguagesCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D318F62AE6FDD000D74A87 /* OnboardingQuickStartSupportedLanguagesCache.swift */; };
 		45D3AAE1298AA69F0017E6DF /* VideoViewPlayerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D3AAE0298AA69F0017E6DF /* VideoViewPlayerState.swift */; };
 		45D40C682A5315B400E8E4AE /* Starscream in Frameworks */ = {isa = PBXBuildFile; productRef = 45D40C672A5315B400E8E4AE /* Starscream */; };
 		45D40C6B2A5315D500E8E4AE /* Fuzi in Frameworks */ = {isa = PBXBuildFile; productRef = 45D40C6A2A5315D500E8E4AE /* Fuzi */; };
@@ -2157,6 +2161,7 @@
 		45C2AF562A8192BB004958AB /* TutorialItemViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TutorialItemViewModel.swift; sourceTree = "<group>"; };
 		45C2AF572A8192BB004958AB /* TutorialItemView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TutorialItemView.swift; sourceTree = "<group>"; };
 		45C321A62ACE7A89003B4F2C /* AppInterfaceStringNavBarItemController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInterfaceStringNavBarItemController.swift; sourceTree = "<group>"; };
+		45C5DDCD2AE6BF1300C70BBA /* AccessibilityScreenElementView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityScreenElementView.swift; sourceTree = "<group>"; };
 		45C883512A93DD5E00F33E6D /* DashboardPresentationLayerDependencies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardPresentationLayerDependencies.swift; sourceTree = "<group>"; };
 		45C8835C2A93EDDF00F33E6D /* DashboardTabBarItemView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DashboardTabBarItemView.swift; sourceTree = "<group>"; };
 		45C8835E2A93EE9C00F33E6D /* DashboardTabBarItemViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardTabBarItemViewModel.swift; sourceTree = "<group>"; };
@@ -2164,6 +2169,8 @@
 		45CE7FD32926A0940056168A /* AccountSectionsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccountSectionsView.swift; sourceTree = "<group>"; };
 		45CF8FEE2A0EC76400802A88 /* ArticleWebViewState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleWebViewState.swift; sourceTree = "<group>"; };
 		45D1202729FABD5E00523FBA /* AuthUserDomainModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthUserDomainModel.swift; sourceTree = "<group>"; };
+		45D318F32AE6FDB100D74A87 /* OnboardingQuickStartSupportedLanguagesRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingQuickStartSupportedLanguagesRepository.swift; sourceTree = "<group>"; };
+		45D318F62AE6FDD000D74A87 /* OnboardingQuickStartSupportedLanguagesCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingQuickStartSupportedLanguagesCache.swift; sourceTree = "<group>"; };
 		45D3AAE0298AA69F0017E6DF /* VideoViewPlayerState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoViewPlayerState.swift; sourceTree = "<group>"; };
 		45D48C8229F81082004E92B1 /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
 		45D48C8829F81692004E92B1 /* AppConfig.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppConfig.swift; sourceTree = "<group>"; };
@@ -3133,6 +3140,7 @@
 			isa = PBXGroup;
 			children = (
 				45131A0C2AB498AD0085AF0D /* AccessibilityStrings.swift */,
+				45C5DDCD2AE6BF1300C70BBA /* AccessibilityScreenElementView.swift */,
 			);
 			path = Accessibility;
 			sourceTree = "<group>";
@@ -7205,6 +7213,23 @@
 			path = AccountSections;
 			sourceTree = "<group>";
 		};
+		45D318F22AE6FDAA00D74A87 /* OnboardingQuickStartSupportedLanguagesRepository */ = {
+			isa = PBXGroup;
+			children = (
+				45D318F32AE6FDB100D74A87 /* OnboardingQuickStartSupportedLanguagesRepository.swift */,
+				45D318F52AE6FDC100D74A87 /* Cache */,
+			);
+			path = OnboardingQuickStartSupportedLanguagesRepository;
+			sourceTree = "<group>";
+		};
+		45D318F52AE6FDC100D74A87 /* Cache */ = {
+			isa = PBXGroup;
+			children = (
+				45D318F62AE6FDD000D74A87 /* OnboardingQuickStartSupportedLanguagesCache.swift */,
+			);
+			path = Cache;
+			sourceTree = "<group>";
+		};
 		45D48C8729F81692004E92B1 /* AppConfig */ = {
 			isa = PBXGroup;
 			children = (
@@ -7759,6 +7784,7 @@
 		45E066C02AE1676B004393CD /* Data */ = {
 			isa = PBXGroup;
 			children = (
+				45D318F22AE6FDAA00D74A87 /* OnboardingQuickStartSupportedLanguagesRepository */,
 				45E066C12AE16796004393CD /* OnboardingTutorialViewedRepository */,
 			);
 			path = Data;
@@ -9797,6 +9823,7 @@
 				459B7E692ABA3A4A0088F44B /* LaunchEnvironmentKey.swift in Sources */,
 				45A415F42A99429C0030E2C7 /* XCUIApplication+Query.swift in Sources */,
 				45FBE5722AB8A33200BFBE92 /* AccessibilityStrings.swift in Sources */,
+				45D318F12AE6F9D300D74A87 /* LanguageCodeDomainModel.swift in Sources */,
 				45FBE5732AB8A33700BFBE92 /* LaunchEnvironmentKey.swift in Sources */,
 				45A415F32A99429C0030E2C7 /* OnboardingFlowTests.swift in Sources */,
 				459B7E6A2ABA3A510088F44B /* AccessibilityStrings.swift in Sources */,
@@ -10011,6 +10038,7 @@
 				45BDA6452954FF08007E259B /* HTMLDocument+ResourceUrls.swift in Sources */,
 				451FB9392896B3DE00423865 /* LanguageDirectionDomainModel.swift in Sources */,
 				454ADAE62ABDDD3800037C27 /* ChooseAppLanguageFlowCompleted.swift in Sources */,
+				45C5DDCE2AE6BF1300C70BBA /* AccessibilityScreenElementView.swift in Sources */,
 				45EB9B8029F16CF200CA74A8 /* Locale+Extensions.swift in Sources */,
 				45860A512923E73A0089C836 /* AccountUserDetailsView.swift in Sources */,
 				458CFE8D29D4E0B9007B423C /* LoadingArticleView.swift in Sources */,
@@ -10441,6 +10469,7 @@
 				45E39ED427457CB5006A59E4 /* MobileContentAnimationViewModel.swift in Sources */,
 				45AE975F27C97A9500C2CB33 /* Text+MobileContentRenderableModel.swift in Sources */,
 				45E8FAA72882FD4B00D7D569 /* RealmSHA256File.swift in Sources */,
+				45D318F42AE6FDB100D74A87 /* OnboardingQuickStartSupportedLanguagesRepository.swift in Sources */,
 				45E41B792A83D14600F886A2 /* LocalizableStringsBundleLoader.swift in Sources */,
 				45A415FD2A9942ED0030E2C7 /* OnboardingPathDeepLinkParser.swift in Sources */,
 				455583DB269F2DA500C3FF14 /* MobileContentAccordionViewModel.swift in Sources */,
@@ -10742,6 +10771,7 @@
 				45D63E52288F67CE009B4610 /* AppDomainLayerDependencies.swift in Sources */,
 				458CFE8F29D4E0B9007B423C /* ArticleWebViewModelFlowType.swift in Sources */,
 				45A835282AD1AE12004F5593 /* ToolDetailsFeatureDiContainer.swift in Sources */,
+				45D318F72AE6FDD000D74A87 /* OnboardingQuickStartSupportedLanguagesCache.swift in Sources */,
 				45860A96292437420089C836 /* DownloadProgressView.swift in Sources */,
 				459BD08C289AD4310075901B /* DetermineToolTranslationsToDownloadType.swift in Sources */,
 				45558350269F2D1000C3FF14 /* LessonPageViewFactory.swift in Sources */,

--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -74,17 +74,9 @@
 		450EE28729A6648900524F64 /* DashboardDeepLinkDashboardPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450EE28129A6648900524F64 /* DashboardDeepLinkDashboardPath.swift */; };
 		450EE28829A6648900524F64 /* DashboardPathDeepLinkParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450EE28229A6648900524F64 /* DashboardPathDeepLinkParser.swift */; };
 		450EE28929A6648900524F64 /* ArticleAemPathDeepLinkParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450EE28429A6648900524F64 /* ArticleAemPathDeepLinkParser.swift */; };
-		450EE29529A668D300524F64 /* ToolDeepLinkToolPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450EE27E29A6648900524F64 /* ToolDeepLinkToolPath.swift */; };
-		450EE29629A668D500524F64 /* ToolPathDeepLinkParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450EE27F29A6648900524F64 /* ToolPathDeepLinkParser.swift */; };
-		450EE29A29A668E400524F64 /* DashboardPathDeepLinkParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450EE28229A6648900524F64 /* DashboardPathDeepLinkParser.swift */; };
-		450EE29B29A668E400524F64 /* DashboardDeepLinkDashboardPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450EE28129A6648900524F64 /* DashboardDeepLinkDashboardPath.swift */; };
-		450EE29C29A668E700524F64 /* ArticleAemPathDeepLinkParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450EE28429A6648900524F64 /* ArticleAemPathDeepLinkParser.swift */; };
 		450EE29E29A66CA500524F64 /* KnowGodDeepLinkParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450EE29D29A66CA500524F64 /* KnowGodDeepLinkParser.swift */; };
 		450EE2A029A66CDF00524F64 /* KnowGodTractDeepLinkQueryParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450EE29F29A66CDF00524F64 /* KnowGodTractDeepLinkQueryParameters.swift */; };
-		450EE2A129A66CE400524F64 /* KnowGodDeepLinkParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450EE29D29A66CA500524F64 /* KnowGodDeepLinkParser.swift */; };
-		450EE2A229A66CE400524F64 /* KnowGodTractDeepLinkQueryParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450EE29F29A66CDF00524F64 /* KnowGodTractDeepLinkQueryParameters.swift */; };
 		450EE2AB29A6719500524F64 /* GodToolsAppLessonsPathDeepLinkParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450EE2AA29A6719500524F64 /* GodToolsAppLessonsPathDeepLinkParser.swift */; };
-		450EE2AC29A6719500524F64 /* GodToolsAppLessonsPathDeepLinkParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450EE2AA29A6719500524F64 /* GodToolsAppLessonsPathDeepLinkParser.swift */; };
 		450EF834247EB3D300978926 /* SF-Pro-Text-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 450EF833247EB3D300978926 /* SF-Pro-Text-Bold.otf */; };
 		450F94DA27A1F0F6009DEA43 /* MobileContentCardCollectionPageCardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450F94D627A1F0F6009DEA43 /* MobileContentCardCollectionPageCardViewModel.swift */; };
 		450F94DB27A1F0F6009DEA43 /* MobileContentCardCollectionPageCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450F94D727A1F0F6009DEA43 /* MobileContentCardCollectionPageCardView.swift */; };
@@ -592,7 +584,6 @@
 		45A415F32A99429C0030E2C7 /* OnboardingFlowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45A415EF2A99429B0030E2C7 /* OnboardingFlowTests.swift */; };
 		45A415F42A99429C0030E2C7 /* XCUIApplication+Query.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45A415F22A99429B0030E2C7 /* XCUIApplication+Query.swift */; };
 		45A415FD2A9942ED0030E2C7 /* OnboardingPathDeepLinkParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45A415FC2A9942ED0030E2C7 /* OnboardingPathDeepLinkParser.swift */; };
-		45A415FE2A9942F30030E2C7 /* OnboardingPathDeepLinkParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45A415FC2A9942ED0030E2C7 /* OnboardingPathDeepLinkParser.swift */; };
 		45A416022A9943D50030E2C7 /* Realm in Frameworks */ = {isa = PBXBuildFile; productRef = 45A416012A9943D50030E2C7 /* Realm */; };
 		45A416042A9943D50030E2C7 /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 45A416032A9943D50030E2C7 /* RealmSwift */; };
 		45A416062A9943D50030E2C7 /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = 45A416052A9943D50030E2C7 /* Lottie */; };
@@ -960,22 +951,6 @@
 		45D63EA6288F77D4009B4610 /* MobileContentResourcesApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D63E9B288F77D4009B4610 /* MobileContentResourcesApi.swift */; };
 		45D63EA7288F77D4009B4610 /* ResourcesRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D63E9C288F77D4009B4610 /* ResourcesRepository.swift */; };
 		45D752142A2E33DF005E747F /* MobileContentAuthProviderToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D752132A2E33DF005E747F /* MobileContentAuthProviderToken.swift */; };
-		45D7781729A570CB00F23D99 /* DeepLinkingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 459E86DA28EDA86C00E197A5 /* DeepLinkingService.swift */; };
-		45D7781829A570D000F23D99 /* IncomingDeepLinkType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 459E86D028EDA86C00E197A5 /* IncomingDeepLinkType.swift */; };
-		45D7781929A570D400F23D99 /* IncomingDeepLinkUrl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 459E86D928EDA86C00E197A5 /* IncomingDeepLinkUrl.swift */; };
-		45D7781A29A570DA00F23D99 /* DeepLinkingManifestType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 459E86D428EDA86C00E197A5 /* DeepLinkingManifestType.swift */; };
-		45D7781B29A570DD00F23D99 /* DeepLinkingParserManifestAppsFlyer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 459E86D328EDA86C00E197A5 /* DeepLinkingParserManifestAppsFlyer.swift */; };
-		45D7781C29A570DF00F23D99 /* DeepLinkingParserManifestType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 459E86D228EDA86C00E197A5 /* DeepLinkingParserManifestType.swift */; };
-		45D7781D29A570E400F23D99 /* DeepLinkingParserManifestUrl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 459E86D528EDA86C00E197A5 /* DeepLinkingParserManifestUrl.swift */; };
-		45D7781E29A570E700F23D99 /* ParsedDeepLinkType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 459E86D728EDA86C00E197A5 /* ParsedDeepLinkType.swift */; };
-		45D7781F29A570E900F23D99 /* ToolDeepLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 459E86D828EDA86C00E197A5 /* ToolDeepLink.swift */; };
-		45D7782029A570FC00F23D99 /* DeepLinkUrlParserType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 459E86BC28EDA86C00E197A5 /* DeepLinkUrlParserType.swift */; };
-		45D7782429A570FC00F23D99 /* DeepLinkParserType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 459E86BB28EDA86C00E197A5 /* DeepLinkParserType.swift */; };
-		45D7782529A570FC00F23D99 /* AppsFlyerDeepLinkValueComponentsParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 459E86C328EDA86C00E197A5 /* AppsFlyerDeepLinkValueComponentsParser.swift */; };
-		45D7782A29A570FC00F23D99 /* DeepLinkAppsFlyerParserType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 459E86C528EDA86C00E197A5 /* DeepLinkAppsFlyerParserType.swift */; };
-		45D7782B29A570FC00F23D99 /* LegacyAppsFlyerDeepLinkValueParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 459E86BE28EDA86C00E197A5 /* LegacyAppsFlyerDeepLinkValueParser.swift */; };
-		45D7782C29A570FC00F23D99 /* AppsFlyerDeepLinkValueParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 459E86C428EDA86C00E197A5 /* AppsFlyerDeepLinkValueParser.swift */; };
-		45D7782E29A5714C00F23D99 /* GodToolsDeepLinkingManifest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 459E86B928EDA86C00E197A5 /* GodToolsDeepLinkingManifest.swift */; };
 		45D7783029A572CC00F23D99 /* PassthroughValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45EC429A272C87430052F2AA /* PassthroughValue.swift */; };
 		45D7783129A572E500F23D99 /* JsonServices.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45AD20E9259391B000A096A0 /* JsonServices.swift */; };
 		45D7783229A572EA00F23D99 /* JsonServicesType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45AD20EA259391B000A096A0 /* JsonServicesType.swift */; };
@@ -10953,60 +10928,35 @@
 			files = (
 				450AF5B72AD8216D00524A15 /* TestsGetAppLanguagesListRepository.swift in Sources */,
 				45D7783029A572CC00F23D99 /* PassthroughValue.swift in Sources */,
-				45D7782529A570FC00F23D99 /* AppsFlyerDeepLinkValueComponentsParser.swift in Sources */,
 				455310CF2AE1D0FC00C0D3CB /* GetOnboardingQuickStartLinksUseCaseTests.swift in Sources */,
-				45D7781A29A570DA00F23D99 /* DeepLinkingManifestType.swift in Sources */,
-				450EE29C29A668E700524F64 /* ArticleAemPathDeepLinkParser.swift in Sources */,
-				450EE29B29A668E400524F64 /* DashboardDeepLinkDashboardPath.swift in Sources */,
-				450EE29629A668D500524F64 /* ToolPathDeepLinkParser.swift in Sources */,
 				45368A1A2ABB2D850028A570 /* LocalizableStringsBundleLoaderTests.swift in Sources */,
 				45A45CEE2731B8C9005D4E74 /* MobileContentBackgroundImageRendererType.swift in Sources */,
 				45E61EC62AE1B72600A98872 /* GetOnboardingTutorialIsAvailableUseCaseTests.swift in Sources */,
-				45D7781E29A570E700F23D99 /* ParsedDeepLinkType.swift in Sources */,
 				45328C092AC46D14006B3B8A /* TestsGetUserPreferredAppLanguageRepository.swift in Sources */,
-				45D7782B29A570FC00F23D99 /* LegacyAppsFlyerDeepLinkValueParser.swift in Sources */,
 				45E61EC42AE1AFD700A98872 /* TestsGetOnboardingTutorialInterfaceStringsRepository.swift in Sources */,
-				45A415FE2A9942F30030E2C7 /* OnboardingPathDeepLinkParser.swift in Sources */,
-				450EE29529A668D300524F64 /* ToolDeepLinkToolPath.swift in Sources */,
-				45D7781929A570D400F23D99 /* IncomingDeepLinkUrl.swift in Sources */,
 				45AFC62D27CD74100090E381 /* MobileContentBackgroundImageAlignment.swift in Sources */,
-				45D7781F29A570E900F23D99 /* ToolDeepLink.swift in Sources */,
-				45D7782E29A5714C00F23D99 /* GodToolsDeepLinkingManifest.swift in Sources */,
 				45368A152ABB2D850028A570 /* Collection+SafeLookupTests.swift in Sources */,
 				45368A1B2ABB2D850028A570 /* LocalizableStringsRepositoryTests.swift in Sources */,
-				45D7781C29A570DF00F23D99 /* DeepLinkingParserManifestType.swift in Sources */,
 				455310D12AE1D14100C0D3CB /* TestsGetOnboardingQuickStartLinksRepository.swift in Sources */,
 				45DB18922AD7924700E9578F /* TestsGetAppLanguagesRepository.swift in Sources */,
 				45368A172ABB2D850028A570 /* RealmDatabaseTests.swift in Sources */,
 				45E61ED02AE1BD0D00A98872 /* GetOnboardingQuickStartInterfaceStringsUseCaseTests.swift in Sources */,
 				450AF5B62AD8211300524A15 /* GetAppLanguagesListUseCaseTests.swift in Sources */,
 				45368A182ABB2D850028A570 /* TestRealmObject.swift in Sources */,
-				45D7781829A570D000F23D99 /* IncomingDeepLinkType.swift in Sources */,
-				45D7781D29A570E400F23D99 /* DeepLinkingParserManifestUrl.swift in Sources */,
 				45E61ECE2AE1B90B00A98872 /* TestsGetLaunchCountRepository.swift in Sources */,
 				455310CD2AE1CC8300C0D3CB /* TestsGetOnboardingQuickStartSupportedLanguagesRepository.swift in Sources */,
-				45D7782429A570FC00F23D99 /* DeepLinkParserType.swift in Sources */,
 				45D7783129A572E500F23D99 /* JsonServices.swift in Sources */,
-				450EE2A129A66CE400524F64 /* KnowGodDeepLinkParser.swift in Sources */,
-				45D7781B29A570DD00F23D99 /* DeepLinkingParserManifestAppsFlyer.swift in Sources */,
-				45D7782A29A570FC00F23D99 /* DeepLinkAppsFlyerParserType.swift in Sources */,
 				455310CB2AE1CBB000C0D3CB /* GetOnboardingQuickStartIsAvailableUseCaseTests.swift in Sources */,
 				45E61EC12AE1AE2800A98872 /* GetOnboardingTutorialInterfaceStringsUseCaseTests.swift in Sources */,
 				45368A192ABB2D850028A570 /* DeepLinkingServiceTests.swift in Sources */,
 				455280B4295F65C300672A1B /* LanguageDirectionDomainModel.swift in Sources */,
-				450EE29A29A668E400524F64 /* DashboardPathDeepLinkParser.swift in Sources */,
-				45D7782029A570FC00F23D99 /* DeepLinkUrlParserType.swift in Sources */,
 				45D7783229A572EA00F23D99 /* JsonServicesType.swift in Sources */,
 				45A45CED2731B8C5005D4E74 /* MobileContentBackgroundImageRenderer.swift in Sources */,
 				45E61ED22AE1BD6A00A98872 /* TestsGetOnboardingQuickStartInterfaceStringsRepository.swift in Sources */,
 				45E61EC82AE1B78600A98872 /* TestsGetOnboardingTutorialViewedRepository.swift in Sources */,
 				45368A1C2ABB2D850028A570 /* LocalizationServicesTests.swift in Sources */,
 				45328C0F2AC46D7F006B3B8A /* GetCurrentAppLanguageUseCaseTests.swift in Sources */,
-				450EE2A229A66CE400524F64 /* KnowGodTractDeepLinkQueryParameters.swift in Sources */,
 				45328C082AC46D14006B3B8A /* TestsGetDeviceLanguageRepository.swift in Sources */,
-				45D7782C29A570FC00F23D99 /* AppsFlyerDeepLinkValueParser.swift in Sources */,
-				45D7781729A570CB00F23D99 /* DeepLinkingService.swift in Sources */,
-				450EE2AC29A6719500524F64 /* GodToolsAppLessonsPathDeepLinkParser.swift in Sources */,
 				45368A162ABB2D850028A570 /* LocaleTests.swift in Sources */,
 				450AF5B52AD81F3B00524A15 /* GetInterfaceLayoutDirectionUseCaseTests.swift in Sources */,
 			);

--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -914,6 +914,11 @@
 		45D318F12AE6F9D300D74A87 /* LanguageCodeDomainModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4585BF5D2AC38D1B00A6D720 /* LanguageCodeDomainModel.swift */; };
 		45D318F42AE6FDB100D74A87 /* OnboardingQuickStartSupportedLanguagesRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D318F32AE6FDB100D74A87 /* OnboardingQuickStartSupportedLanguagesRepository.swift */; };
 		45D318F72AE6FDD000D74A87 /* OnboardingQuickStartSupportedLanguagesCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D318F62AE6FDD000D74A87 /* OnboardingQuickStartSupportedLanguagesCache.swift */; };
+		45D318FA2AE700A200D74A87 /* AppLanguagesCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D318F92AE700A200D74A87 /* AppLanguagesCache.swift */; };
+		45D318FB2AE7020200D74A87 /* AppLanguageDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B3F4472AC3A86100D61BFD /* AppLanguageDataModel.swift */; };
+		45D318FC2AE7020D00D74A87 /* AppLanguageCodeDomainModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450DB5592AC353EC00B2FE3A /* AppLanguageCodeDomainModel.swift */; };
+		45D318FD2AE7031D00D74A87 /* AppLanguagesCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D318F92AE700A200D74A87 /* AppLanguagesCache.swift */; };
+		45D318FE2AE7032700D74A87 /* OnboardingQuickStartSupportedLanguagesCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D318F62AE6FDD000D74A87 /* OnboardingQuickStartSupportedLanguagesCache.swift */; };
 		45D3AAE1298AA69F0017E6DF /* VideoViewPlayerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D3AAE0298AA69F0017E6DF /* VideoViewPlayerState.swift */; };
 		45D40C682A5315B400E8E4AE /* Starscream in Frameworks */ = {isa = PBXBuildFile; productRef = 45D40C672A5315B400E8E4AE /* Starscream */; };
 		45D40C6B2A5315D500E8E4AE /* Fuzi in Frameworks */ = {isa = PBXBuildFile; productRef = 45D40C6A2A5315D500E8E4AE /* Fuzi */; };
@@ -2171,6 +2176,7 @@
 		45D1202729FABD5E00523FBA /* AuthUserDomainModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthUserDomainModel.swift; sourceTree = "<group>"; };
 		45D318F32AE6FDB100D74A87 /* OnboardingQuickStartSupportedLanguagesRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingQuickStartSupportedLanguagesRepository.swift; sourceTree = "<group>"; };
 		45D318F62AE6FDD000D74A87 /* OnboardingQuickStartSupportedLanguagesCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingQuickStartSupportedLanguagesCache.swift; sourceTree = "<group>"; };
+		45D318F92AE700A200D74A87 /* AppLanguagesCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLanguagesCache.swift; sourceTree = "<group>"; };
 		45D3AAE0298AA69F0017E6DF /* VideoViewPlayerState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoViewPlayerState.swift; sourceTree = "<group>"; };
 		45D48C8229F81082004E92B1 /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
 		45D48C8829F81692004E92B1 /* AppConfig.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppConfig.swift; sourceTree = "<group>"; };
@@ -6575,6 +6581,7 @@
 		45B3F4452AC3A86100D61BFD /* AppLanguagesRepository */ = {
 			isa = PBXGroup;
 			children = (
+				45D318F82AE7009700D74A87 /* Cache */,
 				45B3F4462AC3A86100D61BFD /* AppLanguagesRepository.swift */,
 				45B3F4472AC3A86100D61BFD /* AppLanguageDataModel.swift */,
 			);
@@ -7226,6 +7233,14 @@
 			isa = PBXGroup;
 			children = (
 				45D318F62AE6FDD000D74A87 /* OnboardingQuickStartSupportedLanguagesCache.swift */,
+			);
+			path = Cache;
+			sourceTree = "<group>";
+		};
+		45D318F82AE7009700D74A87 /* Cache */ = {
+			isa = PBXGroup;
+			children = (
+				45D318F92AE700A200D74A87 /* AppLanguagesCache.swift */,
 			);
 			path = Cache;
 			sourceTree = "<group>";
@@ -9820,12 +9835,16 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				45D318FD2AE7031D00D74A87 /* AppLanguagesCache.swift in Sources */,
 				459B7E692ABA3A4A0088F44B /* LaunchEnvironmentKey.swift in Sources */,
 				45A415F42A99429C0030E2C7 /* XCUIApplication+Query.swift in Sources */,
 				45FBE5722AB8A33200BFBE92 /* AccessibilityStrings.swift in Sources */,
 				45D318F12AE6F9D300D74A87 /* LanguageCodeDomainModel.swift in Sources */,
 				45FBE5732AB8A33700BFBE92 /* LaunchEnvironmentKey.swift in Sources */,
+				45D318FB2AE7020200D74A87 /* AppLanguageDataModel.swift in Sources */,
+				45D318FE2AE7032700D74A87 /* OnboardingQuickStartSupportedLanguagesCache.swift in Sources */,
 				45A415F32A99429C0030E2C7 /* OnboardingFlowTests.swift in Sources */,
+				45D318FC2AE7020D00D74A87 /* AppLanguageCodeDomainModel.swift in Sources */,
 				459B7E6A2ABA3A510088F44B /* AccessibilityStrings.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -10457,6 +10476,7 @@
 				45558321269F2C7B00C3FF14 /* ToolPagePositions.swift in Sources */,
 				458E410B2A9CCE55009769DF /* AppBuildConfiguration.swift in Sources */,
 				45677780287DB21F0044AEB2 /* ToolTrainingTipView.swift in Sources */,
+				45D318FA2AE700A200D74A87 /* AppLanguagesCache.swift in Sources */,
 				4595E0E32A852DAA00D88DAE /* MobileContentApiUsersMeCodable+UserDetailsDataModelType.swift in Sources */,
 				45AD1F6325938A9800A096A0 /* WebSocketType.swift in Sources */,
 				455583EA269F2DA500C3FF14 /* MobileContentView.swift in Sources */,

--- a/godtools/App/Features/AppLanguage/Data/AppLanguagesRepository/AppLanguagesRepository.swift
+++ b/godtools/App/Features/AppLanguage/Data/AppLanguagesRepository/AppLanguagesRepository.swift
@@ -11,26 +11,16 @@ import Combine
 
 class AppLanguagesRepository {
     
-    init() {
+    private let cache: AppLanguagesCache
+    
+    init(cache: AppLanguagesCache) {
         
+        self.cache = cache
     }
     
     func getLanguagesPublisher() -> AnyPublisher<[AppLanguageDataModel], Never> {
         
-        let appLanguages: [AppLanguageDataModel] = [
-            AppLanguageDataModel(languageCode: "ar", languageDirection: .rightToLeft),
-            AppLanguageDataModel(languageCode: "en", languageDirection: .leftToRight),
-            AppLanguageDataModel(languageCode: "es", languageDirection: .leftToRight),
-            AppLanguageDataModel(languageCode: "pt", languageDirection: .leftToRight),
-            AppLanguageDataModel(languageCode: "fr", languageDirection: .leftToRight),
-            AppLanguageDataModel(languageCode: "id", languageDirection: .leftToRight),
-            AppLanguageDataModel(languageCode: "zh-Hans", languageDirection: .leftToRight),
-            AppLanguageDataModel(languageCode: "zh-Hant", languageDirection: .leftToRight),
-            AppLanguageDataModel(languageCode: "hi", languageDirection: .leftToRight),
-            AppLanguageDataModel(languageCode: "ru", languageDirection: .leftToRight),
-            AppLanguageDataModel(languageCode: "vi", languageDirection: .leftToRight),
-            AppLanguageDataModel(languageCode: "lv", languageDirection: .leftToRight)
-        ]
+        let appLanguages: [AppLanguageDataModel] = cache.getAppLanguages()
         
         return Just(appLanguages)
             .eraseToAnyPublisher()

--- a/godtools/App/Features/AppLanguage/Data/AppLanguagesRepository/Cache/AppLanguagesCache.swift
+++ b/godtools/App/Features/AppLanguage/Data/AppLanguagesRepository/Cache/AppLanguagesCache.swift
@@ -1,0 +1,37 @@
+//
+//  AppLanguagesCache.swift
+//  godtools
+//
+//  Created by Levi Eggert on 10/23/23.
+//  Copyright © 2023 Cru. All rights reserved.
+//
+
+import Foundation
+
+class AppLanguagesCache {
+    
+    private let appLanguages: [AppLanguageDataModel]
+    
+    init() {
+        
+        appLanguages = [
+            AppLanguageDataModel(languageCode: "ar", languageDirection: .rightToLeft),
+            AppLanguageDataModel(languageCode: "en", languageDirection: .leftToRight),
+            AppLanguageDataModel(languageCode: "es", languageDirection: .leftToRight),
+            AppLanguageDataModel(languageCode: "pt", languageDirection: .leftToRight),
+            AppLanguageDataModel(languageCode: "fr", languageDirection: .leftToRight),
+            AppLanguageDataModel(languageCode: "id", languageDirection: .leftToRight),
+            AppLanguageDataModel(languageCode: "zh-Hans", languageDirection: .leftToRight),
+            AppLanguageDataModel(languageCode: "zh-Hant", languageDirection: .leftToRight),
+            AppLanguageDataModel(languageCode: "hi", languageDirection: .leftToRight),
+            AppLanguageDataModel(languageCode: "ru", languageDirection: .leftToRight),
+            AppLanguageDataModel(languageCode: "vi", languageDirection: .leftToRight),
+            AppLanguageDataModel(languageCode: "lv", languageDirection: .leftToRight)
+        ]
+    }
+    
+    func getAppLanguages() -> [AppLanguageDataModel] {
+        
+        return appLanguages
+    }
+}

--- a/godtools/App/Features/AppLanguage/DependencyContainer/AppLanguageFeatureDataLayerDependencies.swift
+++ b/godtools/App/Features/AppLanguage/DependencyContainer/AppLanguageFeatureDataLayerDependencies.swift
@@ -19,8 +19,12 @@ class AppLanguageFeatureDataLayerDependencies {
     
     // MARK: - Data Layer Classes
     
+    private func getAppLanguagesCache() -> AppLanguagesCache {
+        return AppLanguagesCache()
+    }
+    
     private func getAppLanguagesRepository() -> AppLanguagesRepository {
-        return AppLanguagesRepository()
+        return AppLanguagesRepository(cache: getAppLanguagesCache())
     }
     
     func getUserAppLanguageCache() -> RealmUserAppLanguageCache {

--- a/godtools/App/Features/AppLanguage/DependencyContainer/AppLanguageFeatureDataLayerDependencies.swift
+++ b/godtools/App/Features/AppLanguage/DependencyContainer/AppLanguageFeatureDataLayerDependencies.swift
@@ -23,11 +23,15 @@ class AppLanguageFeatureDataLayerDependencies {
         return AppLanguagesRepository()
     }
     
+    func getUserAppLanguageCache() -> RealmUserAppLanguageCache {
+        return RealmUserAppLanguageCache(
+            realmDatabase: coreDataLayer.getSharedRealmDatabase()
+        )
+    }
+    
     private func getUserAppLanguageRepository() -> UserAppLanguageRepository {
         return UserAppLanguageRepository(
-            cache: RealmUserAppLanguageCache(
-                realmDatabase: coreDataLayer.getSharedRealmDatabase()
-            )
+            cache: getUserAppLanguageCache()
         )
     }
     

--- a/godtools/App/Features/AppLanguage/Presentation/AppLanguages/AppLanguagesView.swift
+++ b/godtools/App/Features/AppLanguage/Presentation/AppLanguages/AppLanguagesView.swift
@@ -21,6 +21,8 @@ struct AppLanguagesView: View {
         
         VStack(spacing: 0) {
             
+            AccessibilityScreenElementView(screenAccessibility: .appLanguages)
+                        
             SearchBarView(viewModel: viewModel.getSearchBarViewModel())
             
             List {

--- a/godtools/App/Features/Dashboard/Presentation/Favorites/FavoritesView.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Favorites/FavoritesView.swift
@@ -24,6 +24,8 @@ struct FavoritesView: View {
         
         GeometryReader { geometry in
                   
+            AccessibilityScreenElementView(screenAccessibility: .dashboardFavorites)
+            
             if viewModel.isLoadingYourFavoritedTools {
                 CenteredCircularProgressView(
                     progressColor: ColorPalette.gtGrey.color

--- a/godtools/App/Features/Dashboard/Presentation/Tools/ToolsView.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Tools/ToolsView.swift
@@ -25,6 +25,8 @@ struct ToolsView: View {
         
         GeometryReader { geometry in
               
+            AccessibilityScreenElementView(screenAccessibility: .dashboardTools)
+            
             if viewModel.isLoadingAllTools {
                 CenteredCircularProgressView(
                     progressColor: ColorPalette.gtGrey.color

--- a/godtools/App/Features/Lessons/Presentation/Lessons/LessonsView.swift
+++ b/godtools/App/Features/Lessons/Presentation/Lessons/LessonsView.swift
@@ -26,6 +26,8 @@ struct LessonsView: View {
         
         GeometryReader { geometry in
                     
+            AccessibilityScreenElementView(screenAccessibility: .dashboardLessons)
+            
             if viewModel.isLoadingLessons {
                 CenteredCircularProgressView(
                     progressColor: ColorPalette.gtGrey.color

--- a/godtools/App/Features/Onboarding/Data-DomainInterface/GetOnboardingQuickStartSupportedLanguagesRepository.swift
+++ b/godtools/App/Features/Onboarding/Data-DomainInterface/GetOnboardingQuickStartSupportedLanguagesRepository.swift
@@ -11,15 +11,16 @@ import Combine
 
 class GetOnboardingQuickStartSupportedLanguagesRepository: GetOnboardingQuickStartSupportedLanguagesRepositoryInterface {
     
-    private let supportedLanguages: [LanguageCodeDomainModel] = [.english, .french, .latvian, .spanish, .vietnamese]
-    
-    init() {
+    private let onboardingQuickStartSupportedLanguagesRepository: OnboardingQuickStartSupportedLanguagesRepository
         
+    init(onboardingQuickStartSupportedLanguagesRepository: OnboardingQuickStartSupportedLanguagesRepository) {
+        
+        self.onboardingQuickStartSupportedLanguagesRepository = onboardingQuickStartSupportedLanguagesRepository
     }
     
     func getLanguagesPublisher() -> AnyPublisher<[LanguageCodeDomainModel], Never> {
         
-        return Just(supportedLanguages)
+        return onboardingQuickStartSupportedLanguagesRepository.getLanguagesPublisher()
             .eraseToAnyPublisher()
     }
 }

--- a/godtools/App/Features/Onboarding/Data/OnboardingQuickStartSupportedLanguagesRepository/Cache/OnboardingQuickStartSupportedLanguagesCache.swift
+++ b/godtools/App/Features/Onboarding/Data/OnboardingQuickStartSupportedLanguagesRepository/Cache/OnboardingQuickStartSupportedLanguagesCache.swift
@@ -1,0 +1,22 @@
+//
+//  OnboardingQuickStartSupportedLanguagesCache.swift
+//  godtools
+//
+//  Created by Levi Eggert on 10/23/23.
+//  Copyright © 2023 Cru. All rights reserved.
+//
+
+import Foundation
+
+class OnboardingQuickStartSupportedLanguagesCache {
+    
+    private let supportedLanguages: [LanguageCodeDomainModel] = [.english, .french, .latvian, .spanish, .vietnamese]
+    
+    init() {
+        
+    }
+    
+    func getSupportedLanguages() -> [LanguageCodeDomainModel] {
+        return supportedLanguages
+    }
+}

--- a/godtools/App/Features/Onboarding/Data/OnboardingQuickStartSupportedLanguagesRepository/OnboardingQuickStartSupportedLanguagesRepository.swift
+++ b/godtools/App/Features/Onboarding/Data/OnboardingQuickStartSupportedLanguagesRepository/OnboardingQuickStartSupportedLanguagesRepository.swift
@@ -1,0 +1,26 @@
+//
+//  OnboardingQuickStartSupportedLanguagesRepository.swift
+//  godtools
+//
+//  Created by Levi Eggert on 10/23/23.
+//  Copyright © 2023 Cru. All rights reserved.
+//
+
+import Foundation
+import Combine
+
+class OnboardingQuickStartSupportedLanguagesRepository {
+    
+    private let cache: OnboardingQuickStartSupportedLanguagesCache
+    
+    init(cache: OnboardingQuickStartSupportedLanguagesCache) {
+        
+        self.cache = cache
+    }
+    
+    func getLanguagesPublisher() -> AnyPublisher<[LanguageCodeDomainModel], Never> {
+        
+        return Just(cache.getSupportedLanguages())
+            .eraseToAnyPublisher()
+    }
+}

--- a/godtools/App/Features/Onboarding/DependencyContainer/OnboardingDataLayerDependencies.swift
+++ b/godtools/App/Features/Onboarding/DependencyContainer/OnboardingDataLayerDependencies.swift
@@ -19,6 +19,16 @@ class OnboardingDataLayerDependencies {
     
     // MARK: - Data Layer Classes
     
+    private func getOnboardingQuickStartSupportedLanguagesCache() -> OnboardingQuickStartSupportedLanguagesCache {
+        return OnboardingQuickStartSupportedLanguagesCache()
+    }
+    
+    private func getOnboardingQuickStartSupportedLanguagesRepository() -> OnboardingQuickStartSupportedLanguagesRepository {
+        return OnboardingQuickStartSupportedLanguagesRepository(
+            cache: getOnboardingQuickStartSupportedLanguagesCache()
+        )
+    }
+    
     private func getOnboardingTutorialViewedRepository() -> OnboardingTutorialViewedRepository {
         return OnboardingTutorialViewedRepository(
             cache: OnboardingTutorialViewedUserDefaultsCache(sharedUserDefaultsCache: coreDataLayer.getSharedUserDefaultsCache())
@@ -40,7 +50,9 @@ class OnboardingDataLayerDependencies {
     }
     
     func getOnboardingQuickStartSupportedLanguagesRepositoryInterface() -> GetOnboardingQuickStartSupportedLanguagesRepositoryInterface {
-        return GetOnboardingQuickStartSupportedLanguagesRepository()
+        return GetOnboardingQuickStartSupportedLanguagesRepository(
+            onboardingQuickStartSupportedLanguagesRepository: getOnboardingQuickStartSupportedLanguagesRepository()
+        )
     }
     
     func getOnboardingTutorialInterfaceStringsRepositoryInterface() -> GetOnboardingTutorialInterfaceStringsRepositoryInterface {

--- a/godtools/App/Features/Onboarding/Presentation/OnboardingQuickStart/OnboardingQuickStartView.swift
+++ b/godtools/App/Features/Onboarding/Presentation/OnboardingQuickStart/OnboardingQuickStartView.swift
@@ -25,6 +25,8 @@ struct OnboardingQuickStartView: View {
          
         GeometryReader { geometry in
             
+            AccessibilityScreenElementView(screenAccessibility: .onboardingQuickStart)
+            
             VStack(alignment: .center, spacing: 0) {
                 
                 Text(viewModel.title)

--- a/godtools/App/Features/Onboarding/Presentation/OnboardingTutorial/OnboardingTutorialView.swift
+++ b/godtools/App/Features/Onboarding/Presentation/OnboardingTutorial/OnboardingTutorialView.swift
@@ -26,6 +26,8 @@ struct OnboardingTutorialView: View {
         
         GeometryReader { geometry in
             
+            AccessibilityScreenElementView(screenAccessibility: .onboardingTutorial)
+
             VStack(alignment: .center, spacing: 0) {
                    
                 PagedView(numberOfPages: viewModel.pages.count, currentPage: $viewModel.currentPage) { (page: Int) in
@@ -84,7 +86,6 @@ struct OnboardingTutorialView: View {
             .padding([.top], chooseAppLanguageButtonPosition)
             .animation(.interpolatingSpring(stiffness: 80, damping: 10), value: chooseAppLanguageButtonPosition)
         }
-        .accessibilityIdentifier(AccessibilityStrings.Screen.onboardingTutorial.id)
         .environment(\.layoutDirection, ApplicationLayout.shared.layoutDirection)
     }
 }

--- a/godtools/App/Features/Onboarding/Presentation/OnboardingTutorial/Subviews/ChooseAppLanguageButton/InvisibleChooseAppLanguageButtonForNavigationBar.swift
+++ b/godtools/App/Features/Onboarding/Presentation/OnboardingTutorial/Subviews/ChooseAppLanguageButton/InvisibleChooseAppLanguageButtonForNavigationBar.swift
@@ -28,6 +28,7 @@ class InvisibleChooseAppLanguageButtonForNavigationBar: UIView {
         addSubview(button)
         
         button.addTarget(self, action: #selector(buttonTapped), for: .touchUpInside)
+        button.accessibilityIdentifier = AccessibilityStrings.Button.chooseAppLanguage.id
     }
     
     required init?(coder: NSCoder) {

--- a/godtools/App/Features/Onboarding/Presentation/OnboardingTutorial/Subviews/OnboardingTutorialPrimaryButton/OnboardingTutorialPrimaryButton.swift
+++ b/godtools/App/Features/Onboarding/Presentation/OnboardingTutorial/Subviews/OnboardingTutorialPrimaryButton/OnboardingTutorialPrimaryButton.swift
@@ -16,7 +16,7 @@ struct OnboardingTutorialPrimaryButton: View {
     
     var body: some View {
         
-        GTBlueButton(title: title, font: FontLibrary.sfProTextSemibold.font(size: 17), width: geometry.size.width - 60, height: 50, highlightsTitleOnTap: false) {
+        GTBlueButton(title: title, font: FontLibrary.sfProTextSemibold.font(size: 17), width: geometry.size.width - 60, height: 50, highlightsTitleOnTap: false, accessibility: .nextOnboardingTutorial) {
             
             action()
         }

--- a/godtools/App/Flows/App/AppFlow.swift
+++ b/godtools/App/Flows/App/AppFlow.swift
@@ -104,7 +104,7 @@ class AppFlow: NSObject, ToolNavigationFlow, Flow {
         switch step {
         
         case .appLaunchedFromTerminatedState:
-              
+                          
             if let deepLink = appLaunchedFromDeepLink {
                 
                 appLaunchedFromDeepLink = nil
@@ -656,7 +656,12 @@ extension AppFlow {
         case .dashboard:
             navigateToDashboard(startingTab: .favorites)
             
-        case .onboarding:
+        case .onboarding(let appLanguageCode):
+            
+            let userAppLanguageCache: RealmUserAppLanguageCache = appDiContainer.feature.appLanguage.dataLayer.getUserAppLanguageCache()
+            
+            userAppLanguageCache.storeLanguage(languageCode: appLanguageCode)
+            
             navigateToOnboarding(animated: true)
         }
     }

--- a/godtools/App/Flows/Onboarding/OnboardingFlow.swift
+++ b/godtools/App/Flows/Onboarding/OnboardingFlow.swift
@@ -156,7 +156,7 @@ extension OnboardingFlow {
             getInterfaceStringInAppLanguageUseCase: appDiContainer.feature.appLanguage.domainLayer.getInterfaceStringInAppLanguageUseCase(),
             target: viewModel,
             action: #selector(viewModel.skipTapped),
-            accessibilityIdentifier: nil,
+            accessibilityIdentifier: AccessibilityStrings.Button.skipOnboardingTutorial.id,
             toggleVisibilityPublisher: viewModel.hidesSkipButtonPublisher
         )
         

--- a/godtools/App/Share/Application/Accessibility/AccessibilityScreenElementView.swift
+++ b/godtools/App/Share/Application/Accessibility/AccessibilityScreenElementView.swift
@@ -1,0 +1,30 @@
+//
+//  AccessibilityScreenElementView.swift
+//  godtools
+//
+//  Created by Levi Eggert on 10/23/23.
+//  Copyright © 2023 Cru. All rights reserved.
+//
+
+import SwiftUI
+
+// NOTE: Place within a view that makes up a screen.  Typically a GeometryReader or VStack etc.
+// Having accessibilityIdentifier on the top level GeometryReader was somehow causing an issue when querying for the choose app language button in OnboardingTutorialView.
+// Also keeping the accessibility on a TextElement solved issues with querying.  Tried placing on a Group and ZStack but was unable to find the element. ~Levi
+
+struct AccessibilityScreenElementView: View {
+    
+    private let screenAccessibility: AccessibilityStrings.Screen
+    
+    init(screenAccessibility: AccessibilityStrings.Screen) {
+        
+        self.screenAccessibility = screenAccessibility
+    }
+    
+    var body: some View {
+        ZStack {
+            Text("")
+                .accessibilityIdentifier(screenAccessibility.id)
+        }
+    }
+}

--- a/godtools/App/Share/Application/Accessibility/AccessibilityStrings.swift
+++ b/godtools/App/Share/Application/Accessibility/AccessibilityStrings.swift
@@ -35,7 +35,6 @@ class AccessibilityStrings {
             return rawValue
         }
         
-        case testButton = "Test Button"
         case chooseAppLanguage = "Choose App Language"
         case watchOnboardingTutorialVideo = "Watch Onboarding Tutorial Video Button"
         case closeOnboardingTutorialVideo = "Close Onboarding Tutorial Video Button"

--- a/godtools/App/Share/Application/Accessibility/AccessibilityStrings.swift
+++ b/godtools/App/Share/Application/Accessibility/AccessibilityStrings.swift
@@ -16,8 +16,17 @@ class AccessibilityStrings {
             return rawValue
         }
         
+        case appLanguages = "App Languages"
         case onboardingTutorial = "Onboarding Tutorial Screen"
+        case onboardingTutorialPage1 = "Onboarding Tutorial Page 1"
+        case onboardingTutorialPage2 = "Onboarding Tutorial Page 2"
+        case onboardingTutorialPage3 = "Onboarding Tutorial Page 3"
+        case onboardingTutorialPage4 = "Onboarding Tutorial Page 4"
         case watchOnboardingTutorialVideo = "Watch Onboarding Tutorial Video Screen"
+        case onboardingQuickStart = "Onboarding Quick Start"
+        case dashboardLessons = "Dashboard Lessons"
+        case dashboardFavorites = "Dashboard Favorites"
+        case dashboardTools = "Dashboard Tools"
     }
     
     enum Button: String {
@@ -26,7 +35,11 @@ class AccessibilityStrings {
             return rawValue
         }
         
+        case testButton = "Test Button"
+        case chooseAppLanguage = "Choose App Language"
         case watchOnboardingTutorialVideo = "Watch Onboarding Tutorial Video Button"
         case closeOnboardingTutorialVideo = "Close Onboarding Tutorial Video Button"
+        case nextOnboardingTutorial = "Next Onboarding Tutorial Button"
+        case skipOnboardingTutorial = "Skip Onboarding Tutorial Button"
     }
 }

--- a/godtools/App/Share/Data/DeepLinkingService/ParsedDeepLink/ParsedDeepLinkType.swift
+++ b/godtools/App/Share/Data/DeepLinkingService/ParsedDeepLink/ParsedDeepLinkType.swift
@@ -15,6 +15,6 @@ enum ParsedDeepLinkType: Equatable {
     case dashboard
     case favoritedToolsList
     case lessonsList
-    case onboarding
+    case onboarding(appLanguageCode: AppLanguageCodeDomainModel)
     case tool(toolDeepLink: ToolDeepLink)
 }

--- a/godtools/App/Share/Data/DeepLinkingService/Parsers/Onboarding/OnboardingPathDeepLinkParser.swift
+++ b/godtools/App/Share/Data/DeepLinkingService/Parsers/Onboarding/OnboardingPathDeepLinkParser.swift
@@ -20,6 +20,8 @@ class OnboardingPathDeepLinkParser: DeepLinkUrlParserType {
             return nil
         }
         
-        return .onboarding
+        let appLanguageCode: AppLanguageCodeDomainModel = (queryParameters["appLanguageCode"] as? String) ?? LanguageCodeDomainModel.english.value
+        
+        return .onboarding(appLanguageCode: appLanguageCode)
     }
 }

--- a/godtools/App/Share/Domain/Entities/LanguageCodeDomainModel.swift
+++ b/godtools/App/Share/Domain/Entities/LanguageCodeDomainModel.swift
@@ -10,6 +10,7 @@ import Foundation
 
 enum LanguageCodeDomainModel: String {
     
+    case afrikaans = "af"
     case arabic = "ar"
     case chinese = "zh"
     case czech = "cs"
@@ -17,6 +18,7 @@ enum LanguageCodeDomainModel: String {
     case french = "fr"
     case hebrew = "he"
     case latvian = "lv"
+    case portuguese = "pt"
     case russian = "ru"
     case spanish = "es"
     case vietnamese = "vi"

--- a/godtools/App/Share/SwiftUI Views/FullScreenVideoView/FullScreenVideoView.swift
+++ b/godtools/App/Share/SwiftUI Views/FullScreenVideoView/FullScreenVideoView.swift
@@ -28,6 +28,8 @@ struct FullScreenVideoView: View {
     var body: some View {
         
         GeometryReader { geometry in
+                        
+            AccessibilityScreenElementView(screenAccessibility: screenAccessibility)
             
             VStack(alignment: .center, spacing: 0) {
                 
@@ -52,7 +54,6 @@ struct FullScreenVideoView: View {
         .onDisappear {
             videoPlayerState = .paused
         }
-        .accessibilityIdentifier(screenAccessibility.id)
         .statusBarHidden(true)
         .background(backgroundColor)
     }

--- a/godtools/App/Share/SwiftUI Views/GTBlueButton/GTBlueButton.swift
+++ b/godtools/App/Share/SwiftUI Views/GTBlueButton/GTBlueButton.swift
@@ -16,15 +16,17 @@ struct GTBlueButton: View {
     let height: CGFloat
     let cornerRadius: CGFloat
     let highlightsTitleOnTap: Bool
+    let accessibility: AccessibilityStrings.Button?
     let action: () -> Void
     
-    init(title: String, font: Font? = nil, fontSize: CGFloat? = nil, width: CGFloat, height: CGFloat, cornerRadius: CGFloat = 6, highlightsTitleOnTap: Bool = true, action: @escaping () -> Void) {
+    init(title: String, font: Font? = nil, fontSize: CGFloat? = nil, width: CGFloat, height: CGFloat, cornerRadius: CGFloat = 6, highlightsTitleOnTap: Bool = true, accessibility: AccessibilityStrings.Button? = nil, action: @escaping () -> Void) {
         
         self.title = title
         self.width = width
         self.height = height
         self.cornerRadius = cornerRadius
         self.highlightsTitleOnTap = highlightsTitleOnTap
+        self.accessibility = accessibility
         self.action = action
         
         if let font = font {
@@ -62,6 +64,7 @@ struct GTBlueButton: View {
                     }
                 }
             }
+            .accessibilityIdentifier(accessibility?.id ?? "")
             .frame(width: width, height: height, alignment: .center)
             .background(ColorPalette.gtBlue.color)
             .cornerRadius(cornerRadius)

--- a/godtoolsTests/App/Features/AppLanguage/Domain/UseCaseTests/GetInterfaceLayoutDirectionUseCaseTests.swift
+++ b/godtoolsTests/App/Features/AppLanguage/Domain/UseCaseTests/GetInterfaceLayoutDirectionUseCaseTests.swift
@@ -27,7 +27,9 @@ class GetInterfaceLayoutDirectionUseCaseTests: QuickSpec {
                 )
                 
                 let getAppLanguageRepository = GetAppLanguageRepository(
-                    appLanguagesRepository: AppLanguagesRepository()
+                    appLanguagesRepository: AppLanguagesRepository(
+                        cache: AppLanguagesCache()
+                    )
                 )
                 
                 let getUserPreferredAppLanguageRepository = TestsGetUserPreferredAppLanguageRepository(userAppLanguageCode: .arabic)
@@ -73,7 +75,9 @@ class GetInterfaceLayoutDirectionUseCaseTests: QuickSpec {
                 )
                 
                 let getAppLanguageRepository = GetAppLanguageRepository(
-                    appLanguagesRepository: AppLanguagesRepository()
+                    appLanguagesRepository: AppLanguagesRepository(
+                        cache: AppLanguagesCache()
+                    )
                 )
                 
                 let getUserPreferredAppLanguageRepository = TestsGetUserPreferredAppLanguageRepository(userAppLanguageCode: .arabic)

--- a/godtoolsTests/App/Share/Data/DeepLinkingService/DeepLinkingServiceTests.swift
+++ b/godtoolsTests/App/Share/Data/DeepLinkingService/DeepLinkingServiceTests.swift
@@ -362,6 +362,6 @@ class DeepLinkingServiceTests: XCTestCase {
         
         let parsedDeepLink: ParsedDeepLinkType? = deepLinkingService.parseDeepLink(incomingDeepLink: DeepLinkUrl.godtoolsCustomUrlSchemeOnboarding.incomingDeepLinkUrl)
         
-        XCTAssertTrue(parsedDeepLink == .onboarding)
+        XCTAssertTrue(parsedDeepLink == .onboarding(appLanguageCode: "en"))
     }
 }

--- a/godtoolsUITests/App/Flows/Onboarding/OnboardingFlowTests.swift
+++ b/godtoolsUITests/App/Flows/Onboarding/OnboardingFlowTests.swift
@@ -142,12 +142,12 @@ class OnboardingFlowTests: XCTestCase {
         assertIfScreenDoesNotExist(screenAccessibility: .onboardingQuickStart)
     }
     
-    func testSkippingOnboardingTutorialNavigatesToDashboardWhenQuickStartIsNotAvailable() {
+    func testSkippingOnboardingTutorialNavigatesToDashboardFavoritesWhenQuickStartIsNotAvailable() {
                       
         let appLanguages: [AppLanguageDataModel] = AppLanguagesCache().getAppLanguages()
         let supportedLanguages: [String] = OnboardingQuickStartSupportedLanguagesCache().getSupportedLanguages().map({ $0.value })
         
-        var unsupportedAppLanguage: AppLanguageCodeDomainModel?
+        var appLanguageNotAvailableForQuickStart: AppLanguageCodeDomainModel?
         
         for appLanguage in appLanguages {
          
@@ -155,18 +155,18 @@ class OnboardingFlowTests: XCTestCase {
             let isSupportedByQuickStart: Bool = supportedLanguages.contains(appLanguageCode)
             
             if !isSupportedByQuickStart {
-                unsupportedAppLanguage = appLanguageCode
+                appLanguageNotAvailableForQuickStart = appLanguageCode
                 break
             }
         }
         
-        guard let unsupportedAppLanguage = unsupportedAppLanguage else {
+        guard let appLanguageNotAvailableForQuickStart = appLanguageNotAvailableForQuickStart else {
             return
         }
         
         // NOTE: Language will have to be an available app language that is not supported by quick start. ~Levi
         
-        launchApp(appLanguageCode: unsupportedAppLanguage)
+        launchApp(appLanguageCode: appLanguageNotAvailableForQuickStart)
         
         let nextTutorialPageButton = getNextTutorialPageButton(app: app)
         

--- a/godtoolsUITests/App/Flows/Onboarding/OnboardingFlowTests.swift
+++ b/godtoolsUITests/App/Flows/Onboarding/OnboardingFlowTests.swift
@@ -34,11 +34,11 @@ class OnboardingFlowTests: XCTestCase {
         super.tearDown()
     }
     
-    private func launchApp(appLanguageCode: LanguageCodeDomainModel? = nil) {
+    private func launchApp(appLanguageCode: String? = nil) {
         
         self.app = XCUIApplication()
         
-        let languageCode: String = appLanguageCode?.value ?? LanguageCodeDomainModel.english.value
+        let languageCode: String = appLanguageCode ?? LanguageCodeDomainModel.english.value
         
         let deepLinkUrl: String = onboardingDeepLinkUrl + "?" + "appLanguageCode=" + languageCode
         
@@ -125,7 +125,7 @@ class OnboardingFlowTests: XCTestCase {
     
     func testSkippingOnboardingTutorialNavigatesToQuickStartWhenQuickStartIsAvailable() {
               
-        launchApp(appLanguageCode: .english)
+        launchApp(appLanguageCode: LanguageCodeDomainModel.english.value)
         
         let nextTutorialPageButton = getNextTutorialPageButton(app: app)
         
@@ -143,8 +143,30 @@ class OnboardingFlowTests: XCTestCase {
     }
     
     func testSkippingOnboardingTutorialNavigatesToDashboardWhenQuickStartIsNotAvailable() {
-              
-        launchApp(appLanguageCode: .portuguese) // NOTE: Language will have to be an available app language that is not supported by quick start. ~Levi
+                      
+        let appLanguages: [AppLanguageDataModel] = AppLanguagesCache().getAppLanguages()
+        let supportedLanguages: [String] = OnboardingQuickStartSupportedLanguagesCache().getSupportedLanguages().map({ $0.value })
+        
+        var unsupportedAppLanguage: AppLanguageCodeDomainModel?
+        
+        for appLanguage in appLanguages {
+         
+            let appLanguageCode: String = appLanguage.languageCode
+            let isSupportedByQuickStart: Bool = supportedLanguages.contains(appLanguageCode)
+            
+            if !isSupportedByQuickStart {
+                unsupportedAppLanguage = appLanguageCode
+                break
+            }
+        }
+        
+        guard let unsupportedAppLanguage = unsupportedAppLanguage else {
+            return
+        }
+        
+        // NOTE: Language will have to be an available app language that is not supported by quick start. ~Levi
+        
+        launchApp(appLanguageCode: unsupportedAppLanguage)
         
         let nextTutorialPageButton = getNextTutorialPageButton(app: app)
         

--- a/godtoolsUITests/Share/Extensions/XCUIApplication+Query.swift
+++ b/godtoolsUITests/Share/Extensions/XCUIApplication+Query.swift
@@ -11,9 +11,16 @@ import XCTest
 
 extension XCUIApplication {
     
-    func queryScreen(screenAccessibility: AccessibilityStrings.Screen) -> XCUIElement? {
+    func queryDescendants(id: String) -> XCUIElement? {
     
-        return descendants(matching: .any).matching(NSPredicate(format: "identifier == %@", screenAccessibility.id)).allElementsBoundByIndex.first
+        return descendants(matching: .any).matching(NSPredicate(format: "identifier == %@", id)).allElementsBoundByIndex.first
+    }
+    
+    func queryScreen(screenAccessibility: AccessibilityStrings.Screen) -> XCUIElement {
+    
+        // NOTE: See AccessibilityScreenElementView.swift ~Levi
+        
+        return staticTexts[screenAccessibility.id]
     }
     
     func queryButton(buttonAccessibility: AccessibilityStrings.Button) -> XCUIElement {


### PR DESCRIPTION
Adding some more navigation tests for the Onboarding Flow in the GodTools-UITests Scheme.  

Navigation tests include:

- Test skipping onboarding tutorial will go to the quick starts screen if quick start is supported by the selected app language.
- Testing skipping onboarding tutorial will go to dashboard favorites if quick start is not supported by the selected app language.
- Added a SwiftUI View AccessibilityScreenElementView.swift which must be placed inside of a View that makes up a screen.  I had some issues placing the accessibility identifier on the top level View that makes up a screen.

