### PR TITLE
GT-2294 Update cyoa back navigation to go to parent

### DIFF
--- a/godtools/App/Features/Dashboard/Presentation/ChooseYourOwnAdventure/ChooseYourOwnAdventureViewModel.swift
+++ b/godtools/App/Features/Dashboard/Presentation/ChooseYourOwnAdventure/ChooseYourOwnAdventureViewModel.swift
@@ -78,18 +78,77 @@ extension ChooseYourOwnAdventureViewModel {
             return
         }
         
-        let event = MobileContentPagesNavigationEvent(
-            pageNavigation: PageNavigationCollectionViewNavigationModel(
-                navigationDirection: nil,
-                page: currentRenderedPageNumber - 1,
-                animated: true,
-                reloadCollectionViewDataNeeded: false,
-                insertPages: nil
-            ),
-            pagePositions: nil
-        )
+        let navigationEvent: MobileContentPagesNavigationEvent
         
-        pageNavigationEventSignal.accept(value: event)
+        let currentPages: [Page] = getPages()
+
+        if let currentPage = getCurrentPage(),
+           let parentPage = currentPage.parentPage,
+           let parentPageIndex = currentPages.firstIndex(of: parentPage) {
+
+            var newPages: [Page] = Array()
+
+            for index in 0 ... parentPageIndex {
+                newPages.append(currentPages[index])
+            }
+
+            newPages.append(currentPage)
+
+            var pageIndexesToRemove: [Int] = Array()
+
+            for pageIndex in 0 ..< currentPages.count {
+
+                let page: Page = currentPages[pageIndex]
+                let pageIsInNewPages: Bool = newPages.contains(where: {$0.id == page.id})
+
+                if !pageIsInNewPages {
+                    pageIndexesToRemove.append(pageIndex)
+                }
+            }
+
+            let lastPageIndexInNewPages: Int = newPages.count - 1
+            var parentPageIndexInNewPagesList: Int = lastPageIndexInNewPages - 1
+            if parentPageIndexInNewPagesList < 0 {
+                parentPageIndexInNewPagesList = 0
+            }
+            
+            // NOTE: May revisit this later, but we need to make sure to update the ViewModel pages before triggering the navigation event for MobileContentPagesNavigationEvent.
+            //  Once the navigation event is triggered with deletePages: [Int] then those pages will be removed from the UICollectionView.
+            //  It would be nice if possible to somehow keep this logic more closely together when inserting/deleting items from the ViewModel and UICollectionView. ~Levi
+            super.setPages(pages: newPages)
+            
+            let goToParentPageEvent = MobileContentPagesNavigationEvent(
+                pageNavigation: PageNavigationCollectionViewNavigationModel(
+                    navigationDirection: nil,
+                    page: parentPageIndexInNewPagesList,
+                    animated: true,
+                    reloadCollectionViewDataNeeded: false,
+                    insertPages: nil,
+                    deletePages: pageIndexesToRemove
+                ),
+                pagePositions: nil
+            )
+                        
+            navigationEvent = goToParentPageEvent
+        }
+        else {
+            
+            let goToPreviousPageEvent = MobileContentPagesNavigationEvent(
+                pageNavigation: PageNavigationCollectionViewNavigationModel(
+                    navigationDirection: nil,
+                    page: currentRenderedPageNumber - 1,
+                    animated: true,
+                    reloadCollectionViewDataNeeded: false,
+                    insertPages: nil,
+                    deletePages: nil
+                ),
+                pagePositions: nil
+            )
+            
+            navigationEvent = goToPreviousPageEvent
+        }
+        
+        pageNavigationEventSignal.accept(value: navigationEvent)
     }
     
     func languageTapped(index: Int) {

--- a/godtools/App/Features/Dashboard/Presentation/Tool/ToolViewModel.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Tool/ToolViewModel.swift
@@ -321,7 +321,8 @@ extension ToolViewModel {
                 page: page ?? super.currentRenderedPageNumber,
                 animated: animated,
                 reloadCollectionViewDataNeeded: navBarLanguageChanged,
-                insertPages: nil
+                insertPages: nil,
+                deletePages: nil
             ),
             pagePositions: pagePositions
         )

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/Pages/MobileContentPagesViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/Pages/MobileContentPagesViewModel.swift
@@ -148,6 +148,23 @@ class MobileContentPagesViewModel: NSObject, ObservableObject {
         setPageRenderer(pageRenderer: currentPageRenderer.value, navigationEvent: nil, pagePositions: nil)
     }
     
