### PR TITLE
GT-2231 update tool options share tool modal for app language

### DIFF
--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -1051,6 +1051,11 @@
 		45C2AF4A2A81764D004958AB /* GTPageControlAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45C2AF492A81764D004958AB /* GTPageControlAttributes.swift */; };
 		45C321A72ACE7A89003B4F2C /* AppInterfaceStringNavBarItemController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45C321A62ACE7A89003B4F2C /* AppInterfaceStringNavBarItemController.swift */; };
 		45C5DDCE2AE6BF1300C70BBA /* AccessibilityScreenElementView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45C5DDCD2AE6BF1300C70BBA /* AccessibilityScreenElementView.swift */; };
+		45C649BC2B31E14D000249E0 /* ViewShareToolUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45C649BB2B31E14D000249E0 /* ViewShareToolUseCase.swift */; };
+		45C649BE2B31E178000249E0 /* ViewShareToolDomainModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45C649BD2B31E178000249E0 /* ViewShareToolDomainModel.swift */; };
+		45C649C02B31E1A9000249E0 /* ShareToolInterfaceStringsDomainModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45C649BF2B31E1A9000249E0 /* ShareToolInterfaceStringsDomainModel.swift */; };
+		45C649C22B31E212000249E0 /* GetShareToolInterfaceStringsRepositoryInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45C649C12B31E212000249E0 /* GetShareToolInterfaceStringsRepositoryInterface.swift */; };
+		45C649C42B31E246000249E0 /* GetShareToolInterfaceStringsRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45C649C32B31E246000249E0 /* GetShareToolInterfaceStringsRepository.swift */; };
 		45C883522A93DD5E00F33E6D /* DashboardPresentationLayerDependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45C883512A93DD5E00F33E6D /* DashboardPresentationLayerDependencies.swift */; };
 		45C8835D2A93EDDF00F33E6D /* DashboardTabBarItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45C8835C2A93EDDF00F33E6D /* DashboardTabBarItemView.swift */; };
 		45C8835F2A93EE9C00F33E6D /* DashboardTabBarItemViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45C8835E2A93EE9C00F33E6D /* DashboardTabBarItemViewModel.swift */; };
@@ -2482,6 +2487,11 @@
 		45C2AF492A81764D004958AB /* GTPageControlAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GTPageControlAttributes.swift; sourceTree = "<group>"; };
 		45C321A62ACE7A89003B4F2C /* AppInterfaceStringNavBarItemController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInterfaceStringNavBarItemController.swift; sourceTree = "<group>"; };
 		45C5DDCD2AE6BF1300C70BBA /* AccessibilityScreenElementView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityScreenElementView.swift; sourceTree = "<group>"; };
+		45C649BB2B31E14D000249E0 /* ViewShareToolUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewShareToolUseCase.swift; sourceTree = "<group>"; };
+		45C649BD2B31E178000249E0 /* ViewShareToolDomainModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewShareToolDomainModel.swift; sourceTree = "<group>"; };
+		45C649BF2B31E1A9000249E0 /* ShareToolInterfaceStringsDomainModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareToolInterfaceStringsDomainModel.swift; sourceTree = "<group>"; };
+		45C649C12B31E212000249E0 /* GetShareToolInterfaceStringsRepositoryInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetShareToolInterfaceStringsRepositoryInterface.swift; sourceTree = "<group>"; };
+		45C649C32B31E246000249E0 /* GetShareToolInterfaceStringsRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetShareToolInterfaceStringsRepository.swift; sourceTree = "<group>"; };
 		45C883512A93DD5E00F33E6D /* DashboardPresentationLayerDependencies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardPresentationLayerDependencies.swift; sourceTree = "<group>"; };
 		45C8835C2A93EDDF00F33E6D /* DashboardTabBarItemView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DashboardTabBarItemView.swift; sourceTree = "<group>"; };
 		45C8835E2A93EE9C00F33E6D /* DashboardTabBarItemViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardTabBarItemViewModel.swift; sourceTree = "<group>"; };
@@ -8118,6 +8128,7 @@
 				450B7FBE2B2B5121000B9035 /* GetToolSettingsPrimaryLanguageUseCase.swift */,
 				4512D4B82B28F1B300DFAFB3 /* SetToolSettingsParallelLanguageUseCase.swift */,
 				4512D4B62B28F17C00DFAFB3 /* SetToolSettingsPrimaryLanguageUseCase.swift */,
