### PR TITLE
GT-2246 fix retain cycle in language settings

### DIFF
--- a/godtools/App/Features/AppLanguage/Presentation/LanguageSettings/LanguageSettingsViewModel.swift
+++ b/godtools/App/Features/AppLanguage/Presentation/LanguageSettings/LanguageSettingsViewModel.swift
@@ -64,6 +64,10 @@ class LanguageSettingsViewModel: ObservableObject {
             }
             .store(in: &cancellables)
     }
+    
+    deinit {
+        print("x deinit: \(type(of: self))")
+    }
 }
 
 // MARK: - Inputs

--- a/godtools/App/Features/AppLanguage/Presentation/LanguageSettings/LanguageSettingsViewModel.swift
+++ b/godtools/App/Features/AppLanguage/Presentation/LanguageSettings/LanguageSettingsViewModel.swift
@@ -44,7 +44,7 @@ class LanguageSettingsViewModel: ObservableObject {
         $appLanguage.eraseToAnyPublisher()
             .flatMap({ (appLanguage: AppLanguageDomainModel) -> AnyPublisher<ViewLanguageSettingsDomainModel, Never> in
                 
-                return self.viewLanguageSettingsUseCase
+                return viewLanguageSettingsUseCase
                     .viewPublisher(appLanguage: appLanguage)
                     .eraseToAnyPublisher()
             })

--- a/godtools/App/Flows/LanguageSettings/LanguageSettingsFlow.swift
+++ b/godtools/App/Flows/LanguageSettings/LanguageSettingsFlow.swift
@@ -28,6 +28,10 @@ class LanguageSettingsFlow: Flow, ChooseAppLanguageNavigationFlow {
         sharedNavigationController.pushViewController(getLanguageSettingsView(), animated: true)
     }
     
+    deinit {
+        print("x deinit: \(type(of: self))")
+    }
+    
     func navigate(step: FlowStep) {
         
         switch step {


### PR DESCRIPTION
Hey @rachaelblue found a retain cycle in LanguageSettingsViewModel.  It was a little tricky to spot, but inside of the flatMap I was capturing self which was leading to the retain cycle.  Since that UseCase is available in the scope of that flatMap (injected on init) I was able to just remove the ```self.``` capture.
I created another ticket to go through the rest of our ViewModels to make sure those aren't staying in memory.