### PR TITLE
GT-2215 provide number of tools available per language and per category

### DIFF
--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -623,6 +623,8 @@
 		4597101629CDE02400C47040 /* View+CornerRadius.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4597101529CDE02400C47040 /* View+CornerRadius.swift */; };
 		459A33FB29BFE46B00C49308 /* OnboardingQuickStartItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 459A33FA29BFE46B00C49308 /* OnboardingQuickStartItemView.swift */; };
 		459A668C289B0E3A00DACBF8 /* GetToolTranslationsFilesFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 459A668B289B0E3A00DACBF8 /* GetToolTranslationsFilesFilter.swift */; };
+		459ABF5D2B0B98850034499D /* ResourcesFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 459ABF5C2B0B98850034499D /* ResourcesFilter.swift */; };
+		459ABF612B0BB29D0034499D /* RealmResourcesCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 459ABF602B0BB29D0034499D /* RealmResourcesCacheTests.swift */; };
 		459B7E692ABA3A4A0088F44B /* LaunchEnvironmentKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45131A062AB498AD0085AF0D /* LaunchEnvironmentKey.swift */; };
 		459B7E6A2ABA3A510088F44B /* AccessibilityStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45131A0C2AB498AD0085AF0D /* AccessibilityStrings.swift */; };
 		459BD08A289AD4310075901B /* DetermineToolTranslationsToDownloadError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 459BD083289AD4310075901B /* DetermineToolTranslationsToDownloadError.swift */; };
@@ -1991,6 +1993,8 @@
 		4597101529CDE02400C47040 /* View+CornerRadius.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "View+CornerRadius.swift"; sourceTree = "<group>"; };
 		459A33FA29BFE46B00C49308 /* OnboardingQuickStartItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingQuickStartItemView.swift; sourceTree = "<group>"; };
 		459A668B289B0E3A00DACBF8 /* GetToolTranslationsFilesFilter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GetToolTranslationsFilesFilter.swift; sourceTree = "<group>"; };
+		459ABF5C2B0B98850034499D /* ResourcesFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourcesFilter.swift; sourceTree = "<group>"; };
+		459ABF602B0BB29D0034499D /* RealmResourcesCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealmResourcesCacheTests.swift; sourceTree = "<group>"; };
 		459BD083289AD4310075901B /* DetermineToolTranslationsToDownloadError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DetermineToolTranslationsToDownloadError.swift; sourceTree = "<group>"; };
 		459BD084289AD4310075901B /* DetermineDeepLinkedToolTranslationsToDownload.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DetermineDeepLinkedToolTranslationsToDownload.swift; sourceTree = "<group>"; };
 		459BD085289AD4310075901B /* DetermineToolTranslationsToDownloadType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DetermineToolTranslationsToDownloadType.swift; sourceTree = "<group>"; };
@@ -3908,6 +3912,7 @@
 				45368A092ABB2D840028A570 /* DeepLinkingService */,
 				45368A0B2ABB2D840028A570 /* LocalizationServices */,
 				45368A062ABB2D840028A570 /* RealmDatabase */,
+				459ABF5E2B0BB2910034499D /* ResourcesRepository */,
 			);
 			path = Data;
 			sourceTree = "<group>";
@@ -6124,6 +6129,22 @@
 			path = OnboardingQuickStartItem;
 			sourceTree = "<group>";
 		};