+				45C649BB2B31E14D000249E0 /* ViewShareToolUseCase.swift */,
 				4512D4C62B29125700DFAFB3 /* ViewToolSettingsToolLanguagesListUseCase.swift */,
 				45EA5AA22B2246AF00D9E330 /* ViewToolSettingsUseCase.swift */,
 			);
@@ -9322,6 +9333,7 @@
 			isa = PBXGroup;
 			children = (
 				450B7FB92B2B4A29000B9035 /* DeleteToolSettingsParallelLanguageRepositoryInterface.swift */,
+				45C649C12B31E212000249E0 /* GetShareToolInterfaceStringsRepositoryInterface.swift */,
 				45EA5AA62B22473700D9E330 /* GetToolSettingsInterfaceStringsRepositoryInterface.swift */,
 				453EFFFF2B29F15100029402 /* GetToolSettingsParallelLanguageRepositoryInterface.swift */,
 				453EFFFD2B29F13E00029402 /* GetToolSettingsPrimaryLanguageRepositoryInterface.swift */,
@@ -9336,10 +9348,12 @@
 		45EA5A9F2B22468A00D9E330 /* Entities */ = {
 			isa = PBXGroup;
 			children = (
+				45C649BF2B31E1A9000249E0 /* ShareToolInterfaceStringsDomainModel.swift */,
 				45EA5AA42B22471C00D9E330 /* ToolSettingsInterfaceStringsDomainModel.swift */,
 				4512D4CB2B29127200DFAFB3 /* ToolSettingsToolLanguageDomainModel.swift */,
 				4512D4CC2B29127200DFAFB3 /* ToolSettingsToolLanguagesListInterfaceStringsDomainModel.swift */,
 				450B7FC12B2B53A2000B9035 /* ToolSettingsToolLanguagesListTypeDomainModel.swift */,
+				45C649BD2B31E178000249E0 /* ViewShareToolDomainModel.swift */,
 				45EA5AA02B2246A800D9E330 /* ViewToolSettingsDomainModel.swift */,
 				4512D4CA2B29127200DFAFB3 /* ViewToolSettingsToolLanguagesListDomainModel.swift */,
 			);
@@ -9368,6 +9382,7 @@
 			isa = PBXGroup;
 			children = (
 				450B7FBB2B2B4A78000B9035 /* DeleteToolSettingsParallelLanguageRepository.swift */,
+				45C649C32B31E246000249E0 /* GetShareToolInterfaceStringsRepository.swift */,
 				45EA5AAB2B22476300D9E330 /* GetToolSettingsInterfaceStringsRepository.swift */,
 				453E00012B29F16D00029402 /* GetToolSettingsParallelLanguageRepository.swift */,
 				453E00032B29F18100029402 /* GetToolSettingsPrimaryLanguageRepository.swift */,
@@ -11184,6 +11199,7 @@
 				459E86DD28EDA86C00E197A5 /* DeepLinkUrlParserType.swift in Sources */,
 				459C56D225FF954F00F15967 /* (null) in Sources */,
 				45D63E86288F75B0009B4610 /* RealmAttachment.swift in Sources */,
+				45C649C22B31E212000249E0 /* GetShareToolInterfaceStringsRepositoryInterface.swift in Sources */,
 				45A8BDE32ACC9F47007A1EBB /* LessonsViewModel.swift in Sources */,
 				45EA5AAE2B22481700D9E330 /* ToolSettingsDiContainer.swift in Sources */,
 				45E39EC927457A14006A59E4 /* AnimatedView.swift in Sources */,
@@ -11652,6 +11668,7 @@
 				45DBE62B2ACDA6F8008A93BF /* GetFeaturedLessonsRepository.swift in Sources */,
 				45C152812A44888100F2A1E8 /* LessonEvaluationViewModel.swift in Sources */,
 				4534F92E2AE9A9F800A7A071 /* EvaluateLessonRepositoryInterface.swift in Sources */,
+				45C649BC2B31E14D000249E0 /* ViewShareToolUseCase.swift in Sources */,
 				45FB1CC1295F4184002BACD9 /* UISemanticContentAttribute+LanguageDirectionDomainModel.swift in Sources */,
 				457766EB2AD6FB360093B19A /* GetInterfaceStringForLanguageRepositoryInterface.swift in Sources */,
 				45369AC32AFA7FA500BD10F0 /* GetToolScreenShareTutorialRepository.swift in Sources */,
@@ -12151,10 +12168,12 @@
 				450D63AB2AC8A84600B90319 /* TrackExitLinkAnalyticsPropertiesDomainModel.swift in Sources */,
 				D4F1DE8D2967538A00A2F674 /* IncrementUserCounterUseCase.swift in Sources */,
 				453AC11228F4A10400291791 /* FailedFollowUpsCache.swift in Sources */,
+				45C649C42B31E246000249E0 /* GetShareToolInterfaceStringsRepository.swift in Sources */,
 				4595E0DB2A8523DC00D88DAE /* MobileContentApiUsersMeCodable.swift in Sources */,
 				45F305872A9BB6B100BDFB93 /* AppConfigInterface.swift in Sources */,
 				4581D98B297AE09900D056D6 /* RealmGlobalAnalytics.swift in Sources */,
 				45EB9B7F29F16CF200CA74A8 /* Collection+SafeLookup.swift in Sources */,
+				45C649BE2B31E178000249E0 /* ViewShareToolDomainModel.swift in Sources */,
 				4571020D2AB9E58200D1BFFC /* RequestOperationError+MobileContentApiError.swift in Sources */,
 				45AD1BC825938A4F00A096A0 /* UIViewController+AppNavBackButton.swift in Sources */,
 				455EE8302AEC576F00C3205C /* DownloadToolProgressView.swift in Sources */,
@@ -12180,6 +12199,7 @@
 				45C1523B2A43D1BD00F2A1E8 /* ToolSettingsView.swift in Sources */,
 				45F7164F290A12D70019B715 /* AccountViewModel.swift in Sources */,
 				457102012AB9DDDB00D1BFFC /* MobileContentApiErrorsCodable.swift in Sources */,
+				45C649C02B31E1A9000249E0 /* ShareToolInterfaceStringsDomainModel.swift in Sources */,
 				45558336269F2C7B00C3FF14 /* ToolPageCallToActionViewModel.swift in Sources */,
 				45369ACC2AFA7FA500BD10F0 /* IncrementNumberOfToolScreenShareTutorialViewsRepositoryInterface.swift in Sources */,
 				456BB02927C588E80087CCA4 /* MobileContentHeadingViewModelType.swift in Sources */,

--- a/godtools/App/Features/ToolSettings/Data-DomainInterface/GetShareToolInterfaceStringsRepository.swift
+++ b/godtools/App/Features/ToolSettings/Data-DomainInterface/GetShareToolInterfaceStringsRepository.swift
@@ -1,0 +1,43 @@
+//
+//  GetShareToolInterfaceStringsRepository.swift
+//  godtools
+//
+//  Created by Levi Eggert on 12/19/23.
+//  Copyright © 2023 Cru. All rights reserved.
+//
+
+import Foundation
+import Combine
+
+class GetShareToolInterfaceStringsRepository: GetShareToolInterfaceStringsRepositoryInterface {
+    
+    private let localizationServices: LocalizationServices
+    
+    init(localizationServices: LocalizationServices) {
+        
+        self.localizationServices = localizationServices
+    }
+    
+    // TODO: Eventually shouldn't depend on ResourceModel here.  Should be a domain model. ~Levi
+    func getStringsPublisher(resource: ResourceModel, language: LanguageDomainModel, pageNumber: Int, translateInLanguage: AppLanguageDomainModel) -> AnyPublisher<ShareToolInterfaceStringsDomainModel, Never> {
+        
+        var toolUrl: String = "https://knowgod.com/\(language.localeIdentifier)/\(resource.abbreviation)"
+
+        if pageNumber > 0 {
+            toolUrl = toolUrl.appending("/").appending("\(pageNumber)")
+        }
+        
+        toolUrl = toolUrl.replacingOccurrences(of: " ", with: "").appending("?icid=gtshare ")
+
+        let localizedShareToolMessage: String = localizationServices.stringForLocaleElseEnglish(localeIdentifier: translateInLanguage, key: "tract_share_message")
+        
+        let shareMessageWithToolUrl: String = String.localizedStringWithFormat(localizedShareToolMessage, toolUrl)
+        
+        let interfaceStrings = ShareToolInterfaceStringsDomainModel(
+            shareMessage: shareMessageWithToolUrl
+        )
+        
+        return Just(interfaceStrings)
+            .eraseToAnyPublisher()
+    }
+}

--- a/godtools/App/Features/ToolSettings/DependencyContainer/ToolSettingsDataLayerDependencies.swift
+++ b/godtools/App/Features/ToolSettings/DependencyContainer/ToolSettingsDataLayerDependencies.swift
@@ -35,6 +35,12 @@ class ToolSettingsDataLayerDependencies {
         )
     }
     
+    func getShareToolInterfaceStringsRepositoryInterface() -> GetShareToolInterfaceStringsRepositoryInterface {
+        return GetShareToolInterfaceStringsRepository(
+            localizationServices: coreDataLayer.getLocalizationServices()
+        )
+    }
+    
     func getToolSettingsInterfaceStringsRepositoryInterface() -> GetToolSettingsInterfaceStringsRepositoryInterface {
         return GetToolSettingsInterfaceStringsRepository(
             localizationServices: coreDataLayer.getLocalizationServices()

--- a/godtools/App/Features/ToolSettings/DependencyContainer/ToolSettingsDomainLayerDependencies.swift
+++ b/godtools/App/Features/ToolSettings/DependencyContainer/ToolSettingsDomainLayerDependencies.swift
@@ -47,6 +47,12 @@ class ToolSettingsDomainLayerDependencies {
         )
     }
     
+    func getViewShareToolUseCase() -> ViewShareToolUseCase {
+        return ViewShareToolUseCase(
+            getInterfaceStringsRepository: dataLayer.getShareToolInterfaceStringsRepositoryInterface()
+        )
+    }
+    
     func getViewToolSettingsToolLanguagesListUseCase() -> ViewToolSettingsToolLanguagesListUseCase {
         return ViewToolSettingsToolLanguagesListUseCase(
             getInterfaceStringsRepository: dataLayer.getToolSettingsToolLanguagesListInterfaceStringsRepositoryInterface(),

--- a/godtools/App/Features/ToolSettings/Domain/Entities/ShareToolInterfaceStringsDomainModel.swift
+++ b/godtools/App/Features/ToolSettings/Domain/Entities/ShareToolInterfaceStringsDomainModel.swift
@@ -1,0 +1,14 @@
+//
+//  ShareToolInterfaceStringsDomainModel.swift
+//  godtools
+//
+//  Created by Levi Eggert on 12/19/23.
+//  Copyright © 2023 Cru. All rights reserved.
+//
+
+import Foundation
+
+struct ShareToolInterfaceStringsDomainModel {
+    
+    let shareMessage: String
+}

--- a/godtools/App/Features/ToolSettings/Domain/Entities/ViewShareToolDomainModel.swift
+++ b/godtools/App/Features/ToolSettings/Domain/Entities/ViewShareToolDomainModel.swift
@@ -1,0 +1,14 @@
+//
+//  ViewShareToolDomainModel.swift
+//  godtools
+//
+//  Created by Levi Eggert on 12/19/23.
+//  Copyright © 2023 Cru. All rights reserved.
+//
+
+import Foundation
+
+struct ViewShareToolDomainModel {
+    
+    let interfaceStrings: ShareToolInterfaceStringsDomainModel
+}

--- a/godtools/App/Features/ToolSettings/Domain/Interfaces/GetShareToolInterfaceStringsRepositoryInterface.swift
+++ b/godtools/App/Features/ToolSettings/Domain/Interfaces/GetShareToolInterfaceStringsRepositoryInterface.swift
@@ -1,0 +1,15 @@
+//
+//  GetShareToolInterfaceStringsRepositoryInterface.swift
+//  godtools
+//
+//  Created by Levi Eggert on 12/19/23.
+//  Copyright © 2023 Cru. All rights reserved.
+//
+
+import Foundation
+import Combine
+
+protocol GetShareToolInterfaceStringsRepositoryInterface {
+    
+    func getStringsPublisher(resource: ResourceModel, language: LanguageDomainModel, pageNumber: Int, translateInLanguage: AppLanguageDomainModel) -> AnyPublisher<ShareToolInterfaceStringsDomainModel, Never>
+}

--- a/godtools/App/Features/ToolSettings/Domain/UseCases/ViewShareToolUseCase.swift
+++ b/godtools/App/Features/ToolSettings/Domain/UseCases/ViewShareToolUseCase.swift
@@ -1,0 +1,32 @@
+//
+//  ViewShareToolUseCase.swift
+//  godtools
+//
+//  Created by Levi Eggert on 12/19/23.
+//  Copyright © 2023 Cru. All rights reserved.
+//
+
+import Foundation
+import Combine
+
+class ViewShareToolUseCase {
+    
+    private let getInterfaceStringsRepository: GetShareToolInterfaceStringsRepositoryInterface
+    
+    init(getInterfaceStringsRepository: GetShareToolInterfaceStringsRepositoryInterface) {
+        
+        self.getInterfaceStringsRepository = getInterfaceStringsRepository
+    }
+    
+    func viewPublisher(resource: ResourceModel, language: LanguageDomainModel, pageNumber: Int, appLanguage: AppLanguageDomainModel) -> AnyPublisher<ViewShareToolDomainModel, Never> {
+        
+        return getInterfaceStringsRepository
+            .getStringsPublisher(resource: resource, language: language, pageNumber: pageNumber, translateInLanguage: appLanguage)
+            .map {
+                return ViewShareToolDomainModel(
+                    interfaceStrings: $0
+                )
+            }
+            .eraseToAnyPublisher()
+    }
+}

--- a/godtools/App/Features/ToolSettings/Presentation/ShareTool/ShareToolView.swift
+++ b/godtools/App/Features/ToolSettings/Presentation/ShareTool/ShareToolView.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class ShareToolView: NSObject {
+class ShareToolView {
     
     private let viewModel: ShareToolViewModel
     
@@ -22,9 +22,7 @@ class ShareToolView: NSObject {
             activityItems: [viewModel.shareMessage],
             applicationActivities: nil
         )
-        
-        super.init()
-        
+                
         viewModel.pageViewed()
     }
 }

--- a/godtools/App/Features/ToolSettings/Presentation/ShareTool/ShareToolViewModel.swift
+++ b/godtools/App/Features/ToolSettings/Presentation/ShareTool/ShareToolViewModel.swift
@@ -13,7 +13,6 @@ class ShareToolViewModel {
         
     private let resource: ResourceModel
     private let incrementUserCounterUseCase: IncrementUserCounterUseCase
-    private let localizationServices: LocalizationServices
     private let trackScreenViewAnalyticsUseCase: TrackScreenViewAnalyticsUseCase
     private let trackActionAnalyticsUseCase: TrackActionAnalyticsUseCase
     private let pageNumber: Int
@@ -22,26 +21,15 @@ class ShareToolViewModel {
     
     private var cancellables = Set<AnyCancellable>()
     
-    init(resource: ResourceModel, language: LanguageDomainModel, pageNumber: Int, incrementUserCounterUseCase: IncrementUserCounterUseCase, localizationServices: LocalizationServices, trackScreenViewAnalyticsUseCase: TrackScreenViewAnalyticsUseCase, trackActionAnalyticsUseCase: TrackActionAnalyticsUseCase) {
+    init(viewShareToolDomainModel: ViewShareToolDomainModel, resource: ResourceModel, pageNumber: Int, incrementUserCounterUseCase: IncrementUserCounterUseCase, trackScreenViewAnalyticsUseCase: TrackScreenViewAnalyticsUseCase, trackActionAnalyticsUseCase: TrackActionAnalyticsUseCase) {
                 
         self.resource = resource
         self.incrementUserCounterUseCase = incrementUserCounterUseCase
-        self.localizationServices = localizationServices
         self.trackScreenViewAnalyticsUseCase = trackScreenViewAnalyticsUseCase
         self.trackActionAnalyticsUseCase = trackActionAnalyticsUseCase
         self.pageNumber = pageNumber
-        
-        var shareUrlString: String = "https://knowgod.com/\(language.localeIdentifier)/\(resource.abbreviation)"
-
-        if pageNumber > 0 {
-            shareUrlString = shareUrlString.appending("/").appending("\(pageNumber)")
-        }
-        
-        shareUrlString = shareUrlString.replacingOccurrences(of: " ", with: "").appending("?icid=gtshare ")
-        
-        let localizedTractShareMessage: String = localizationServices.stringForSystemElseEnglish(key: "tract_share_message")
-        
-        shareMessage = String.localizedStringWithFormat(localizedTractShareMessage, shareUrlString)
+                
+        shareMessage = viewShareToolDomainModel.interfaceStrings.shareMessage
     }
     
     private var analyticsScreenName: String {


### PR DESCRIPTION
This PR translates the interface strings in Share Tool modal to the current app language.  I had to inject the ViewShareToolDomainModel since I can't have a publisher on the UIActivityViewController.  

![share-tool-modal](https://github.com/CruGlobal/godtools-swift/assets/59846460/905d692b-7e42-4026-ab8f-d4a3d5b3ace5)
