### PR TITLE
GT-2214 Undownload language button

### DIFF
--- a/godtools/App/Features/AppLanguage/Presentation/DownloadableLanguages/DownloadableLanguagesView.swift
+++ b/godtools/App/Features/AppLanguage/Presentation/DownloadableLanguages/DownloadableLanguagesView.swift
@@ -28,7 +28,7 @@ struct DownloadableLanguagesView: View {
                     
                     DownloadableLanguageItemView(downloadableLanguage: downloadableLanguage) {
                         
-                        viewModel.downloadableLanguageTapped(downloadableLanguage: downloadableLanguage)
+                        self.downloadableLanguageTapped(downloadableLanguage: downloadableLanguage)
                     }
                     .listRowBackground(Color.clear)
                 }
@@ -40,5 +40,19 @@ struct DownloadableLanguagesView: View {
         .navigationBarBackButtonHidden(true)
         .navigationTitle(viewModel.navTitle)
         .environment(\.layoutDirection, ApplicationLayout.shared.layoutDirection)
+    }
+    
+    private func downloadableLanguageTapped(downloadableLanguage: DownloadableLanguageListItemDomainModel) {
+        
+        switch downloadableLanguage.downloadStatus {
+        case .notDownloaded:
+            viewModel.downloadLanguage(downloadableLanguage)
+            
+        case .downloading:
+            break
+            
+        case .downloaded:
+            viewModel.removeDownloadedLanguage(downloadableLanguage)
+        }
     }
 }

--- a/godtools/App/Features/AppLanguage/Presentation/DownloadableLanguages/DownloadableLanguagesView.swift
+++ b/godtools/App/Features/AppLanguage/Presentation/DownloadableLanguages/DownloadableLanguagesView.swift
@@ -28,7 +28,7 @@ struct DownloadableLanguagesView: View {
                     
                     DownloadableLanguageItemView(downloadableLanguage: downloadableLanguage) {
                         
-                        self.downloadableLanguageTapped(downloadableLanguage: downloadableLanguage)
+                        downloadableLanguageTapped(downloadableLanguage: downloadableLanguage)
                     }
                     .listRowBackground(Color.clear)
                 }

