### PR TITLE
GT Add method to track download translations from remote with progress

### DIFF
--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -456,6 +456,7 @@
 		455EE8442AEC59EB00C3205C /* DownloadToolProgressFeatureDataLayerDependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 455EE8432AEC59EB00C3205C /* DownloadToolProgressFeatureDataLayerDependencies.swift */; };
 		455EE8462AEC59F500C3205C /* DownloadToolProgressFeatureDomainLayerDependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 455EE8452AEC59F500C3205C /* DownloadToolProgressFeatureDomainLayerDependencies.swift */; };
 		455EE8492AEC5F6000C3205C /* ProgressTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 455EE8482AEC5F6000C3205C /* ProgressTimer.swift */; };
+		4560C9B92B30F42700C68984 /* TranslationsDownloadProgressDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4560C9B82B30F42700C68984 /* TranslationsDownloadProgressDataModel.swift */; };
 		4561AC94279C4C7D003718C0 /* MobileContentContentPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4561AC93279C4C7D003718C0 /* MobileContentContentPageView.swift */; };
 		4561AC96279C4C94003718C0 /* MobileContentContentPageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4561AC95279C4C93003718C0 /* MobileContentContentPageViewModel.swift */; };
 		4561AC9A279C4CC6003718C0 /* MobileContentCardCollectionPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4561AC99279C4CC6003718C0 /* MobileContentCardCollectionPageView.swift */; };
@@ -1903,6 +1904,7 @@
 		455EE8432AEC59EB00C3205C /* DownloadToolProgressFeatureDataLayerDependencies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadToolProgressFeatureDataLayerDependencies.swift; sourceTree = "<group>"; };
 		455EE8452AEC59F500C3205C /* DownloadToolProgressFeatureDomainLayerDependencies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadToolProgressFeatureDomainLayerDependencies.swift; sourceTree = "<group>"; };
 		455EE8482AEC5F6000C3205C /* ProgressTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressTimer.swift; sourceTree = "<group>"; };
+		4560C9B82B30F42700C68984 /* TranslationsDownloadProgressDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslationsDownloadProgressDataModel.swift; sourceTree = "<group>"; };
 		4561AC93279C4C7D003718C0 /* MobileContentContentPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileContentContentPageView.swift; sourceTree = "<group>"; };
 		4561AC95279C4C93003718C0 /* MobileContentContentPageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileContentContentPageViewModel.swift; sourceTree = "<group>"; };
 		4561AC99279C4CC6003718C0 /* MobileContentCardCollectionPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileContentCardCollectionPageView.swift; sourceTree = "<group>"; };
@@ -7746,6 +7748,7 @@
 				45B36524288504D40012BE53 /* TranslationsRepository.swift */,
 				459C527028941A5B00DA9E95 /* TranslationFilesDataModel.swift */,
 				459C526E289418EB00DA9E95 /* TranslationManifestFileDataModel.swift */,
+				4560C9B82B30F42700C68984 /* TranslationsDownloadProgressDataModel.swift */,
 				45B36525288504D40012BE53 /* Api */,
 				45B365292885054F0012BE53 /* Cache */,
 				45B3652E288595F50012BE53 /* ManifestParser */,
@@ -12176,6 +12179,7 @@
 				4567CE3F27CD0C6B00C3B543 /* MobileContentPageRenderer.swift in Sources */,
 				45F3790B2B23642C00EEF039 /* LearnToShareToolInterfaceStringsDomainModel.swift in Sources */,
 				451C848F2AF1C2A40003BF1A /* SocialSignInView.swift in Sources */,
+				4560C9B92B30F42700C68984 /* TranslationsDownloadProgressDataModel.swift in Sources */,
 				45B3F4392AC3A82E00D61BFD /* GetAppLanguagesListRepository.swift in Sources */,
 				45369ACB2AFA7FA500BD10F0 /* GetToolScreenShareTutorialRepositoryInterface.swift in Sources */,
 				45AD204D25938AC300A096A0 /* GoogleAdwordsAnalytics.swift in Sources */,

--- a/godtools/App/Share/Data/TranslationsRepository/TranslationsDownloadProgressDataModel.swift
+++ b/godtools/App/Share/Data/TranslationsRepository/TranslationsDownloadProgressDataModel.swift
@@ -1,0 +1,16 @@
+//
+//  TranslationsDownloadProgressDataModel.swift
+//  godtools
+//
+//  Created by Levi Eggert on 12/18/23.
+//  Copyright © 2023 Cru. All rights reserved.
+//
+
+import Foundation
+
+struct TranslationsDownloadProgressDataModel {
+    
+    let progress: Double
+    let numberOfTranslationsToDownload: Int
+    let currentNumberOfTranslationsDownloaded: Int
+}


### PR DESCRIPTION
This PR adds a way to track the download progress of translations by comparing how many translations have been downloaded against the total number of translations to download.  

Example method of downloading tool translations for a given language code with progress.

```swift
private func downloadToolTranslations(for languageCode: BCP47LanguageIdentifier) -> AnyPublisher<Double, Error> {
        
        let includeToolTypes: [ResourceType] = [.article, .tract, .lesson, .chooseYourOwnAdventure]
        
        let tools: [ResourceModel] = resourcesRepository.getCachedResourcesByFilter(filter: ResourcesFilter(category: nil, languageCode: languageCode, resourceTypes: includeToolTypes))
       
        let translations: [TranslationModel] = tools.compactMap {
            translationsRepository.getLatestTranslation(resourceId: $0.id, languageCode: languageCode)
        }
        
        guard !translations.isEmpty else {
            return Just(1).setFailureType(to: Error.self)
                .eraseToAnyPublisher()
        }
        
        return translationsRepository.getTranslationManifestsFromRemoteWithProgress(
            translations: translations,
            manifestParserType: .renderer,
            includeRelatedFiles: true,
            shouldFallbackToLatestDownloadedTranslationIfRemoteFails: true
        )
        .map {
            return $0.progress
        }
        .eraseToAnyPublisher()
    }
```