### PR TITLE
GT-2280 Fix tool parallel should not match primary

### DIFF
--- a/godtools/App/Features/ToolDetails/Data-DomainInterface/GetToolDetailsLearnToShareToolIsAvailableRepository.swift
+++ b/godtools/App/Features/ToolDetails/Data-DomainInterface/GetToolDetailsLearnToShareToolIsAvailableRepository.swift
@@ -19,9 +19,9 @@ class GetToolDetailsLearnToShareToolIsAvailableRepository: GetToolDetailsLearnTo
         self.translationsRepository = translationsRepository
     }
     
-    func getIsAvailablePublisher(tool: ToolDomainModel, toolLanguageCode: String) -> AnyPublisher<Bool, Never> {
+    func getIsAvailablePublisher(tool: ToolDomainModel, language: BCP47LanguageIdentifier) -> AnyPublisher<Bool, Never> {
         
-        guard let translation = translationsRepository.getLatestTranslation(resourceId: tool.dataModelId, languageCode: toolLanguageCode) else {
+        guard let translation = translationsRepository.getLatestTranslation(resourceId: tool.dataModelId, languageCode: language) else {
             return Just(false)
                 .eraseToAnyPublisher()
         }

--- a/godtools/App/Features/ToolDetails/Domain/Interface/GetToolDetailsLearnToShareToolIsAvailableRepositoryInterface.swift
+++ b/godtools/App/Features/ToolDetails/Domain/Interface/GetToolDetailsLearnToShareToolIsAvailableRepositoryInterface.swift
@@ -11,5 +11,5 @@ import Combine
 
 protocol GetToolDetailsLearnToShareToolIsAvailableRepositoryInterface {
     
-    func getIsAvailablePublisher(tool: ToolDomainModel, toolLanguageCode: String) -> AnyPublisher<Bool, Never>
+    func getIsAvailablePublisher(tool: ToolDomainModel, language: BCP47LanguageIdentifier) -> AnyPublisher<Bool, Never>
 }

--- a/godtools/App/Features/ToolDetails/Domain/UseCases/GetToolDetailsLearnToShareToolIsAvailableUseCase.swift
+++ b/godtools/App/Features/ToolDetails/Domain/UseCases/GetToolDetailsLearnToShareToolIsAvailableUseCase.swift
@@ -18,17 +18,9 @@ class GetToolDetailsLearnToShareToolIsAvailableUseCase {
         self.getToolDetailsLearnToShareToolIsAvailableRepository = getToolDetailsLearnToShareToolIsAvailableRepository
     }
     
-    func getIsAvailablePublisher(toolChangedPublisher: AnyPublisher<ToolDomainModel, Never>, toolLanguageCodeChangedPublisher: AnyPublisher<String, Never>) -> AnyPublisher<Bool, Never> {
+    func getIsAvailablePublisher(tool: ToolDomainModel, language: BCP47LanguageIdentifier) -> AnyPublisher<Bool, Never> {
         
-        Publishers.CombineLatest(
-            toolChangedPublisher.eraseToAnyPublisher(),
-            toolLanguageCodeChangedPublisher.eraseToAnyPublisher()
-        )
-        .flatMap({ (tool: ToolDomainModel, toolLanguageCode: String) -> AnyPublisher<Bool, Never> in
-            
-            return self.getToolDetailsLearnToShareToolIsAvailableRepository.getIsAvailablePublisher(tool: tool, toolLanguageCode: toolLanguageCode)
-                .eraseToAnyPublisher()
-        })
-        .eraseToAnyPublisher()
+        return self.getToolDetailsLearnToShareToolIsAvailableRepository.getIsAvailablePublisher(tool: tool, language: language)
+            .eraseToAnyPublisher()
     }
 }

--- a/godtools/App/Flows/App/AppFlow.swift
+++ b/godtools/App/Flows/App/AppFlow.swift
@@ -172,7 +172,7 @@ class AppFlow: NSObject, ToolNavigationFlow, Flow {
             
             let toolDetails = getToolDetails(
                 tool: spotlightTool,
-                toolLanguage: toolFilterLanguage?.language?.localeIdentifier,
+                parallelLanguage: toolFilterLanguage?.language?.localeIdentifier,
                 selectedLanguageIndex: 1
             )
             
@@ -182,7 +182,7 @@ class AppFlow: NSObject, ToolNavigationFlow, Flow {
             
             let toolDetails = getToolDetails(
                 tool: tool,
-                toolLanguage: toolFilterLanguage?.language?.localeIdentifier,
+                parallelLanguage: toolFilterLanguage?.language?.localeIdentifier,
                 selectedLanguageIndex: 1
             )
             
@@ -204,7 +204,7 @@ class AppFlow: NSObject, ToolNavigationFlow, Flow {
             
             let toolDetails = getToolDetails(
                 tool: tool,
-                toolLanguage: nil,
+                parallelLanguage: nil,
                 selectedLanguageIndex: nil
             )
             
@@ -229,7 +229,7 @@ class AppFlow: NSObject, ToolNavigationFlow, Flow {
             
             let toolDetails = getToolDetails(
                 tool: tool,
-                toolLanguage: nil,
+                parallelLanguage: nil,
                 selectedLanguageIndex: nil
             )
             
@@ -957,13 +957,13 @@ extension AppFlow {
 
 extension AppFlow {
     
-    private func getToolDetails(tool: ToolDomainModel, toolLanguage: AppLanguageDomainModel?, selectedLanguageIndex: Int?) -> UIViewController {
+    private func getToolDetails(tool: ToolDomainModel, parallelLanguage: AppLanguageDomainModel?, selectedLanguageIndex: Int?) -> UIViewController {
         
         let viewModel = ToolDetailsViewModel(
             flowDelegate: self,
             tool: tool,
             primaryLanguage: appLanguage,
-            parallelLanguage: toolLanguage,
+            parallelLanguage: parallelLanguage,
             selectedLanguageIndex: selectedLanguageIndex,
             getCurrentAppLanguageUseCase: appDiContainer.feature.appLanguage.domainLayer.getCurrentAppLanguageUseCase(),
             getToolUseCase: appDiContainer.domainLayer.getToolUseCase(),

--- a/godtools/App/Flows/App/AppFlow.swift
+++ b/godtools/App/Flows/App/AppFlow.swift
@@ -707,10 +707,13 @@ extension AppFlow {
         
         let languagesRepository: LanguagesRepository = appDiContainer.dataLayer.getLanguagesRepository()
         
-        var languageIds: [String] = Array()
+        let languageIds: Set<String>
         
         if let appLanguageModel = languagesRepository.getLanguage(code: appLanguage) {
-            languageIds.append(appLanguageModel.id)
+            languageIds = [appLanguageModel.id]
+        }
+        else {
+            languageIds = Set()
         }
         
         navigateToTool(toolDataModelId: toolDataModelId, languageIds: languageIds, selectedLanguageIndex: nil, trainingTipsEnabled: trainingTipsEnabled)
@@ -720,33 +723,32 @@ extension AppFlow {
         
         let languagesRepository: LanguagesRepository = appDiContainer.dataLayer.getLanguagesRepository()
         
-        var languageIds: [String] = Array()
+        var languageIds: Set<String> = Set()
         
         if let languageModel = languagesRepository.getLanguage(code: primaryLanguage) {
-            languageIds.append(languageModel.id)
+            languageIds.insert(languageModel.id)
         }
         
         if let parallelLanguage = parallelLanguage, let languageModel = languagesRepository.getLanguage(code: parallelLanguage) {
-            languageIds.append(languageModel.id)
+            languageIds.insert(languageModel.id)
         }
         
         navigateToTool(toolDataModelId: toolDataModelId, languageIds: languageIds, selectedLanguageIndex: selectedLanguageIndex, trainingTipsEnabled: trainingTipsEnabled)
     }
         
-    private func navigateToTool(toolDataModelId: String, languageIds: [String], selectedLanguageIndex: Int?, trainingTipsEnabled: Bool) {
-        
-        var openToolInLanguages: [String] = Array()
-        
-        for languageId in languageIds {
-            if !openToolInLanguages.contains(languageId) {
-                openToolInLanguages.append(languageId)
-            }
-        }
+    private func navigateToTool(toolDataModelId: String, languageIds: Set<String>, selectedLanguageIndex: Int?, trainingTipsEnabled: Bool) {
         
         let languagesRepository: LanguagesRepository = appDiContainer.dataLayer.getLanguagesRepository()
         
-        if openToolInLanguages.isEmpty, let englishLanguage = languagesRepository.getLanguage(code: LanguageCodeDomainModel.english.rawValue) {
-            openToolInLanguages.append(englishLanguage.id)
+        let openToolInLanguages: Set<String>
+        
+        if languageIds.isEmpty, let englishLanguage = languagesRepository.getLanguage(code: LanguageCodeDomainModel.english.rawValue) {
+            
+            openToolInLanguages = [englishLanguage.id]
+        }
+        else {
+            
+            openToolInLanguages = languageIds
         }
         
         navigateToTool(

--- a/godtools/App/Flows/ToolNavigation/ToolNavigationFlow.swift
+++ b/godtools/App/Flows/ToolNavigation/ToolNavigationFlow.swift
@@ -39,7 +39,7 @@ extension ToolNavigationFlow {
         )
     }
     
-    func navigateToTool(resourceId: String, languageIds: [String], liveShareStream: String?, selectedLanguageIndex: Int?, trainingTipsEnabled: Bool, initialPage: MobileContentPagesPage?) {
+    func navigateToTool(resourceId: String, languageIds: Set<String>, liveShareStream: String?, selectedLanguageIndex: Int?, trainingTipsEnabled: Bool, initialPage: MobileContentPagesPage?) {
         
         let determineToolTranslationsToDownload = DetermineToolTranslationsToDownload(
             resourceId: resourceId,

--- a/godtools/App/Flows/ToolSettings/ToolSettingsFlow.swift
+++ b/godtools/App/Flows/ToolSettings/ToolSettingsFlow.swift
@@ -82,14 +82,14 @@ class ToolSettingsFlow: Flow {
         .receive(on: DispatchQueue.main)
         .sink { [weak self] (primaryLanguage: LanguageDomainModel?, parallelLanguage: LanguageDomainModel?) in
             
-            var languageIds: [String] = Array()
+            var languageIds: Set<String> = Set()
             
             if let primaryLanguage = primaryLanguage {
-                languageIds.append(primaryLanguage.id)
+                languageIds.insert(primaryLanguage.id)
             }
             
             if let parallelLanguage = parallelLanguage {
-                languageIds.append(parallelLanguage.id)
+                languageIds.insert(parallelLanguage.id)
             }
             
             self?.setToolLanguages(languageIds: languageIds)
@@ -241,7 +241,7 @@ class ToolSettingsFlow: Flow {
         }
     }
     
-    private func setToolLanguages(languageIds: [String]) {
+    private func setToolLanguages(languageIds: Set<String>){
                 
         let determineToolTranslationsToDownload = DetermineToolTranslationsToDownload(
             resourceId: toolData.renderer.value.resource.id,

--- a/godtools/App/Share/Domain/UseCases/GetToolTranslationsFilesUseCase/DetermineToolTranslationsToDownload/DetermineToolTranslationsToDownload.swift
+++ b/godtools/App/Share/Domain/UseCases/GetToolTranslationsFilesUseCase/DetermineToolTranslationsToDownload/DetermineToolTranslationsToDownload.swift
@@ -11,11 +11,11 @@ import Foundation
 class DetermineToolTranslationsToDownload: DetermineToolTranslationsToDownloadType {
     
     private let resourceId: String
-    private let languageIds: [String]
+    private let languageIds: Set<String>
     private let resourcesRepository: ResourcesRepository
     private let translationsRepository: TranslationsRepository
         
-    required init(resourceId: String, languageIds: [String], resourcesRepository: ResourcesRepository, translationsRepository: TranslationsRepository) {
+    init(resourceId: String, languageIds: Set<String>, resourcesRepository: ResourcesRepository, translationsRepository: TranslationsRepository) {
         
         self.resourceId = resourceId
         self.languageIds = languageIds


### PR DESCRIPTION
- Added a check in ToolDetaisViewModel to ensure parallel language doesn't match primary.
- Updated tool navigation flow to take a Set of languageIds instead of an Array to ensure it is unique.
- Removed AnyPublishers inputs in GetToolDetailsLearnToShareToolIsAvailableUseCase and moved those to the ViewModel and inject values instead.