### PR TITLE
GT-2259 Fix opening tool options when parallel language is selected selects primary language in the navigation bar

### DIFF
--- a/godtools/App/Flows/ChooseYourOwnAdventure/ChooseYourOwnAdventureFlow.swift
+++ b/godtools/App/Flows/ChooseYourOwnAdventure/ChooseYourOwnAdventureFlow.swift
@@ -119,6 +119,7 @@ extension ChooseYourOwnAdventureFlow {
             languageSelector = NavBarSelectorView(
                 selectorButtonTitles: viewModel.languageNames,
                 layoutDirection: viewModel.layoutDirection,
+                selectedIndex: viewModel.selectedLanguageIndex,
                 borderColor: controlColor,
                 selectedColor: controlColor,
                 deselectedColor: UIColor.clear,

--- a/godtools/App/Flows/Tract/TractFlow.swift
+++ b/godtools/App/Flows/Tract/TractFlow.swift
@@ -293,6 +293,7 @@ extension TractFlow {
         return NavBarSelectorView(
             selectorButtonTitles: viewModel.languageNames,
             layoutDirection: viewModel.layoutDirection,
+            selectedIndex: viewModel.selectedLanguageIndex,
             borderColor: controlColor,
             selectedColor: controlColor,
             deselectedColor: UIColor.clear,


### PR DESCRIPTION
This PR fixes a bug when viewing a tool with primary and parallel language.  The bug occurred when the parallel language was selected in the navigation bar and when tapping tool options it would then highlight the primary language in the navigation bar.  
This is because the language selection was getting rebuilt without highlighting the selectedIndex from the viewModel.  This fix includes that.