### PR TITLE
GT Remove backgroundRealmPublisher

### DIFF
--- a/godtools/App/Share/Data/RealmDatabase/RealmDatabase.swift
+++ b/godtools/App/Share/Data/RealmDatabase/RealmDatabase.swift
@@ -45,16 +45,4 @@ class RealmDatabase {
             }
         }
     }
-    
-    func backgroundRealmPublisher() -> AnyPublisher<Realm, Never> {
-        
-        return Future() { promise in
-            
-            self.background { realm in
-                
-                promise(.success(realm))
-            }
-        }
-        .eraseToAnyPublisher()
-    }
 }


### PR DESCRIPTION
Removing the backgroundRealmPublisher on RealmDatabase.  I think this could lead to random crashes of Realm being accessed from incorrect threads when flatMapping on backgroundRealmPublisher.  
RealmDatabase has some extensions (read, write, delete) for working with publishers in the background.