### PR TITLE
GT-2222 change tool primary to app language

### DIFF
--- a/godtools/App/Features/Dashboard/Presentation/ChooseYourOwnAdventure/ChooseYourOwnAdventureViewModel.swift
+++ b/godtools/App/Features/Dashboard/Presentation/ChooseYourOwnAdventure/ChooseYourOwnAdventureViewModel.swift
@@ -13,12 +13,10 @@ import Combine
 class ChooseYourOwnAdventureViewModel: MobileContentPagesViewModel {
         
     private let fontService: FontService
-    private let initialSelectedLanguageIndex: Int?
     
     @Published private var languages: [LanguageDomainModel] = Array()
     
     private var cancellables: Set<AnyCancellable> = Set()
-    private var didSetInitialSelectedLanguageIndex: Bool = false
     
     private weak var flowDelegate: FlowDelegate?
     
@@ -28,13 +26,11 @@ class ChooseYourOwnAdventureViewModel: MobileContentPagesViewModel {
     @Published var hidesHomeButton: Bool = false
     @Published var hidesBackButton: Bool = true
     @Published var languageNames: [String] = Array()
-    @Published var selectedLanguageIndex: Int = 0
         
     init(flowDelegate: FlowDelegate, renderer: MobileContentRenderer, initialPage: MobileContentPagesPage?, resourcesRepository: ResourcesRepository, translationsRepository: TranslationsRepository, mobileContentEventAnalytics: MobileContentRendererEventAnalyticsTracking, fontService: FontService, trainingTipsEnabled: Bool, incrementUserCounterUseCase: IncrementUserCounterUseCase, selectedLanguageIndex: Int?) {
         
         self.flowDelegate = flowDelegate
         self.fontService = fontService
-        self.initialSelectedLanguageIndex = selectedLanguageIndex
                         
         let primaryManifest: Manifest = renderer.pageRenderers[0].manifest
                      
@@ -48,34 +44,18 @@ class ChooseYourOwnAdventureViewModel: MobileContentPagesViewModel {
         
         languageFont = fontService.getFont(size: 14, weight: .regular)
         
-        super.init(renderer: renderer, initialPage: initialPage, resourcesRepository: resourcesRepository, translationsRepository: translationsRepository, mobileContentEventAnalytics: mobileContentEventAnalytics, initialPageRenderingType: .chooseYourOwnAdventure, trainingTipsEnabled: trainingTipsEnabled, incrementUserCounterUseCase: incrementUserCounterUseCase)
+        super.init(renderer: renderer, initialPage: initialPage, resourcesRepository: resourcesRepository, translationsRepository: translationsRepository, mobileContentEventAnalytics: mobileContentEventAnalytics, initialPageRenderingType: .chooseYourOwnAdventure, trainingTipsEnabled: trainingTipsEnabled, incrementUserCounterUseCase: incrementUserCounterUseCase, selectedLanguageIndex: selectedLanguageIndex)
         
         $languages.eraseToAnyPublisher()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] (languages: [LanguageDomainModel]) in
                 self?.languageNames = languages.map({$0.translatedName})
-                self?.setInitialSelectedLanguageIndexIfNeeded(languages: languages)
             }
             .store(in: &cancellables)
     }
     
     deinit {
         print("x deinit: \(type(of: self))")
-    }
-    
-    private func setInitialSelectedLanguageIndexIfNeeded(languages: [LanguageDomainModel]) {
-        
-        guard !didSetInitialSelectedLanguageIndex && !languages.isEmpty else {
-            return
-        }
-        
-        didSetInitialSelectedLanguageIndex = true
-        
-        guard let initialSelectedLanguageIndex = self.initialSelectedLanguageIndex, initialSelectedLanguageIndex >= 0 && initialSelectedLanguageIndex < languages.count else {
-            return
-        }
-        
-        languageTapped(index: initialSelectedLanguageIndex)
     }
     
     override func pageDidAppear(page: Int) {
@@ -97,7 +77,7 @@ class ChooseYourOwnAdventureViewModel: MobileContentPagesViewModel {
                 
         languages = renderer.pageRenderers.map({$0.language})
         
-        super.setRenderer(renderer: renderer, pageRendererIndex: selectedLanguageIndex, navigationEvent: navigationEvent)
+        super.setRenderer(renderer: renderer, pageRendererIndex: pageRendererIndex, navigationEvent: navigationEvent)
     }
 }
 
@@ -133,7 +113,5 @@ extension ChooseYourOwnAdventureViewModel {
         
         let pageRenderer: MobileContentPageRenderer = renderer.value.pageRenderers[index]
         setPageRenderer(pageRenderer: pageRenderer, navigationEvent: nil, pagePositions: nil)
-        
-        selectedLanguageIndex = index
     }
 }

