### PR TITLE
GT Deprecate and obsolete TextWithLinks

### DIFF
--- a/godtools/App/Share/SwiftUI Views/TextWithLinks/BackwardsCompatibleTextWithLinks.swift
+++ b/godtools/App/Share/SwiftUI Views/TextWithLinks/BackwardsCompatibleTextWithLinks.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 
+@available(iOS, obsoleted: 15.0, message: "When supporting iOS 15 and up use TextWithLinksView.swift")
 struct BackwardsCompatibleTextWithLinks: View {
     
     private let geometry: GeometryProxy

--- a/godtools/App/Share/SwiftUI Views/TextWithLinks/TextViewLinksCoordinator.swift
+++ b/godtools/App/Share/SwiftUI Views/TextWithLinks/TextViewLinksCoordinator.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 
+@available(iOS, obsoleted: 15.0, message: "When supporting iOS 15 and up use TextWithLinksView.swift")
 class TextViewLinksCoordinator: NSObject, UITextViewDelegate {
     
     private let textWithLinks: TextWithLinks

--- a/godtools/App/Share/SwiftUI Views/TextWithLinks/TextWithLinks.swift
+++ b/godtools/App/Share/SwiftUI Views/TextWithLinks/TextWithLinks.swift
@@ -9,6 +9,7 @@
 import UIKit
 import SwiftUI
 
+@available(iOS, deprecated: 14.0, obsoleted: 15.0, message: "For iOS 14 use BackwardsCompatibleTextWithLinks.swift and iOS 15 use TextWithLinksView.swift")
 struct TextWithLinks: UIViewRepresentable {
         
     private let text: String


### PR DESCRIPTION
This is pretty cool, you can mark something as ```obsoleted``` with iOS version.  This way when we move the minimum target to iOS 15 we will get an error here.