--- a/godtools/App/Features/AppLanguage/Presentation/DownloadableLanguages/Subviews/DownloadableLanguageItemView.swift
+++ b/godtools/App/Features/AppLanguage/Presentation/DownloadableLanguages/Subviews/DownloadableLanguageItemView.swift
@@ -19,6 +19,7 @@ struct DownloadableLanguageItemView: View {
     @State private var downloadProgressTarget: Double?
     @State private var timer: Timer?
     @State private var isVisible: Bool = false
+    @State private var shouldConfirmDownloadRemoval: Bool = false
     
     init(downloadableLanguage: DownloadableLanguageListItemDomainModel, tappedClosure: (() -> Void)?) {
         
@@ -52,11 +53,11 @@ struct DownloadableLanguageItemView: View {
             
             Button {
                 
-                tappedClosure?()
+                didTapItem()
                 
             } label: {
                 
-                LanguageDownloadIcon(languageDownloadStatus: downloadableLanguage.downloadStatus, animationDownloadProgress: animationDownloadProgress)
+                LanguageDownloadIcon(languageDownloadStatus: downloadableLanguage.downloadStatus, animationDownloadProgress: animationDownloadProgress, shouldConfirmDownloadRemoval: shouldConfirmDownloadRemoval)
             }
         }
         .onChange(of: downloadableLanguage.downloadStatus, perform: { newDownloadStatus in
@@ -65,6 +66,7 @@ struct DownloadableLanguageItemView: View {
             case .notDownloaded:
                 self.downloadProgressTarget = nil
                 self.animationDownloadProgress = nil
+                self.shouldConfirmDownloadRemoval = false
                 
             case .downloading(let progress):
                 self.downloadProgressTarget = progress
@@ -82,6 +84,7 @@ struct DownloadableLanguageItemView: View {
         })
         .animation(.default, value: downloadableLanguage.downloadStatus)
         .animation(.default, value: animationDownloadProgress)
+        .animation(.default, value: shouldConfirmDownloadRemoval)
         .onDisappear {
             
             isVisible = false
@@ -100,6 +103,23 @@ struct DownloadableLanguageItemView: View {
             
             continueDownloadProgressAnimationIfNeeded()
         }
+    }
+    
+    private func didTapItem() {
+        
+        switch downloadableLanguage.downloadStatus {
+        case .downloaded:
+            
+            if shouldConfirmDownloadRemoval == false {
+                shouldConfirmDownloadRemoval = true
+                return
+            }
+            
+        default:
+            break
+        }
+        
+        tappedClosure?()
     }
     
     private func startAnimationTimer() {

--- a/godtools/App/Features/AppLanguage/Presentation/DownloadableLanguages/Subviews/DownloadableLanguageItemView.swift
+++ b/godtools/App/Features/AppLanguage/Presentation/DownloadableLanguages/Subviews/DownloadableLanguageItemView.swift
@@ -17,9 +17,18 @@ struct DownloadableLanguageItemView: View {
     
     @State private var animationDownloadProgress: Double?
     @State private var downloadProgressTarget: Double?
-    @State private var timer: Timer?
+    @State private var progressAnimationTimer: Timer?
+    @State private var removeDownloadTimer: Timer?
     @State private var isVisible: Bool = false
     @State private var shouldConfirmDownloadRemoval: Bool = false
+    
+    private var isAnimatingDownload: Bool {
+        guard let animationDownloadProgress = animationDownloadProgress else {
+            return false
+        }
+        
+        return animationDownloadProgress < 1
+    }
     
     init(downloadableLanguage: DownloadableLanguageListItemDomainModel, tappedClosure: (() -> Void)?) {
         
@@ -78,8 +87,8 @@ struct DownloadableLanguageItemView: View {
                 self.downloadProgressTarget = 1
             }
             
-            if timer == nil {
-                startAnimationTimer()
+            if progressAnimationTimer == nil {
+                startProgressAnimationTimer()
             }
         })
         .animation(.default, value: downloadableLanguage.downloadStatus)
@@ -88,7 +97,8 @@ struct DownloadableLanguageItemView: View {
         .onDisappear {
             
             isVisible = false
-            stopAnimationTimer()
+            stopProgressAnimationTimer()
+            cancelDownloadRemovalConfirmation()
         }
         .onAppear {
             
@@ -97,7 +107,7 @@ struct DownloadableLanguageItemView: View {
         }
         .onAppBackgrounded {
         
-            stopAnimationTimer()
+            stopProgressAnimationTimer()
         }
         .onAppForegrounded {
             
@@ -110,11 +120,18 @@ struct DownloadableLanguageItemView: View {
         switch downloadableLanguage.downloadStatus {
         case .downloaded:
             
-            if shouldConfirmDownloadRemoval == false {
+            if isAnimatingDownload {
+                return
+                
+            } else if shouldConfirmDownloadRemoval == false {
+                
                 shouldConfirmDownloadRemoval = true
+                startRemoveDownloadTimer()
+                
                 return
                 
             } else {
+                stopRemoveDownloadTimer()
                 tappedClosure?()
             }
             
@@ -124,9 +141,29 @@ struct DownloadableLanguageItemView: View {
         }
     }
     
-    private func startAnimationTimer() {
+    private func startRemoveDownloadTimer() {
         
-        timer = Timer.scheduledTimer(withTimeInterval: 0.2, repeats: true, block: { timer in
+        removeDownloadTimer = Timer.scheduledTimer(withTimeInterval: 3.0, repeats: false, block: { timer in
+            
+            self.cancelDownloadRemovalConfirmation()
+        })
+    }
+    
+    private func cancelDownloadRemovalConfirmation() {
+        
+        shouldConfirmDownloadRemoval = false
+        stopRemoveDownloadTimer()
+    }
+    
+    private func stopRemoveDownloadTimer() {
+        
+        removeDownloadTimer?.invalidate()
+        removeDownloadTimer = nil
+    }
+    
+    private func startProgressAnimationTimer() {
+        
+        progressAnimationTimer = Timer.scheduledTimer(withTimeInterval: 0.2, repeats: true, block: { timer in
             guard let downloadProgress = self.animationDownloadProgress,
                   let progressTarget = self.downloadProgressTarget
             else { return }
@@ -137,21 +174,21 @@ struct DownloadableLanguageItemView: View {
                 
             } else if progressTarget >= 1 && downloadProgress >= 1 {
                 
-                self.stopAnimationTimer()
+                self.stopProgressAnimationTimer()
             }
         })
     }
     
-    private func stopAnimationTimer() {
-        guard timer != nil else { return }
+    private func stopProgressAnimationTimer() {
+        guard progressAnimationTimer != nil else { return }
         
-        timer?.invalidate()
-        timer = nil
+        progressAnimationTimer?.invalidate()
+        progressAnimationTimer = nil
     }
     
     private func continueDownloadProgressAnimationIfNeeded() {
         if shouldContinueDownloadProgressAnimation() {
-            startAnimationTimer()
+            startProgressAnimationTimer()
         }
     }
     

--- a/godtools/App/Features/AppLanguage/Presentation/DownloadableLanguages/Subviews/DownloadableLanguageItemView.swift
+++ b/godtools/App/Features/AppLanguage/Presentation/DownloadableLanguages/Subviews/DownloadableLanguageItemView.swift
@@ -113,13 +113,15 @@ struct DownloadableLanguageItemView: View {
             if shouldConfirmDownloadRemoval == false {
                 shouldConfirmDownloadRemoval = true
                 return
+                
+            } else {
+                tappedClosure?()
             }
             
         default:
-            break
+            
+            tappedClosure?()
         }
-        
-        tappedClosure?()
     }
     
     private func startAnimationTimer() {

--- a/godtools/App/Features/AppLanguage/Presentation/DownloadableLanguages/Subviews/LanguageDownloadIcon.swift
+++ b/godtools/App/Features/AppLanguage/Presentation/DownloadableLanguages/Subviews/LanguageDownloadIcon.swift
@@ -14,10 +14,12 @@ struct LanguageDownloadIcon: View {
     
     private let languageDownloadStatus: LanguageDownloadStatusDomainModel
     private let animationDownloadProgress: Double?
+    private let shouldConfirmDownloadRemoval: Bool
     
-    init(languageDownloadStatus: LanguageDownloadStatusDomainModel, animationDownloadProgress: Double?) {
+    init(languageDownloadStatus: LanguageDownloadStatusDomainModel, animationDownloadProgress: Double?, shouldConfirmDownloadRemoval: Bool) {
         self.languageDownloadStatus = languageDownloadStatus
         self.animationDownloadProgress = animationDownloadProgress
+        self.shouldConfirmDownloadRemoval = shouldConfirmDownloadRemoval
     }
 
     var body: some View {
@@ -53,7 +55,12 @@ struct LanguageDownloadIcon: View {
                         
         case .downloaded:
             
-            if shouldFinishAnimatingDownloadProgress(), let animationDownloadProgress = animationDownloadProgress {
+            if shouldConfirmDownloadRemoval {
+              
+                Image(systemName: "xmark")
+                    .imageScale(.small)
+                
+            } else if shouldFinishAnimatingDownloadProgress(), let animationDownloadProgress = animationDownloadProgress {
 
                 drawProgressInCircle(progress: animationDownloadProgress)
                 
@@ -113,7 +120,12 @@ struct LanguageDownloadIcon: View {
             }
             
         case .downloaded:
-            return ColorPalette.gtBlue.color
+            
+            if shouldConfirmDownloadRemoval {
+                return Color(.sRGB, red: 229 / 255, green: 91 / 255, blue: 54 / 255, opacity: 1.0)
+            } else {
+                return ColorPalette.gtBlue.color
+            }
         }
     }
     


### PR DESCRIPTION
Current logic is that tapping once on a downloaded language should show the red "x", and tapping a second time removes the download.  Waiting to hear back from Jill if there's supposed to be a way to cancel if a user gets the "x" but doesn't want to download.  Depending on what the solution is, I'm thinking that will just be a separate ticket.