+    func getPages() -> [Page] {
+        return pageModels
+    }
+    
+    func setPages(pages: [Page]) {
+        pageModels = pages
+    }
+
+    func getCurrentPage() -> Page? {
+
+        guard currentRenderedPageNumber >= 0 && currentRenderedPageNumber < pageModels.count else {
+            return nil
+        }
+
+        return pageModels[currentRenderedPageNumber]
+    }
+    
     // MARK: - Renderer / Page Renderer
     
     var primaryPageRenderer: MobileContentPageRenderer {
@@ -260,7 +277,8 @@ class MobileContentPagesViewModel: NSObject, ObservableObject {
                     page: currentRenderedPageNumber,
                     animated: false,
                     reloadCollectionViewDataNeeded: true,
-                    insertPages: nil
+                    insertPages: nil,
+                    deletePages: nil
                 ),
                 pagePositions: pagePositions
             )
@@ -272,7 +290,8 @@ class MobileContentPagesViewModel: NSObject, ObservableObject {
                 page: navigationEventToSend.pageNavigation.page,
                 animated: navigationEventToSend.pageNavigation.animated,
                 reloadCollectionViewDataNeeded: navigationEventToSend.pageNavigation.reloadCollectionViewDataNeeded,
-                insertPages: nil
+                insertPages: nil,
+                deletePages: nil
             ),
             pagePositions: navigationEventToSend.pagePositions
         )
@@ -499,7 +518,8 @@ extension MobileContentPagesViewModel {
                     page: pageIndex,
                     animated: animated,
                     reloadCollectionViewDataNeeded: reloadCollectionViewDataNeeded,
-                    insertPages: nil
+                    insertPages: nil,
+                    deletePages: nil
                 ),
                 pagePositions: nil
             )
@@ -532,7 +552,8 @@ extension MobileContentPagesViewModel {
                     page: insertAtIndex,
                     animated: animated,
                     reloadCollectionViewDataNeeded: reloadCollectionViewDataNeeded,
-                    insertPages: [insertAtIndex]
+                    insertPages: [insertAtIndex],
+                    deletePages: nil
                 ),
                 pagePositions: nil
             )

--- a/godtools/App/Share/Views/PageNavigationCollectionView/Models/PageNavigationCollectionViewNavigationModel.swift
+++ b/godtools/App/Share/Views/PageNavigationCollectionView/Models/PageNavigationCollectionViewNavigationModel.swift
@@ -16,6 +16,7 @@ struct PageNavigationCollectionViewNavigationModel {
     let animated: Bool
     let reloadCollectionViewDataNeeded: Bool
     let insertPages: [Int]?
+    let deletePages: [Int]?
     
     var hasPagesToInsert: Bool {
         
@@ -24,5 +25,14 @@ struct PageNavigationCollectionViewNavigationModel {
         }
         
         return !insertPages.isEmpty
+    }
+    
+    var hasPagesToDelete: Bool {
+        
+        guard let deletePages = self.deletePages else {
+            return false
+        }
+        
+        return !deletePages.isEmpty
     }
 }

--- a/godtools/App/Share/Views/PageNavigationCollectionView/PageNavigationCollectionView.swift
+++ b/godtools/App/Share/Views/PageNavigationCollectionView/PageNavigationCollectionView.swift
@@ -487,7 +487,8 @@ extension PageNavigationCollectionView {
                 page: page,
                 animated: animated,
                 reloadCollectionViewDataNeeded: false,
-                insertPages: nil
+                insertPages: nil,
+                deletePages: nil
             )
         )
     }
@@ -512,6 +513,12 @@ extension PageNavigationCollectionView {
             
             let indexPaths: [IndexPath] = insertPages.map({IndexPath(item: $0, section: 0)})
             collectionView.insertItems(at: indexPaths)
+        }
+        
+        if let deletePages = pageNavigation.deletePages, !deletePages.isEmpty {
+            
+            let indexPaths: [IndexPath] = deletePages.map({IndexPath(item: $0, section: 0)})
+            collectionView.deleteItems(at: indexPaths)
         }
         
         let reloadDataNeeded: Bool = pageNavigation.reloadCollectionViewDataNeeded || pageNavigationDirectionChanged


### PR DESCRIPTION
When back button is pressed from a tool that is CYOA (choose your own adventure), instead of moving to the previous page in the list of pages, instead navigate back to the current pages parent page.