+		459ABF5E2B0BB2910034499D /* ResourcesRepository */ = {
+			isa = PBXGroup;
+			children = (
+				459ABF5F2B0BB2910034499D /* Cache */,
+			);
+			path = ResourcesRepository;
+			sourceTree = "<group>";
+		};
+		459ABF5F2B0BB2910034499D /* Cache */ = {
+			isa = PBXGroup;
+			children = (
+				459ABF602B0BB29D0034499D /* RealmResourcesCacheTests.swift */,
+			);
+			path = Cache;
+			sourceTree = "<group>";
+		};
 		459BD081289AD4310075901B /* GetToolTranslationsFilesUseCase */ = {
 			isa = PBXGroup;
 			children = (
@@ -8104,6 +8125,7 @@
 			isa = PBXGroup;
 			children = (
 				45D63E9C288F77D4009B4610 /* ResourcesRepository.swift */,
+				459ABF5C2B0B98850034499D /* ResourcesFilter.swift */,
 				45D63E93288F77D4009B4610 /* Api */,
 				45D63E8D288F77D4009B4610 /* Cache */,
 				45D63E91288F77D4009B4610 /* JsonFileCache */,
@@ -10932,6 +10954,7 @@
 				45E3476F2A49BE230014CCD1 /* Flow+PresentError.swift in Sources */,
 				45C152362A43D1BD00F2A1E8 /* ToolSettingsOptionItemTitleColorStyle.swift in Sources */,
 				451FB9382896B3DE00423865 /* GetLanguageUseCase.swift in Sources */,
+				459ABF5D2B0B98850034499D /* ResourcesFilter.swift in Sources */,
 				45A835232AD1AAEA004F5593 /* GetToolDetailsRepository.swift in Sources */,
 				45AD204E25938AC300A096A0 /* TrackActionAnalytics.swift in Sources */,
 				45B3F46E2AC3B61A00D61BFD /* AppInterfaceLayoutDirectionDomainModel.swift in Sources */,
@@ -11750,6 +11773,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				450AF5B72AD8216D00524A15 /* TestsGetAppLanguagesListRepository.swift in Sources */,
+				459ABF612B0BB29D0034499D /* RealmResourcesCacheTests.swift in Sources */,
 				45D7783029A572CC00F23D99 /* PassthroughValue.swift in Sources */,
 				455310CF2AE1D0FC00C0D3CB /* GetOnboardingQuickStartLinksUseCaseTests.swift in Sources */,
 				45368A1A2ABB2D850028A570 /* LocalizableStringsBundleLoaderTests.swift in Sources */,

--- a/godtools/App/Share/Data/LanguagesRepository/Cache/Models/RealmLanguage.swift
+++ b/godtools/App/Share/Data/LanguagesRepository/Cache/Models/RealmLanguage.swift
@@ -21,6 +21,10 @@ class RealmLanguage: Object, LanguageModelType {
         return "id"
     }
     
+    // Backlink to the resource. This is automatically updated whenever this language is added to or removed from a resource's languages list. ~Levi
+    // (https://www.mongodb.com/docs/realm/sdk/swift/model-data/relationships/)
+    let resource = LinkingObjects(fromType: RealmResource.self, property: "languages")
+    
     func mapFrom(model: LanguageModel) {
         
         code = model.code

--- a/godtools/App/Share/Data/ResourcesRepository/ResourcesFilter.swift
+++ b/godtools/App/Share/Data/ResourcesRepository/ResourcesFilter.swift
@@ -1,0 +1,23 @@
+//
+//  ResourcesFilter.swift
+//  godtools
+//
+//  Created by Levi Eggert on 11/20/23.
+//  Copyright © 2023 Cru. All rights reserved.
+//
+
+import Foundation
+
+struct ResourcesFilter {
+    
+    let category: String?
+    let languageCode: String?
+    let resourceTypes: [ResourceType]?
+    
+    init(category: String? = nil, languageCode: String? = nil, resourceTypes: [ResourceType]? = nil) {
+        
+        self.category = category
+        self.languageCode = languageCode
+        self.resourceTypes = resourceTypes
+    }
+}

--- a/godtools/App/Share/Data/ResourcesRepository/ResourcesRepository.swift
+++ b/godtools/App/Share/Data/ResourcesRepository/ResourcesRepository.swift
@@ -64,6 +64,11 @@ class ResourcesRepository {
         return cache.getSpotlightTools()
     }
     
+    func getCachedResourcesByFilter(filter: ResourcesFilter) -> [ResourceModel] {
+        
+        return cache.getResourcesByFilter(filter: filter)
+    }
+    
     func syncLanguagesAndResourcesPlusLatestTranslationsAndLatestAttachments() -> AnyPublisher<RealmResourcesCacheSyncResult, Error> {
         
         return syncLanguagesAndResourcesPlusLatestTranslationsAndLatestAttachmentsFromJsonFileIfNeeded()

--- a/godtoolsTests/App/Share/Data/ResourcesRepository/Cache/RealmResourcesCacheTests.swift
+++ b/godtoolsTests/App/Share/Data/ResourcesRepository/Cache/RealmResourcesCacheTests.swift
@@ -1,0 +1,204 @@
+//
+//  RealmResourcesCacheTests.swift
+//  godtoolsTests
+//
+//  Created by Levi Eggert on 11/20/23.
+//  Copyright © 2023 Cru. All rights reserved.
+//
+
+import XCTest
+@testable import godtools
+import RealmSwift
+import Combine
+
+class RealmResourcesCacheTests: XCTestCase {
+    
+    private enum Category: String {
+        case article = "article"
+        case gospel = "gospel"
+    }
+    
+    private enum LanguageCode: String {
+        case arabic = "ar"
+        case arabicBahrain = "ar-BH"
+        case english = "en"
+        case spanish = "es"
+    }
+    
+    private struct ResourceData {
+        let category: Category?
+        let languageCode: LanguageCode?
+        let resourceType: ResourceType
+    }
+
+    private let resourcesData: [ResourceData] = [
+        ResourceData(category: .article, languageCode: .arabic, resourceType: .tract),
+        ResourceData(category: .article, languageCode: .arabicBahrain, resourceType: .tract),
+        ResourceData(category: .article, languageCode: .arabicBahrain, resourceType: .tract),
+        ResourceData(category: .article, languageCode: .english, resourceType: .tract),
+        ResourceData(category: .article, languageCode: .english, resourceType: .tract),
+        ResourceData(category: .article, languageCode: .english, resourceType: .tract),
+        ResourceData(category: .gospel, languageCode: .arabic, resourceType: .tract),
+        ResourceData(category: nil, languageCode: .arabic, resourceType: .lesson),
+        ResourceData(category: .gospel, languageCode: .arabic, resourceType: .metaTool),
+        ResourceData(category: .gospel, languageCode: .arabic, resourceType: .chooseYourOwnAdventure),
+        ResourceData(category: .gospel, languageCode: .arabic, resourceType: .tract),
+        ResourceData(category: .gospel, languageCode: .arabic, resourceType: .tract),
+        ResourceData(category: .gospel, languageCode: .arabic, resourceType: .tract)
+    ]
+    
+    private let numberOfArticleCategories: Int = 2
+    private let numberOfGospelCategories: Int = 5
+    
+    private var realmResourcesCache: RealmResourcesCache?
+    
+    override func setUp() {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+        
+        if realmResourcesCache == nil {
+            
+            let realmDatabase = getNewTestDatabase()
+            
+            let realmResourcesCacheSync = RealmResourcesCacheSync(
+                realmDatabase: realmDatabase,
+                trackDownloadedTranslationsRepository: TrackDownloadedTranslationsRepository(
+                    cache: TrackDownloadedTranslationsCache(realmDatabase: realmDatabase)
+                )
+            )
+            
+            realmResourcesCache = RealmResourcesCache(
+                realmDatabase: realmDatabase,
+                resourcesSync: realmResourcesCacheSync
+            )
+        }
+    }
+
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+    
+    func testFilteringArticleResourcesByCategory() {
+        
+        let articles = realmResourcesCache?.getResourcesByFilter(filter: ResourcesFilter(category: RealmResourcesCacheTests.Category.article.rawValue, resourceTypes: [.tract])) ?? Array()
+        
+        XCTAssertEqual(articles.count, 6)
+    }
+    
+    func testFilteringArticleResourcesByCategoryAndLanguage() {
+        
+        let arabicArticles = realmResourcesCache?.getResourcesByFilter(
+            filter: ResourcesFilter(
+                category: RealmResourcesCacheTests.Category.article.rawValue,
+                languageCode: LanguageCode.arabic.rawValue,
+                resourceTypes: [.tract]
+            )
+        ) ?? Array()
+        
+        let arabicBahrainArticles = realmResourcesCache?.getResourcesByFilter(
+            filter: ResourcesFilter(
+                category: RealmResourcesCacheTests.Category.article.rawValue,
+                languageCode: LanguageCode.arabicBahrain.rawValue,
+                resourceTypes: [.tract]
+            )
+        ) ?? Array()
+        
+        let englishArticles = realmResourcesCache?.getResourcesByFilter(
+            filter: ResourcesFilter(
+                category: RealmResourcesCacheTests.Category.article.rawValue,
+                languageCode: LanguageCode.english.rawValue,
+                resourceTypes: [.tract]
+            )
+        ) ?? Array()
+        
+        XCTAssertEqual(arabicArticles.count, 1)
+        XCTAssertEqual(arabicBahrainArticles.count, 2)
+        XCTAssertEqual(englishArticles.count, 3)
+    }
+    
+    func testFilteringGospelResourcesByCategoryAndLanguageAndResourceType() {
+        
+        let gospelArabicTracts = realmResourcesCache?.getResourcesByFilter(
+            filter: ResourcesFilter(
+                category: RealmResourcesCacheTests.Category.gospel.rawValue,
+                languageCode: LanguageCode.arabic.rawValue,
+                resourceTypes: [.tract]
+            )
+        ) ?? Array()
+        
+        let gospelArabicMetaTools = realmResourcesCache?.getResourcesByFilter(
+            filter: ResourcesFilter(
+                category: RealmResourcesCacheTests.Category.gospel.rawValue,
+                languageCode: LanguageCode.arabic.rawValue,
+                resourceTypes: [.metaTool]
+            )
+        ) ?? Array()
+        
+        let gospelArabicCYOAs = realmResourcesCache?.getResourcesByFilter(
+            filter: ResourcesFilter(
+                category: RealmResourcesCacheTests.Category.gospel.rawValue,
+                languageCode: LanguageCode.arabic.rawValue,
+                resourceTypes: [.chooseYourOwnAdventure]
+            )
+        ) ?? Array()
+        
+        let allGospelArabicTools = realmResourcesCache?.getResourcesByFilter(
+            filter: ResourcesFilter(
+                category: RealmResourcesCacheTests.Category.gospel.rawValue,
+                languageCode: LanguageCode.arabic.rawValue,
+                resourceTypes: [.article, .chooseYourOwnAdventure, .tract]
+            )
+        ) ?? Array()
+        
+        XCTAssertEqual(gospelArabicTracts.count, 4)
+        XCTAssertEqual(gospelArabicMetaTools.count, 1)
+        XCTAssertEqual(gospelArabicCYOAs.count, 1)
+        XCTAssertEqual(allGospelArabicTools.count, 5)
+    }
+        
+    private func getNewTestDatabase() -> RealmDatabase {
+                
+        let config = RealmDatabaseConfiguration(cacheType: .inMemory(identifier: "RealmResourcesCacheTests"), schemaVersion: 1)
+        
+        let realmDatabase = RealmDatabase(databaseConfiguration: config)
+                
+        let realm = realmDatabase.openRealm()
+                
+        let realmResources = resourcesData.map({
+            self.mapToRealmResource(resourceData: $0)
+        })
+
+        do {
+            
+            try realm.write {
+                realm.add(realmResources, update: .all)
+            }
+        }
+        catch let error {
+            
+            assertionFailure(error.localizedDescription)
+        }
+        
+        return realmDatabase
+    }
+    
+    private func mapToRealmResource(resourceData: ResourceData) -> RealmResource {
+        
+        let resource = RealmResource()
+        
+        resource.attrCategory = resourceData.category?.rawValue ?? ""
+        resource.id = UUID().uuidString
+        resource.resourceType = resourceData.resourceType.rawValue
+        
+        let language = RealmLanguage()
+        language.id = UUID().uuidString
+        
+        if let languageCode = resourceData.languageCode?.rawValue {
+            
+            language.code = languageCode
+        }
+        
+        resource.languages.append(language)
+        
+        return resource
+    }
+}


### PR DESCRIPTION
This PR starts to add some filtering to RealmResourcesCache to filter RealmResources using NSPredicate.

Currently filtering will support category, languageCode, and resource type.

Was able to create an inverse relationship from RealmLanguage back to RealmResource by using LinkingObjects in RealmSwift. (https://www.mongodb.com/docs/realm/sdk/swift/model-data/relationships/#define-an-inverse-relationship-property)