--- a/godtools/App/Features/Dashboard/Presentation/Tool/ToolView.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Tool/ToolView.swift
@@ -108,7 +108,7 @@ extension ToolView: ToolPageViewDelegate {
 extension ToolView: ToolSettingsToolType {
     
     func setRenderer(renderer: MobileContentRenderer) {
-        viewModel.setRenderer(renderer: renderer, pageRendererIndex: viewModel.selectedLanguageIndex, navigationEvent: nil)
+        viewModel.setRenderer(renderer: renderer, pageRendererIndex: nil, navigationEvent: nil)
     }
     
     func setTrainingTipsEnabled(enabled: Bool) {

--- a/godtools/App/Features/Dashboard/Presentation/Tool/ToolView.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Tool/ToolView.swift
@@ -108,7 +108,7 @@ extension ToolView: ToolPageViewDelegate {
 extension ToolView: ToolSettingsToolType {
     
     func setRenderer(renderer: MobileContentRenderer) {
-        viewModel.setRenderer(renderer: renderer, pageRendererIndex: nil, navigationEvent: nil)
+        viewModel.setRenderer(renderer: renderer, pageRendererIndex: viewModel.selectedLanguageIndex, navigationEvent: nil)
     }
     
     func setTrainingTipsEnabled(enabled: Bool) {

--- a/godtools/App/Features/LearnToShareTool/Presentation/LearnToShareTool/LearnToShareToolViewModel.swift
+++ b/godtools/App/Features/LearnToShareTool/Presentation/LearnToShareTool/LearnToShareToolViewModel.swift
@@ -14,6 +14,7 @@ class LearnToShareToolViewModel: ObservableObject {
     private let tool: ToolDomainModel
     private let toolPrimaryLanguage: AppLanguageDomainModel
     private let toolParallelLanguage: AppLanguageDomainModel?
+    private let toolSelectedLanguageIndex: Int?
     private let getCurrentAppLanguageUseCase: GetCurrentAppLanguageUseCase
     private let viewLearnToShareToolUseCase: ViewLearnToShareToolUseCase
     
@@ -29,12 +30,13 @@ class LearnToShareToolViewModel: ObservableObject {
     @Published var continueTitle: String = ""
     @Published var currentPage: Int = 0
     
-    init(flowDelegate: FlowDelegate, tool: ToolDomainModel, toolPrimaryLanguage: AppLanguageDomainModel, toolParallelLanguage: AppLanguageDomainModel?, getCurrentAppLanguageUseCase: GetCurrentAppLanguageUseCase, viewLearnToShareToolUseCase: ViewLearnToShareToolUseCase) {
+    init(flowDelegate: FlowDelegate, tool: ToolDomainModel, toolPrimaryLanguage: AppLanguageDomainModel, toolParallelLanguage: AppLanguageDomainModel?, toolSelectedLanguageIndex: Int?, getCurrentAppLanguageUseCase: GetCurrentAppLanguageUseCase, viewLearnToShareToolUseCase: ViewLearnToShareToolUseCase) {
         
         self.flowDelegate = flowDelegate
         self.tool = tool
         self.toolPrimaryLanguage = toolPrimaryLanguage
         self.toolParallelLanguage = toolParallelLanguage
+        self.toolSelectedLanguageIndex = toolSelectedLanguageIndex
         self.getCurrentAppLanguageUseCase = getCurrentAppLanguageUseCase
         self.viewLearnToShareToolUseCase = viewLearnToShareToolUseCase
               
@@ -123,13 +125,13 @@ extension LearnToShareToolViewModel {
     }
     
     @objc func closeTapped() {
-        flowDelegate?.navigate(step: .closeTappedFromLearnToShareTool(tool: tool, primaryLanguage: toolPrimaryLanguage, parallelLanguage: toolParallelLanguage))
+        flowDelegate?.navigate(step: .closeTappedFromLearnToShareTool(tool: tool, primaryLanguage: toolPrimaryLanguage, parallelLanguage: toolParallelLanguage, selectedLanguageIndex: toolSelectedLanguageIndex))
     }
     
     func continueTapped() {
         
         if isOnLastPage {
-            flowDelegate?.navigate(step: .continueTappedFromLearnToShareTool(tool: tool, primaryLanguage: toolPrimaryLanguage, parallelLanguage: toolParallelLanguage))
+            flowDelegate?.navigate(step: .continueTappedFromLearnToShareTool(tool: tool, primaryLanguage: toolPrimaryLanguage, parallelLanguage: toolParallelLanguage, selectedLanguageIndex: toolSelectedLanguageIndex))
         }
         else {
             currentPage = currentPage + 1

--- a/godtools/App/Features/Lessons/Presentation/Lesson/LessonViewModel.swift
+++ b/godtools/App/Features/Lessons/Presentation/Lesson/LessonViewModel.swift
@@ -18,7 +18,7 @@ class LessonViewModel: MobileContentPagesViewModel {
                 
         self.flowDelegate = flowDelegate
         
-        super.init(renderer: renderer,initialPage: initialPage, resourcesRepository: resourcesRepository, translationsRepository: translationsRepository, mobileContentEventAnalytics: mobileContentEventAnalytics, initialPageRenderingType: .visiblePages, trainingTipsEnabled: trainingTipsEnabled, incrementUserCounterUseCase: incrementUserCounterUseCase)
+        super.init(renderer: renderer,initialPage: initialPage, resourcesRepository: resourcesRepository, translationsRepository: translationsRepository, mobileContentEventAnalytics: mobileContentEventAnalytics, initialPageRenderingType: .visiblePages, trainingTipsEnabled: trainingTipsEnabled, incrementUserCounterUseCase: incrementUserCounterUseCase, selectedLanguageIndex: nil)
     }
     
     deinit {

--- a/godtools/App/Features/ToolDetails/Presentation/ToolDetails/ToolDetailsView.swift
+++ b/godtools/App/Features/ToolDetails/Presentation/ToolDetails/ToolDetailsView.swift
@@ -112,7 +112,9 @@ struct ToolDetailsView_Preview: PreviewProvider {
         let viewModel = ToolDetailsViewModel(
             flowDelegate: MockFlowDelegate(),
             tool: tool,
-            primaryLanguage: nil,
+            primaryLanguage: LanguageCodeDomainModel.english.rawValue,
+            parallelLanguage: nil,
+            selectedLanguageIndex: nil,
             getCurrentAppLanguageUseCase: appDiContainer.feature.appLanguage.domainLayer.getCurrentAppLanguageUseCase(),
             getToolUseCase: appDiContainer.domainLayer.getToolUseCase(),
             viewToolDetailsUseCase: appDiContainer.feature.toolDetails.domainLayer.getViewToolDetailsUseCase(),

--- a/godtools/App/Features/ToolDetails/Presentation/ToolDetails/ToolDetailsViewModel.swift
+++ b/godtools/App/Features/ToolDetails/Presentation/ToolDetails/ToolDetailsViewModel.swift
@@ -23,6 +23,7 @@ class ToolDetailsViewModel: ObservableObject {
     private let attachmentsRepository: AttachmentsRepository
     private let trackScreenViewAnalyticsUseCase: TrackScreenViewAnalyticsUseCase
     private let trackActionAnalyticsUseCase: TrackActionAnalyticsUseCase
+    private let selectedLanguageIndex: Int?
     
     private var segmentTypes: [ToolDetailsSegmentType] = Array()
     private var cancellables: Set<AnyCancellable> = Set()
@@ -61,10 +62,13 @@ class ToolDetailsViewModel: ObservableObject {
     @Published var toolVersions: [ToolVersionDomainModel] = Array()
     @Published var selectedToolVersion: ToolVersionDomainModel?
     
-    init(flowDelegate: FlowDelegate, tool: ToolDomainModel, primaryLanguage: AppLanguageDomainModel?, getCurrentAppLanguageUseCase: GetCurrentAppLanguageUseCase, getToolUseCase: GetToolUseCase, viewToolDetailsUseCase: ViewToolDetailsUseCase, getToolDetailsMediaUseCase: GetToolDetailsMediaUseCase, getToolDetailsLearnToShareToolIsAvailableUseCase: GetToolDetailsLearnToShareToolIsAvailableUseCase, toggleToolFavoritedUseCase: ToggleToolFavoritedUseCase, attachmentsRepository: AttachmentsRepository, trackScreenViewAnalyticsUseCase: TrackScreenViewAnalyticsUseCase, trackActionAnalyticsUseCase: TrackActionAnalyticsUseCase) {
+    init(flowDelegate: FlowDelegate, tool: ToolDomainModel, primaryLanguage: AppLanguageDomainModel, parallelLanguage: AppLanguageDomainModel?, selectedLanguageIndex: Int?, getCurrentAppLanguageUseCase: GetCurrentAppLanguageUseCase, getToolUseCase: GetToolUseCase, viewToolDetailsUseCase: ViewToolDetailsUseCase, getToolDetailsMediaUseCase: GetToolDetailsMediaUseCase, getToolDetailsLearnToShareToolIsAvailableUseCase: GetToolDetailsLearnToShareToolIsAvailableUseCase, toggleToolFavoritedUseCase: ToggleToolFavoritedUseCase, attachmentsRepository: AttachmentsRepository, trackScreenViewAnalyticsUseCase: TrackScreenViewAnalyticsUseCase, trackActionAnalyticsUseCase: TrackActionAnalyticsUseCase) {
         
         self.flowDelegate = flowDelegate
         self.tool = tool
+        self.primaryLanguage = primaryLanguage
+        self.parallelLanguage = parallelLanguage
+        self.selectedLanguageIndex = selectedLanguageIndex
         self.getCurrentAppLanguageUseCase = getCurrentAppLanguageUseCase
         self.getToolUseCase = getToolUseCase
         self.viewToolDetailsUseCase = viewToolDetailsUseCase
@@ -74,27 +78,6 @@ class ToolDetailsViewModel: ObservableObject {
         self.attachmentsRepository = attachmentsRepository
         self.trackScreenViewAnalyticsUseCase = trackScreenViewAnalyticsUseCase
         self.trackActionAnalyticsUseCase = trackActionAnalyticsUseCase
-        
-        getCurrentAppLanguageUseCase
-            .getLanguagePublisher()
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] appLanguage in
-                
-                if let primaryLanguage = primaryLanguage {
-                    
-                    self?.primaryLanguage = primaryLanguage
-                    
-                    if primaryLanguage != appLanguage {
-                        self?.parallelLanguage = appLanguage
-                    }
-                }
-                else {
-                    
-                    self?.primaryLanguage = appLanguage
-                    self?.parallelLanguage = nil
-                }
-            }
-            .store(in: &cancellables)
         
         Publishers.CombineLatest($tool.eraseToAnyPublisher(), $primaryLanguage.eraseToAnyPublisher())
             .receive(on: DispatchQueue.main)
@@ -232,12 +215,12 @@ extension ToolDetailsViewModel {
             ]
         )
         
-        flowDelegate?.navigate(step: .openToolTappedFromToolDetails(tool: tool, primaryLanguage: primaryLanguage, parallelLanguage: parallelLanguage))
+        flowDelegate?.navigate(step: .openToolTappedFromToolDetails(tool: tool, primaryLanguage: primaryLanguage, parallelLanguage: parallelLanguage, selectedLanguageIndex: selectedLanguageIndex))
     }
     
     func learnToShareToolTapped() {
         
-        flowDelegate?.navigate(step: .learnToShareToolTappedFromToolDetails(tool: tool, primaryLanguage: primaryLanguage, parallelLanguage: parallelLanguage))
+        flowDelegate?.navigate(step: .learnToShareToolTappedFromToolDetails(tool: tool, primaryLanguage: primaryLanguage, parallelLanguage: parallelLanguage, selectedLanguageIndex: selectedLanguageIndex))
     }
     
     func toggleFavorited() {

--- a/godtools/App/Flows/App/AppFlow.swift
+++ b/godtools/App/Flows/App/AppFlow.swift
@@ -169,13 +169,27 @@ class AppFlow: NSObject, ToolNavigationFlow, Flow {
             navigationController.popViewController(animated: true)
             
         case .spotlightToolTappedFromTools(let spotlightTool, let toolFilterLanguage):
-            navigationController.pushViewController(getToolDetails(tool: spotlightTool, toolLanguage: toolFilterLanguage?.language?.localeIdentifier), animated: true)
+            
+            let toolDetails = getToolDetails(
+                tool: spotlightTool,
+                toolLanguage: toolFilterLanguage?.language?.localeIdentifier,
+                selectedLanguageIndex: 1
+            )
+            
+            navigationController.pushViewController(toolDetails, animated: true)
                         
         case .toolTappedFromTools(let tool, let toolFilterLanguage):
-            navigationController.pushViewController(getToolDetails(tool: tool, toolLanguage: toolFilterLanguage?.language?.localeIdentifier), animated: true)
+            
+            let toolDetails = getToolDetails(
+                tool: tool,
+                toolLanguage: toolFilterLanguage?.language?.localeIdentifier,
+                selectedLanguageIndex: 1
+            )
+            
+            navigationController.pushViewController(toolDetails, animated: true)
                                     
-        case .openToolTappedFromToolDetails(let tool, let primaryLanguage, let parallelLanguage):
-            navigateToTool(toolDataModelId: tool.dataModelId, primaryLanguage: primaryLanguage, parallelLanguage: parallelLanguage, trainingTipsEnabled: false)
+        case .openToolTappedFromToolDetails(let tool, let primaryLanguage, let parallelLanguage, let selectedLanguageIndex):
+            navigateToTool(toolDataModelId: tool.dataModelId, primaryLanguage: primaryLanguage, parallelLanguage: parallelLanguage, selectedLanguageIndex: selectedLanguageIndex, trainingTipsEnabled: false)
             
         case .lessonTappedFromLessonsList(let lessonListItem):
             navigateToToolInAppLanguage(toolDataModelId: lessonListItem.dataModelId, trainingTipsEnabled: false)
@@ -187,7 +201,14 @@ class AppFlow: NSObject, ToolNavigationFlow, Flow {
             navigationController.pushViewController(getAllFavoriteTools(), animated: true)
             
         case .toolDetailsTappedFromFavorites(let tool):
-            navigationController.pushViewController(getToolDetails(tool: tool, toolLanguage: nil), animated: true)
+            
+            let toolDetails = getToolDetails(
+                tool: tool,
+                toolLanguage: nil,
+                selectedLanguageIndex: nil
+            )
+            
+            navigationController.pushViewController(toolDetails, animated: true)
         
         case .openToolTappedFromFavorites(let tool):
             navigateToToolInAppLanguage(toolDataModelId: tool.dataModelId, trainingTipsEnabled: false)
@@ -205,7 +226,14 @@ class AppFlow: NSObject, ToolNavigationFlow, Flow {
             navigationController.popViewController(animated: true)
             
         case .toolDetailsTappedFromAllYourFavoriteTools(let tool):
-            navigationController.pushViewController(getToolDetails(tool: tool, toolLanguage: nil), animated: true)
+            
+            let toolDetails = getToolDetails(
+                tool: tool,
+                toolLanguage: nil,
+                selectedLanguageIndex: nil
+            )
+            
+            navigationController.pushViewController(toolDetails, animated: true)
         
         case .openToolTappedFromAllYourFavoriteTools(let tool):
             navigateToToolInAppLanguage(toolDataModelId: tool.dataModelId, trainingTipsEnabled: false)
@@ -348,17 +376,17 @@ class AppFlow: NSObject, ToolNavigationFlow, Flow {
                 UIApplication.shared.open(url)
             }
             
-        case .learnToShareToolTappedFromToolDetails(let tool, let primaryLanguage, let parallelLanguage):
-            navigateToLearnToShareTool(tool: tool, primaryLanguage: primaryLanguage, parallelLanguage: parallelLanguage)
+        case .learnToShareToolTappedFromToolDetails(let tool, let primaryLanguage, let parallelLanguage, let selectedLanguageIndex):
+            navigateToLearnToShareTool(tool: tool, primaryLanguage: primaryLanguage, parallelLanguage: parallelLanguage, selectedLanguageIndex: selectedLanguageIndex)
             
-        case .continueTappedFromLearnToShareTool(let tool, let primaryLanguage, let parallelLanguage):
+        case .continueTappedFromLearnToShareTool(let tool, let primaryLanguage, let parallelLanguage, let selectedLanguageIndex):
             dismissLearnToShareToolFlow {
-                self.navigateToTool(toolDataModelId: tool.dataModelId, primaryLanguage: primaryLanguage, parallelLanguage: parallelLanguage, trainingTipsEnabled: true)
+                self.navigateToTool(toolDataModelId: tool.dataModelId, primaryLanguage: primaryLanguage, parallelLanguage: parallelLanguage, selectedLanguageIndex: selectedLanguageIndex, trainingTipsEnabled: true)
             }
             
-        case .closeTappedFromLearnToShareTool(let tool, let primaryLanguage, let parallelLanguage):
+        case .closeTappedFromLearnToShareTool(let tool, let primaryLanguage, let parallelLanguage, let selectedLanguageIndex):
             dismissLearnToShareToolFlow {
-                self.navigateToTool(toolDataModelId: tool.dataModelId, primaryLanguage: primaryLanguage, parallelLanguage: parallelLanguage, trainingTipsEnabled: true)
+                self.navigateToTool(toolDataModelId: tool.dataModelId, primaryLanguage: primaryLanguage, parallelLanguage: parallelLanguage, selectedLanguageIndex: selectedLanguageIndex, trainingTipsEnabled: true)
             }
             
         case .closeTappedFromLessonEvaluation:
@@ -628,7 +656,7 @@ extension AppFlow {
                
             navigateToDashboard(startingTab: .favorites, animatePopToToolsMenu: false, animateDismissingPresentedView: false, didCompleteDismissingPresentedView: nil)
                         
-            navigateToToolFromToolDeepLink(toolDeepLink: toolDeepLink, didCompleteToolNavigation: nil)
+            navigateToToolFromToolDeepLink(toolDeepLink: toolDeepLink, selectedLanguageIndex: nil, didCompleteToolNavigation: nil)
             
         case .articleAemUri(let aemUri):
             
@@ -675,7 +703,7 @@ extension AppFlow {
 
 extension AppFlow {
     
-    private func navigateToToolInAppLanguage(toolDataModelId: String, parallelLanguageId: String? = nil, trainingTipsEnabled: Bool) {
+    private func navigateToToolInAppLanguage(toolDataModelId: String, trainingTipsEnabled: Bool) {
         
         let languagesRepository: LanguagesRepository = appDiContainer.dataLayer.getLanguagesRepository()
         
@@ -685,14 +713,10 @@ extension AppFlow {
             languageIds.append(appLanguageModel.id)
         }
         
-        if let parallelLanguageId = parallelLanguageId {
-            languageIds.append(parallelLanguageId)
-        }
-        
-        navigateToTool(toolDataModelId: toolDataModelId, languageIds: languageIds, trainingTipsEnabled: trainingTipsEnabled)
+        navigateToTool(toolDataModelId: toolDataModelId, languageIds: languageIds, selectedLanguageIndex: nil, trainingTipsEnabled: trainingTipsEnabled)
     }
     
-    private func navigateToTool(toolDataModelId: String, primaryLanguage: AppLanguageDomainModel, parallelLanguage: AppLanguageDomainModel? = nil, trainingTipsEnabled: Bool) {
+    private func navigateToTool(toolDataModelId: String, primaryLanguage: AppLanguageDomainModel, parallelLanguage: AppLanguageDomainModel?, selectedLanguageIndex: Int?, trainingTipsEnabled: Bool) {
         
         let languagesRepository: LanguagesRepository = appDiContainer.dataLayer.getLanguagesRepository()
         
@@ -706,10 +730,10 @@ extension AppFlow {
             languageIds.append(languageModel.id)
         }
         
-        navigateToTool(toolDataModelId: toolDataModelId, languageIds: languageIds, trainingTipsEnabled: trainingTipsEnabled)
+        navigateToTool(toolDataModelId: toolDataModelId, languageIds: languageIds, selectedLanguageIndex: selectedLanguageIndex, trainingTipsEnabled: trainingTipsEnabled)
     }
         
-    private func navigateToTool(toolDataModelId: String, languageIds: [String], trainingTipsEnabled: Bool) {
+    private func navigateToTool(toolDataModelId: String, languageIds: [String], selectedLanguageIndex: Int?, trainingTipsEnabled: Bool) {
         
         var openToolInLanguages: [String] = Array()
         
@@ -729,6 +753,7 @@ extension AppFlow {
             resourceId: toolDataModelId,
             languageIds: openToolInLanguages,
             liveShareStream: nil,
+            selectedLanguageIndex: selectedLanguageIndex,
             trainingTipsEnabled: trainingTipsEnabled,
             initialPage: nil
         )
@@ -930,12 +955,14 @@ extension AppFlow {
 
 extension AppFlow {
     
-    private func getToolDetails(tool: ToolDomainModel, toolLanguage: AppLanguageDomainModel?) -> UIViewController {
+    private func getToolDetails(tool: ToolDomainModel, toolLanguage: AppLanguageDomainModel?, selectedLanguageIndex: Int?) -> UIViewController {
         
         let viewModel = ToolDetailsViewModel(
             flowDelegate: self,
             tool: tool,
-            primaryLanguage: toolLanguage,
+            primaryLanguage: appLanguage,
+            parallelLanguage: toolLanguage,
+            selectedLanguageIndex: selectedLanguageIndex,
             getCurrentAppLanguageUseCase: appDiContainer.feature.appLanguage.domainLayer.getCurrentAppLanguageUseCase(),
             getToolUseCase: appDiContainer.domainLayer.getToolUseCase(),
             viewToolDetailsUseCase: appDiContainer.feature.toolDetails.domainLayer.getViewToolDetailsUseCase(),
@@ -973,7 +1000,7 @@ extension AppFlow {
 
 extension AppFlow {
     
-    private func navigateToLearnToShareTool(tool: ToolDomainModel, primaryLanguage: AppLanguageDomainModel, parallelLanguage: AppLanguageDomainModel?) {
+    private func navigateToLearnToShareTool(tool: ToolDomainModel, primaryLanguage: AppLanguageDomainModel, parallelLanguage: AppLanguageDomainModel?, selectedLanguageIndex: Int?) {
         
         let toolTrainingTipsOnboardingViews: ToolTrainingTipsOnboardingViewsService = appDiContainer.getToolTrainingTipsOnboardingViews()
                     
@@ -988,7 +1015,8 @@ extension AppFlow {
                 appDiContainer: appDiContainer,
                 tool: tool,
                 toolPrimaryLanguage: primaryLanguage,
-                toolParallelLanguage: parallelLanguage
+                toolParallelLanguage: parallelLanguage,
+                toolSelectedLanguageIndex: selectedLanguageIndex
             )
             
             navigationController.present(learnToShareToolFlow.navigationController, animated: true, completion: nil)
@@ -997,7 +1025,13 @@ extension AppFlow {
         }
         else {
             
-            navigateToTool(toolDataModelId: tool.dataModelId, primaryLanguage: primaryLanguage, parallelLanguage: parallelLanguage, trainingTipsEnabled: true)
+            navigateToTool(
+                toolDataModelId: tool.dataModelId,
+                primaryLanguage: primaryLanguage,
+                parallelLanguage: parallelLanguage,
+                selectedLanguageIndex: selectedLanguageIndex,
+                trainingTipsEnabled: true
+            )
         }
     }
     

--- a/godtools/App/Flows/ChooseYourOwnAdventure/ChooseYourOwnAdventureFlow.swift
+++ b/godtools/App/Flows/ChooseYourOwnAdventure/ChooseYourOwnAdventureFlow.swift
@@ -25,14 +25,14 @@ class ChooseYourOwnAdventureFlow: ToolNavigationFlow {
     var tractFlow: TractFlow?
     var downloadToolTranslationFlow: DownloadToolTranslationsFlow?
     
-    init(flowDelegate: FlowDelegate, appDiContainer: AppDiContainer, sharedNavigationController: AppNavigationController, toolTranslations: ToolTranslationsDomainModel, initialPage: MobileContentPagesPage?) {
+    init(flowDelegate: FlowDelegate, appDiContainer: AppDiContainer, sharedNavigationController: AppNavigationController, toolTranslations: ToolTranslationsDomainModel, initialPage: MobileContentPagesPage?, selectedLanguageIndex: Int?) {
         
         self.flowDelegate = flowDelegate
         self.appDiContainer = appDiContainer
         self.navigationController = sharedNavigationController
         
         sharedNavigationController.pushViewController(
-            getChooseYourOwnAdventureView(toolTranslations: toolTranslations, initialPage: initialPage),
+            getChooseYourOwnAdventureView(toolTranslations: toolTranslations, initialPage: initialPage, selectedLanguageIndex: selectedLanguageIndex),
             animated: true
         )
     }
@@ -59,7 +59,7 @@ class ChooseYourOwnAdventureFlow: ToolNavigationFlow {
 
 extension ChooseYourOwnAdventureFlow {
     
-    private func getChooseYourOwnAdventureView(toolTranslations: ToolTranslationsDomainModel, initialPage: MobileContentPagesPage?) -> UIViewController {
+    private func getChooseYourOwnAdventureView(toolTranslations: ToolTranslationsDomainModel, initialPage: MobileContentPagesPage?, selectedLanguageIndex: Int?) -> UIViewController {
         
         let navigation: MobileContentRendererNavigation = appDiContainer.getMobileContentRendererNavigation(
             parentFlow: self,
@@ -83,7 +83,8 @@ extension ChooseYourOwnAdventureFlow {
             mobileContentEventAnalytics: appDiContainer.getMobileContentRendererEventAnalyticsTracking(),
             fontService: appDiContainer.getFontService(),
             trainingTipsEnabled: false,
-            incrementUserCounterUseCase: appDiContainer.domainLayer.getIncrementUserCounterUseCase()
+            incrementUserCounterUseCase: appDiContainer.domainLayer.getIncrementUserCounterUseCase(),
+            selectedLanguageIndex: selectedLanguageIndex
         )
         
         navigationController.setSemanticContentAttribute(semanticContentAttribute: navBarLayoutDirection)

--- a/godtools/App/Flows/ChooseYourOwnAdventure/ChooseYourOwnAdventureFlow.swift
+++ b/godtools/App/Flows/ChooseYourOwnAdventure/ChooseYourOwnAdventureFlow.swift
@@ -154,6 +154,7 @@ extension ChooseYourOwnAdventureFlow {
         return NavBarSelectorView(
             selectorButtonTitles: viewModel.languageNames,
             layoutDirection: navBarLayoutDirection,
+            selectedIndex: viewModel.selectedLanguageIndex,
             borderColor: controlColor,
             selectedColor: controlColor,
             deselectedColor: UIColor.clear,

--- a/godtools/App/Flows/Flow/FlowStep.swift
+++ b/godtools/App/Flows/Flow/FlowStep.swift
@@ -71,13 +71,13 @@ enum FlowStep {
     
     // toolDetails
     case backTappedFromToolDetails
-    case openToolTappedFromToolDetails(tool: ToolDomainModel, primaryLanguage: AppLanguageDomainModel, parallelLanguage: AppLanguageDomainModel?)
-    case learnToShareToolTappedFromToolDetails(tool: ToolDomainModel, primaryLanguage: AppLanguageDomainModel, parallelLanguage: AppLanguageDomainModel?)
+    case openToolTappedFromToolDetails(tool: ToolDomainModel, primaryLanguage: AppLanguageDomainModel, parallelLanguage: AppLanguageDomainModel?, selectedLanguageIndex: Int?)
+    case learnToShareToolTappedFromToolDetails(tool: ToolDomainModel, primaryLanguage: AppLanguageDomainModel, parallelLanguage: AppLanguageDomainModel?, selectedLanguageIndex: Int?)
     case urlLinkTappedFromToolDetail(url: URL, screenName: String, siteSection: String, siteSubSection: String, contentLanguage: String?, contentLanguageSecondary: String?)
     
     // learnToShareTool
-    case closeTappedFromLearnToShareTool(tool: ToolDomainModel, primaryLanguage: AppLanguageDomainModel, parallelLanguage: AppLanguageDomainModel?)
-    case continueTappedFromLearnToShareTool(tool: ToolDomainModel, primaryLanguage: AppLanguageDomainModel, parallelLanguage: AppLanguageDomainModel?)
+    case closeTappedFromLearnToShareTool(tool: ToolDomainModel, primaryLanguage: AppLanguageDomainModel, parallelLanguage: AppLanguageDomainModel?, selectedLanguageIndex: Int?)
+    case continueTappedFromLearnToShareTool(tool: ToolDomainModel, primaryLanguage: AppLanguageDomainModel, parallelLanguage: AppLanguageDomainModel?, selectedLanguageIndex: Int?)
             
     // tool
     case homeTappedFromTool(isScreenSharing: Bool)

--- a/godtools/App/Flows/LearnToShareTool/LearnToShareToolFlow.swift
+++ b/godtools/App/Flows/LearnToShareTool/LearnToShareToolFlow.swift
@@ -18,11 +18,12 @@ class LearnToShareToolFlow: Flow {
     
     private let toolPrimaryLanguage: AppLanguageDomainModel
     private let toolParallelLanguage: AppLanguageDomainModel?
+    private let toolSelectedLanguageIndex: Int?
     
     let appDiContainer: AppDiContainer
     let navigationController: AppNavigationController
     
-    init(flowDelegate: FlowDelegate, appDiContainer: AppDiContainer, tool: ToolDomainModel, toolPrimaryLanguage: AppLanguageDomainModel, toolParallelLanguage: AppLanguageDomainModel?) {
+    init(flowDelegate: FlowDelegate, appDiContainer: AppDiContainer, tool: ToolDomainModel, toolPrimaryLanguage: AppLanguageDomainModel, toolParallelLanguage: AppLanguageDomainModel?, toolSelectedLanguageIndex: Int?) {
         
         let navigationBarAppearance = AppNavigationBarAppearance(backgroundColor: .clear, controlColor: ColorPalette.gtBlue.uiColor, titleFont: nil, titleColor: nil, isTranslucent: true)
         
@@ -31,6 +32,7 @@ class LearnToShareToolFlow: Flow {
         self.navigationController = AppNavigationController(navigationBarAppearance: navigationBarAppearance)
         self.toolPrimaryLanguage = toolPrimaryLanguage
         self.toolParallelLanguage = toolParallelLanguage
+        self.toolSelectedLanguageIndex = toolSelectedLanguageIndex
         
         navigationController.modalPresentationStyle = .fullScreen
         
@@ -47,11 +49,11 @@ class LearnToShareToolFlow: Flow {
         
         switch step {
             
-        case .continueTappedFromLearnToShareTool(let tool, let primaryLanguage, let parallelLanguage):
-            flowDelegate?.navigate(step: .continueTappedFromLearnToShareTool(tool: tool, primaryLanguage: primaryLanguage, parallelLanguage: parallelLanguage))
+        case .continueTappedFromLearnToShareTool(let tool, let primaryLanguage, let parallelLanguage, let selectedLanguageIndex):
+            flowDelegate?.navigate(step: .continueTappedFromLearnToShareTool(tool: tool, primaryLanguage: primaryLanguage, parallelLanguage: parallelLanguage, selectedLanguageIndex: selectedLanguageIndex))
             
-        case .closeTappedFromLearnToShareTool(let tool, let primaryLanguage, let parallelLanguage):
-            flowDelegate?.navigate(step: .closeTappedFromLearnToShareTool(tool: tool, primaryLanguage: primaryLanguage, parallelLanguage: parallelLanguage))
+        case .closeTappedFromLearnToShareTool(let tool, let primaryLanguage, let parallelLanguage, let selectedLanguageIndex):
+            flowDelegate?.navigate(step: .closeTappedFromLearnToShareTool(tool: tool, primaryLanguage: primaryLanguage, parallelLanguage: parallelLanguage, selectedLanguageIndex: selectedLanguageIndex))
             
         default:
             break
@@ -65,6 +67,7 @@ class LearnToShareToolFlow: Flow {
             tool: tool,
             toolPrimaryLanguage: toolPrimaryLanguage,
             toolParallelLanguage: toolParallelLanguage,
+            toolSelectedLanguageIndex: toolSelectedLanguageIndex,
             getCurrentAppLanguageUseCase: appDiContainer.feature.appLanguage.domainLayer.getCurrentAppLanguageUseCase(),
             viewLearnToShareToolUseCase: appDiContainer.feature.learnToShareTool.domainLayer.getViewLearnToShareToolUseCase()
         )

--- a/godtools/App/Flows/ToolNavigation/ToolNavigationFlow.swift
+++ b/godtools/App/Flows/ToolNavigation/ToolNavigationFlow.swift
@@ -20,7 +20,7 @@ protocol ToolNavigationFlow: Flow {
 
 extension ToolNavigationFlow {
         
-    func navigateToToolFromToolDeepLink(toolDeepLink: ToolDeepLink, didCompleteToolNavigation: ((_ resource: ResourceModel) -> Void)?) {
+    func navigateToToolFromToolDeepLink(toolDeepLink: ToolDeepLink, selectedLanguageIndex: Int?, didCompleteToolNavigation: ((_ resource: ResourceModel) -> Void)?) {
         
         let determineDeepLinkedToolTranslationsToDownload = DetermineDeepLinkedToolTranslationsToDownload(
             toolDeepLink: toolDeepLink,
@@ -33,12 +33,13 @@ extension ToolNavigationFlow {
         navigateToToolAndDetermineToolTranslationsToDownload(
             determineToolTranslationsToDownload: determineDeepLinkedToolTranslationsToDownload,
             liveShareStream: toolDeepLink.liveShareStream,
+            selectedLanguageIndex: selectedLanguageIndex,
             trainingTipsEnabled: false,
             initialPage: toolDeepLink.mobileContentPage
         )
     }
     
-    func navigateToTool(resourceId: String, languageIds: [String], liveShareStream: String?, trainingTipsEnabled: Bool, initialPage: MobileContentPagesPage?) {
+    func navigateToTool(resourceId: String, languageIds: [String], liveShareStream: String?, selectedLanguageIndex: Int?, trainingTipsEnabled: Bool, initialPage: MobileContentPagesPage?) {
         
         let determineToolTranslationsToDownload = DetermineToolTranslationsToDownload(
             resourceId: resourceId,
@@ -50,12 +51,13 @@ extension ToolNavigationFlow {
         navigateToToolAndDetermineToolTranslationsToDownload(
             determineToolTranslationsToDownload: determineToolTranslationsToDownload,
             liveShareStream: liveShareStream,
+            selectedLanguageIndex: selectedLanguageIndex,
             trainingTipsEnabled: trainingTipsEnabled,
             initialPage: initialPage
         )
     }
     
-    private func navigateToToolAndDetermineToolTranslationsToDownload(determineToolTranslationsToDownload: DetermineToolTranslationsToDownloadType, liveShareStream: String?, trainingTipsEnabled: Bool, initialPage: MobileContentPagesPage?) {
+    private func navigateToToolAndDetermineToolTranslationsToDownload(determineToolTranslationsToDownload: DetermineToolTranslationsToDownloadType, liveShareStream: String?, selectedLanguageIndex: Int?, trainingTipsEnabled: Bool, initialPage: MobileContentPagesPage?) {
         
         let didDownloadToolTranslationsClosure = { [weak self] (result: Result<ToolTranslationsDomainModel, Error>) in
                         
@@ -66,6 +68,7 @@ extension ToolNavigationFlow {
                 self?.navigateToTool(
                     toolTranslations: toolTranslations,
                     liveShareStream: liveShareStream,
+                    selectedLanguageIndex: selectedLanguageIndex,
                     trainingTipsEnabled: trainingTipsEnabled,
                     initialPage: initialPage
                 )
@@ -87,7 +90,7 @@ extension ToolNavigationFlow {
         self.downloadToolTranslationFlow = downloadToolTranslationFlow
     }
     
-    private func navigateToTool(toolTranslations: ToolTranslationsDomainModel, liveShareStream: String?, trainingTipsEnabled: Bool, initialPage: MobileContentPagesPage?) {
+    private func navigateToTool(toolTranslations: ToolTranslationsDomainModel, liveShareStream: String?, selectedLanguageIndex: Int?, trainingTipsEnabled: Bool, initialPage: MobileContentPagesPage?) {
         
         let resourceType: ResourceType = toolTranslations.tool.resourceTypeEnum
         
@@ -121,6 +124,7 @@ extension ToolNavigationFlow {
                 sharedNavigationController: navigationController,
                 toolTranslations: toolTranslations,
                 liveShareStream: liveShareStream,
+                selectedLanguageIndex: selectedLanguageIndex,
                 trainingTipsEnabled: trainingTipsEnabled,
                 initialPage: initialPage
             )
@@ -132,7 +136,8 @@ extension ToolNavigationFlow {
                 appDiContainer: appDiContainer,
                 sharedNavigationController: navigationController,
                 toolTranslations: toolTranslations,
-                initialPage: initialPage
+                initialPage: initialPage,
+                selectedLanguageIndex: selectedLanguageIndex
             )
             
         case .metaTool:

--- a/godtools/App/Flows/Tract/TractFlow.swift
+++ b/godtools/App/Flows/Tract/TractFlow.swift
@@ -28,7 +28,7 @@ class TractFlow: ToolNavigationFlow, Flow {
     var tractFlow: TractFlow?
     var downloadToolTranslationFlow: DownloadToolTranslationsFlow?
     
-    init(flowDelegate: FlowDelegate, appDiContainer: AppDiContainer, sharedNavigationController: AppNavigationController?, toolTranslations: ToolTranslationsDomainModel, liveShareStream: String?, trainingTipsEnabled: Bool, initialPage: MobileContentPagesPage?) {
+    init(flowDelegate: FlowDelegate, appDiContainer: AppDiContainer, sharedNavigationController: AppNavigationController?, toolTranslations: ToolTranslationsDomainModel, liveShareStream: String?, selectedLanguageIndex: Int?, trainingTipsEnabled: Bool, initialPage: MobileContentPagesPage?) {
         
         self.flowDelegate = flowDelegate
         self.appDiContainer = appDiContainer
@@ -41,6 +41,7 @@ class TractFlow: ToolNavigationFlow, Flow {
         let toolView = getToolView(
             toolTranslations: toolTranslations,
             liveShareStream: liveShareStream,
+            selectedLanguageIndex: selectedLanguageIndex,
             trainingTipsEnabled: trainingTipsEnabled,
             initialPage: initialPage
         )
@@ -172,7 +173,7 @@ class TractFlow: ToolNavigationFlow, Flow {
 
 extension TractFlow {
     
-    private func getToolView(toolTranslations: ToolTranslationsDomainModel, liveShareStream: String?, trainingTipsEnabled: Bool, initialPage: MobileContentPagesPage?) -> UIViewController {
+    private func getToolView(toolTranslations: ToolTranslationsDomainModel, liveShareStream: String?, selectedLanguageIndex: Int?, trainingTipsEnabled: Bool, initialPage: MobileContentPagesPage?) -> UIViewController {
         
         let navigation: MobileContentRendererNavigation = appDiContainer.getMobileContentRendererNavigation(
             parentFlow: self,
@@ -204,7 +205,8 @@ extension TractFlow {
             liveShareStream: liveShareStream,
             initialPage: initialPage,
             trainingTipsEnabled: trainingTipsEnabled,
-            incrementUserCounterUseCase: appDiContainer.domainLayer.getIncrementUserCounterUseCase()
+            incrementUserCounterUseCase: appDiContainer.domainLayer.getIncrementUserCounterUseCase(),
+            selectedLanguageIndex: selectedLanguageIndex
         )
         
         navigationController.setSemanticContentAttribute(semanticContentAttribute: navBarLayoutDirection)

--- a/godtools/App/Services/Renderer/Navigation/MobileContentRendererNavigation.swift
+++ b/godtools/App/Services/Renderer/Navigation/MobileContentRendererNavigation.swift
@@ -61,7 +61,7 @@ class MobileContentRendererNavigation {
                 
             case .tool(let toolDeepLink):
                 
-                parentFlow?.navigateToToolFromToolDeepLink(toolDeepLink: toolDeepLink, didCompleteToolNavigation: nil)
+                parentFlow?.navigateToToolFromToolDeepLink(toolDeepLink: toolDeepLink, selectedLanguageIndex: nil, didCompleteToolNavigation: nil)
             }
         }
         else {

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/Pages/MobileContentPagesViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/Pages/MobileContentPagesViewModel.swift
@@ -128,8 +128,9 @@ class MobileContentPagesViewModel: NSObject, ObservableObject {
     func setRenderer(renderer: MobileContentRenderer, pageRendererIndex: Int?, navigationEvent: MobileContentPagesNavigationEvent?) {
             
         let pageRenderer: MobileContentPageRenderer?
+        let pageRendererIndex: Int = pageRendererIndex ?? selectedLanguageIndex
         
-        if let pageRendererIndex = pageRendererIndex, pageRendererIndex >= 0 && pageRendererIndex < renderer.pageRenderers.count {
+        if pageRendererIndex >= 0 && pageRendererIndex < renderer.pageRenderers.count {
             pageRenderer = renderer.pageRenderers[pageRendererIndex]
         }
         else if let firstPageRenderer = renderer.pageRenderers.first {


### PR DESCRIPTION
This task adds selectedLanguageIndex: Int to base class MobileContentPagesViewModel.  This will allow us to control which language should start as selected.

- When opening a tool from the tools list, the tool will be opened with the app language as primary and the tool filter language as parallel and the parallel language will be selected.