### PR TITLE
GT-2207 fix navigation bar button visibility toggle

### DIFF
--- a/godtools/App/Features/Dashboard/Presentation/Dashboard/DashboardView.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Dashboard/DashboardView.swift
@@ -77,8 +77,7 @@ struct DashboardView_Previews: PreviewProvider {
             startingTab: .favorites,
             flowDelegate: MockFlowDelegate(),
             dashboardPresentationLayerDependencies: DashboardPresentationLayerDependencies(appDiContainer: appDiContainer, flowDelegate: MockFlowDelegate()),
-            localizationServices: appDiContainer.dataLayer.getLocalizationServices(),
-            hidesLanguagesSettingsButton: CurrentValueSubject<Bool, Never>(false)
+            localizationServices: appDiContainer.dataLayer.getLocalizationServices()
         )
         
         return viewModel

--- a/godtools/App/Features/Dashboard/Presentation/Dashboard/DashboardViewModel.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Dashboard/DashboardViewModel.swift
@@ -13,11 +13,11 @@ class DashboardViewModel: ObservableObject {
     
     private let dashboardPresentationLayerDependencies: DashboardPresentationLayerDependencies
     private let localizationServices: LocalizationServices
-    private let hidesLanguagesSettingsButton: CurrentValueSubject<Bool, Never>
     private let tabs: [DashboardTabTypeDomainModel] = [.lessons, .favorites, .tools]
         
     private weak var flowDelegate: FlowDelegate?
         
+    @Published var hidesLanguagesSettingsButton: Bool = true
     @Published var numberOfTabs: Int = 0
     @Published var currentTab: Int {
         didSet {
@@ -25,13 +25,12 @@ class DashboardViewModel: ObservableObject {
         }
     }
     
-    init(startingTab: DashboardTabTypeDomainModel, flowDelegate: FlowDelegate, dashboardPresentationLayerDependencies: DashboardPresentationLayerDependencies, localizationServices: LocalizationServices, hidesLanguagesSettingsButton: CurrentValueSubject<Bool, Never>) {
+    init(startingTab: DashboardTabTypeDomainModel, flowDelegate: FlowDelegate, dashboardPresentationLayerDependencies: DashboardPresentationLayerDependencies, localizationServices: LocalizationServices) {
         
         self.currentTab = tabs.firstIndex(of: startingTab) ?? 0
         self.flowDelegate = flowDelegate
         self.dashboardPresentationLayerDependencies = dashboardPresentationLayerDependencies
         self.localizationServices = localizationServices
-        self.hidesLanguagesSettingsButton = hidesLanguagesSettingsButton
         
         numberOfTabs = tabs.count
                 
@@ -39,8 +38,8 @@ class DashboardViewModel: ObservableObject {
     }
     
     private func tabChanged() {
-                
-        hidesLanguagesSettingsButton.send(tabs[currentTab] == .lessons)
+                        
+        hidesLanguagesSettingsButton = tabs[currentTab] == .lessons
     }
     
     func getTab(tabIndex: Int) -> DashboardTabTypeDomainModel {

--- a/godtools/App/Features/LearnToShareTool/Presentation/LearnToShareTool/LearnToShareToolViewModel.swift
+++ b/godtools/App/Features/LearnToShareTool/Presentation/LearnToShareTool/LearnToShareToolViewModel.swift
@@ -14,13 +14,13 @@ class LearnToShareToolViewModel: ObservableObject {
     private let tool: ToolDomainModel
     private let getLearnToShareToolItemsUseCase: GetLearnToShareToolItemsUseCase
     private let localizationServices: LocalizationServices
-    private let hidesBackButtonSubject: CurrentValueSubject<Bool, Never> = CurrentValueSubject(true)
     
     private var learnToShareToolItems: [LearnToShareToolItemDomainModel] = Array()
     private var cancellables: Set<AnyCancellable> = Set()
     
     private weak var flowDelegate: FlowDelegate?
     
+    @Published var hidesBackButton: Bool = true
     @Published var numberOfLearnToShareToolItems: Int = 0
     @Published var continueTitle: String = ""
     @Published var currentPage: Int = 0 {
@@ -53,7 +53,7 @@ class LearnToShareToolViewModel: ObservableObject {
                 
         self.continueTitle = localizationServices.stringForSystemElseEnglish(key: localizedKey)
         
-        hidesBackButtonSubject.send(page == 0)
+        hidesBackButton = page == 0
     }
     
     private var isOnFirstPage: Bool {
@@ -69,11 +69,6 @@ class LearnToShareToolViewModel: ObservableObject {
         return currentPage >= numberOfLearnToShareToolItems - 1
     }
     
-    var hidesBackButtonPublisher: AnyPublisher<Bool, Never> {
-        return hidesBackButtonSubject
-            .eraseToAnyPublisher()
-    }
-
     func getLearnToShareToolItemViewModel(index: Int) -> LearnToShareToolItemViewModel {
         
         return LearnToShareToolItemViewModel(

--- a/godtools/App/Features/Onboarding/Presentation/OnboardingTutorial/OnboardingTutorialViewModel.swift
+++ b/godtools/App/Features/Onboarding/Presentation/OnboardingTutorial/OnboardingTutorialViewModel.swift
@@ -22,7 +22,6 @@ class OnboardingTutorialViewModel: ObservableObject {
     private let trackScreenViewAnalyticsUseCase: TrackScreenViewAnalyticsUseCase
     private let trackActionAnalyticsUseCase: TrackActionAnalyticsUseCase
     private let readyForEveryConversationYoutubeVideoId: String = "RvhZ_wuxAgE"
-    private let hidesSkipButtonSubject: CurrentValueSubject<Bool, Never> = CurrentValueSubject(true)
     private let showsChooseAppLanguageButtonOnPages: [Int] = [0]
     
     private var interfaceStrings: OnboardingTutorialInterfaceStringsDomainModel?
@@ -32,6 +31,7 @@ class OnboardingTutorialViewModel: ObservableObject {
     
     @Published private var appLanguage: AppLanguageDomainModel = ""
     
+    @Published var hidesSkipButton: Bool = true
     @Published var currentPage: Int = 0 {
         
         didSet {
@@ -119,11 +119,11 @@ class OnboardingTutorialViewModel: ObservableObject {
         switch page {
         
         case 0:
-            hidesSkipButtonSubject.send(true)
+            hidesSkipButton = true
             continueButtonTitle = interfaceStrings?.beginTutorialButtonTitle ?? ""
        
         default:
-            hidesSkipButtonSubject.send(false)
+            hidesSkipButton = false
             continueButtonTitle = interfaceStrings?.nextTutorialPageButtonTitle ?? ""
         }
         
@@ -136,11 +136,6 @@ class OnboardingTutorialViewModel: ObservableObject {
             contentLanguage: pageAnalytics.contentLanguage,
             contentLanguageSecondary: pageAnalytics.contentLanguageSecondary
         )
-    }
-    
-    var hidesSkipButtonPublisher: AnyPublisher<Bool, Never> {
-        return hidesSkipButtonSubject
-            .eraseToAnyPublisher()
     }
     
     func getOnboardingTutorialReadyForEveryConversationViewModel() -> OnboardingTutorialReadyForEveryConversationViewModel {

--- a/godtools/App/Features/Tutorial/Presentation/Tutorial/TutorialViewModel.swift
+++ b/godtools/App/Features/Tutorial/Presentation/Tutorial/TutorialViewModel.swift
@@ -16,7 +16,6 @@ class TutorialViewModel: ObservableObject {
     private let trackScreenViewAnalyticsUseCase: TrackScreenViewAnalyticsUseCase
     private let trackActionAnalyticsUseCase: TrackActionAnalyticsUseCase
     private let tutorialVideoAnalytics: TutorialVideoAnalytics
-    private let hidesBackButtonSubject: CurrentValueSubject<Bool, Never> = CurrentValueSubject(true)
     
     private var trackedAnalyticsForYouTubeVideoIds: [String] = Array()
     private var cancellables: Set<AnyCancellable> = Set()
@@ -26,6 +25,7 @@ class TutorialViewModel: ObservableObject {
     @Published private var appLanguage: AppLanguageDomainModel = LanguageCodeDomainModel.english.value
     @Published private var interfaceStrings: TutorialInterfaceStringsDomainModel?
     
+    @Published var hidesBackButton: Bool = true
     @Published var tutorialPages: [TutorialPageDomainModel] = Array()
     @Published var continueTitle: String = ""
     @Published var currentPage: Int = 0
@@ -101,7 +101,7 @@ class TutorialViewModel: ObservableObject {
     
     private func pageDidChange(page: Int) {
                 
-        hidesBackButtonSubject.send(isOnFirstPage)
+        hidesBackButton = isOnFirstPage
                                 
         let analyticsScreenName = getAnalyticsScreenName(tutorialItemIndex: page)
         let analyticsSiteSection = analyticsSiteSection
@@ -125,11 +125,6 @@ class TutorialViewModel: ObservableObject {
             url: nil,
             data: nil
         )
-    }
-    
-    var hidesBackButtonPublisher: AnyPublisher<Bool, Never> {
-        return hidesBackButtonSubject
-            .eraseToAnyPublisher()
     }
     
     private func refreshContinueTitle(interfaceStrings: TutorialInterfaceStringsDomainModel) {

--- a/godtools/App/Flows/App/AppFlow.swift
+++ b/godtools/App/Flows/App/AppFlow.swift
@@ -453,9 +453,7 @@ extension AppFlow {
     }
     
     private func getNewDashboardView(startingTab: DashboardTabTypeDomainModel?) -> UIViewController {
-        
-        let hidesLanguagesSettingsButton: CurrentValueSubject<Bool, Never> = CurrentValueSubject(true)
-        
+                
         let viewModel = DashboardViewModel(
             startingTab: startingTab ?? AppFlow.defaultStartingDashboardTab,
             flowDelegate: self,
@@ -463,8 +461,7 @@ extension AppFlow {
                 appDiContainer: appDiContainer,
                 flowDelegate: self
             ),
-            localizationServices: appDiContainer.dataLayer.getLocalizationServices(),
-            hidesLanguagesSettingsButton: hidesLanguagesSettingsButton
+            localizationServices: appDiContainer.dataLayer.getLocalizationServices()
         )
                 
         let view = DashboardView(viewModel: viewModel)
@@ -481,7 +478,7 @@ extension AppFlow {
             target: viewModel,
             action: #selector(viewModel.languageSettingsTapped),
             accessibilityIdentifier: nil,
-            toggleVisibilityPublisher: hidesLanguagesSettingsButton.eraseToAnyPublisher()
+            toggleVisibilityPublisher: viewModel.$hidesLanguagesSettingsButton.eraseToAnyPublisher()
         )
         
         let hostingController = AppHostingController<DashboardView>(

--- a/godtools/App/Flows/LearnToShareTool/LearnToShareToolFlow.swift
+++ b/godtools/App/Flows/LearnToShareTool/LearnToShareToolFlow.swift
@@ -70,7 +70,7 @@ class LearnToShareToolFlow: Flow {
             target: viewModel,
             action: #selector(viewModel.backTapped),
             accessibilityIdentifier: nil,
-            toggleVisibilityPublisher: viewModel.hidesBackButtonPublisher
+            toggleVisibilityPublisher: viewModel.$hidesBackButton.eraseToAnyPublisher()
         )
         
         let closeButton = AppCloseBarItem(

--- a/godtools/App/Flows/Onboarding/OnboardingFlow.swift
+++ b/godtools/App/Flows/Onboarding/OnboardingFlow.swift
@@ -167,7 +167,7 @@ extension OnboardingFlow {
             target: viewModel,
             action: #selector(viewModel.skipTapped),
             accessibilityIdentifier: AccessibilityStrings.Button.skipOnboardingTutorial.id,
-            toggleVisibilityPublisher: viewModel.hidesSkipButtonPublisher
+            toggleVisibilityPublisher: viewModel.$hidesSkipButton.eraseToAnyPublisher()
         )
         
         let hostingView = AppHostingController<OnboardingTutorialView>(

--- a/godtools/App/Flows/Tutorial/TutorialFlow.swift
+++ b/godtools/App/Flows/Tutorial/TutorialFlow.swift
@@ -81,7 +81,7 @@ extension TutorialFlow {
             target: viewModel,
             action: #selector(viewModel.backTapped),
             accessibilityIdentifier: nil,
-            toggleVisibilityPublisher: viewModel.hidesBackButtonPublisher
+            toggleVisibilityPublisher: viewModel.$hidesBackButton.eraseToAnyPublisher()
         )
         
         let closeButton = AppCloseBarItem(

--- a/godtools/App/Share/Views/Navigation/ViewControllers/AppHostingController.swift
+++ b/godtools/App/Share/Views/Navigation/ViewControllers/AppHostingController.swift
@@ -18,8 +18,6 @@ class AppHostingController<Content: View>: UIHostingController<Content> {
         self.navigationBar = navigationBar
         
         super.init(rootView: rootView)
-        
-        navigationBar?.configure(viewController: self)
     }
     
     @MainActor required dynamic init?(coder aDecoder: NSCoder) {
@@ -28,6 +26,8 @@ class AppHostingController<Content: View>: UIHostingController<Content> {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        
+        navigationBar?.configure(viewController: self)
         
         navigationBar?.willAppear(animated: animated)
     }

--- a/godtools/App/Share/Views/Navigation/ViewControllers/AppViewController.swift
+++ b/godtools/App/Share/Views/Navigation/ViewControllers/AppViewController.swift
@@ -17,8 +17,6 @@ class AppViewController: UIViewController {
         self.navigationBar = navigationBar
         
         super.init(nibName: nil, bundle: nil)
-        
-        navigationBar?.configure(viewController: self)
     }
     
     init(nibName: String?, bundle: Bundle?, navigationBar: AppNavigationBar?) {
@@ -36,6 +34,8 @@ class AppViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        
+        navigationBar?.configure(viewController: self)
         
         navigationBar?.willAppear(animated: animated)
     }


### PR DESCRIPTION
Changes in this PR:
- Fixed visibility toggle publisher by moving AppNavigationBar configure to UIViewController viewWillAppear().  There seemed to be some issue with accessing navigation item before viewWillAppear life cycle.
- Also removed some of the CurrentValueSubjects that were exposed on the ViewModel for toggling bar button item visibility and replaced with Published property wrappers.