### PR TITLE
GT 2248 fix retain cycle

### DIFF
--- a/godtools/App/Features/Dashboard/Presentation/Dashboard/DashboardView.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Dashboard/DashboardView.swift
@@ -27,20 +27,33 @@ struct DashboardView: View {
             
             VStack(alignment: .center, spacing: 0) {
                 
-                PagedView(numberOfPages: viewModel.tabs.count, currentPage: $viewModel.currentTab) { (index: Int) in
+                TabView(selection: $viewModel.currentTab) {
                     
-                    switch viewModel.tabs[index] {
+                    Group {
                         
-                    case .lessons:
-                        LessonsView(viewModel: viewModel.getLessonsViewModel())
-                        
-                    case .favorites:
-                        FavoritesView(viewModel: viewModel.getFavoritesViewModel())
-                        
-                    case .tools:
-                        ToolsView(viewModel: viewModel.getToolsViewModel())
+                        if ApplicationLayout.shared.layoutDirection == .rightToLeft {
+                            
+                            ForEach((0 ..< viewModel.tabs.count).reversed(), id: \.self) { index in
+                                
+                                getDashboardPageView(index: index)
+                                    .environment(\.layoutDirection, ApplicationLayout.shared.layoutDirection)
+                                    .tag(index)
+                            }
+                        }
+                        else {
+                            
+                            ForEach(0 ..< viewModel.tabs.count, id: \.self) { index in
+                                
+                                getDashboardPageView(index: index)
+                                    .environment(\.layoutDirection, ApplicationLayout.shared.layoutDirection)
+                                    .tag(index)
+                            }
+                        }
                     }
                 }
+                .environment(\.layoutDirection, .leftToRight)
+                .tabViewStyle(.page(indexDisplayMode: .never))
+                .animation(.easeOut, value: viewModel.currentTab)
                 
                 DashboardTabBarView(
                     viewModel: viewModel
@@ -48,6 +61,21 @@ struct DashboardView: View {
             }
         }
         .environment(\.layoutDirection, ApplicationLayout.shared.layoutDirection)
+    }
+    
+    @ViewBuilder private func getDashboardPageView(index: Int) -> some View {
+        
+        switch viewModel.tabs[index] {
+            
+        case .lessons:
+            LessonsView(viewModel: viewModel.getLessonsViewModel())
+            
+        case .favorites:
+            FavoritesView(viewModel: viewModel.getFavoritesViewModel())
+            
+        case .tools:
+            ToolsView(viewModel: viewModel.getToolsViewModel())
+        }
     }
 }
     

--- a/godtools/App/Features/LearnToShareTool/Presentation/LearnToShareTool/LearnToShareToolView.swift
+++ b/godtools/App/Features/LearnToShareTool/Presentation/LearnToShareTool/LearnToShareToolView.swift
@@ -26,13 +26,33 @@ struct LearnToShareToolView: View {
             
             VStack(spacing: 0) {
                 
-                PagedView(numberOfPages: viewModel.learnToShareToolItems.count, currentPage: $viewModel.currentPage) { (index: Int) in
+                TabView(selection: $viewModel.currentPage) {
                     
-                    LearnToShareToolItemView(
-                        viewModel: viewModel.getLearnToShareToolItemViewModel(index: index),
-                        geometry: geometry
-                    )
+                    Group {
+                        
+                        if ApplicationLayout.shared.layoutDirection == .rightToLeft {
+                            
+                            ForEach((0 ..< viewModel.learnToShareToolItems.count).reversed(), id: \.self) { index in
+                                
+                                getLearnToShareToolItemView(index: index, geometry: geometry)
+                                    .environment(\.layoutDirection, ApplicationLayout.shared.layoutDirection)
+                                    .tag(index)
+                            }
+                        }
+                        else {
+                            
+                            ForEach(0 ..< viewModel.learnToShareToolItems.count, id: \.self) { index in
+                                
+                                getLearnToShareToolItemView(index: index, geometry: geometry)
+                                    .environment(\.layoutDirection, ApplicationLayout.shared.layoutDirection)
+                                    .tag(index)
+                            }
+                        }
+                    }
                 }
+                .environment(\.layoutDirection, .leftToRight)
+                .tabViewStyle(.page(indexDisplayMode: .never))
+                .animation(.easeOut, value: viewModel.currentPage)
                 
                 GTBlueButton(title: viewModel.continueTitle, font: FontLibrary.sfProTextRegular.font(size: 18), width: geometry.size.width - (continueButtonPadding * 2), height: 50) {
                     
@@ -47,5 +67,13 @@ struct LearnToShareToolView: View {
                 .padding(EdgeInsets(top: 20, leading: 0, bottom: 10, trailing: 0))
             }
         }
+    }
+    
+    private func getLearnToShareToolItemView(index: Int, geometry: GeometryProxy) -> LearnToShareToolItemView {
+        
+        return LearnToShareToolItemView(
+            viewModel: viewModel.getLearnToShareToolItemViewModel(index: index),
+            geometry: geometry
+        )
     }
 }

--- a/godtools/App/Features/Onboarding/Presentation/OnboardingTutorial/OnboardingTutorialView.swift
+++ b/godtools/App/Features/Onboarding/Presentation/OnboardingTutorial/OnboardingTutorialView.swift
@@ -30,46 +30,33 @@ struct OnboardingTutorialView: View {
 
             VStack(alignment: .center, spacing: 0) {
                    
-                PagedView(numberOfPages: viewModel.pages.count, currentPage: $viewModel.currentPage) { (page: Int) in
+                TabView(selection: $viewModel.currentPage) {
                     
-                    switch viewModel.pages[page] {
+                    Group {
                         
-                    case .readyForEveryConversation:
-                       
-                        OnboardingTutorialReadyForEveryConversationView(
-                            viewModel: viewModel.getOnboardingTutorialReadyForEveryConversationViewModel(),
-                            geometry: geometry,
-                            screenAccessibility: .onboardingTutorialPage1,
-                            watchVideoTappedClosure: {
-                                viewModel.watchReadyForEveryConversationVideoTapped()
+                        if ApplicationLayout.shared.layoutDirection == .rightToLeft {
+                            
+                            ForEach((0 ..< viewModel.pages.count).reversed(), id: \.self) { index in
+                                
+                                getOnboardingTutorialView(index: index, geometry: geometry)
+                                    .environment(\.layoutDirection, ApplicationLayout.shared.layoutDirection)
+                                    .tag(index)
                             }
-                        )
-                        
-                    case .talkAboutGodWithAnyone:
-                        
-                        OnboardingTutorialMediaView(
-                            viewModel: viewModel.getOnboardingTutorialTalkAboutGodWithAnyoneViewModel(),
-                            geometry: geometry,
-                            screenAccessibility: .onboardingTutorialPage2
-                        )
-                        
-                    case .prepareForTheMomentsThatMatter:
-                        
-                        OnboardingTutorialMediaView(
-                            viewModel: viewModel.getOnboardingTutorialPrepareForTheMomentsThatMatterViewModel(),
-                            geometry: geometry,
-                            screenAccessibility: .onboardingTutorialPage3
-                        )
-                        
-                    case .helpSomeoneDiscoverJesus:
-                        
-                        OnboardingTutorialMediaView(
-                            viewModel: viewModel.getOnboardingTutorialHelpSomeoneDiscoverJesusViewModel(),
-                            geometry: geometry,
-                            screenAccessibility: .onboardingTutorialPage4
-                        )
+                        }
+                        else {
+                            
+                            ForEach(0 ..< viewModel.pages.count, id: \.self) { index in
+                                
+                                getOnboardingTutorialView(index: index, geometry: geometry)
+                                    .environment(\.layoutDirection, ApplicationLayout.shared.layoutDirection)
+                                    .tag(index)
+                            }
+                        }
                     }
                 }
+                .environment(\.layoutDirection, .leftToRight)
+                .tabViewStyle(.page(indexDisplayMode: .never))
+                .animation(.easeOut, value: viewModel.currentPage)
                 
                 OnboardingTutorialPrimaryButton(geometry: geometry, title: viewModel.continueButtonTitle, accessibility: .nextOnboardingTutorial) {
                     viewModel.continueTapped()
@@ -91,6 +78,47 @@ struct OnboardingTutorialView: View {
             .animation(.interpolatingSpring(stiffness: 80, damping: 10), value: chooseAppLanguageButtonPosition)
         }
         .environment(\.layoutDirection, ApplicationLayout.shared.layoutDirection)
+    }
+    
+    @ViewBuilder private func getOnboardingTutorialView(index: Int, geometry: GeometryProxy) -> some View {
+        
+        switch viewModel.pages[index] {
+            
+        case .readyForEveryConversation:
+           
+            OnboardingTutorialReadyForEveryConversationView(
+                viewModel: viewModel.getOnboardingTutorialReadyForEveryConversationViewModel(),
+                geometry: geometry,
+                screenAccessibility: .onboardingTutorialPage1,
+                watchVideoTappedClosure: {
+                    viewModel.watchReadyForEveryConversationVideoTapped()
+                }
+            )
+            
+        case .talkAboutGodWithAnyone:
+            
+            OnboardingTutorialMediaView(
+                viewModel: viewModel.getOnboardingTutorialTalkAboutGodWithAnyoneViewModel(),
+                geometry: geometry,
+                screenAccessibility: .onboardingTutorialPage2
+            )
+            
+        case .prepareForTheMomentsThatMatter:
+            
+            OnboardingTutorialMediaView(
+                viewModel: viewModel.getOnboardingTutorialPrepareForTheMomentsThatMatterViewModel(),
+                geometry: geometry,
+                screenAccessibility: .onboardingTutorialPage3
+            )
+            
+        case .helpSomeoneDiscoverJesus:
+            
+            OnboardingTutorialMediaView(
+                viewModel: viewModel.getOnboardingTutorialHelpSomeoneDiscoverJesusViewModel(),
+                geometry: geometry,
+                screenAccessibility: .onboardingTutorialPage4
+            )
+        }
     }
 }
 

--- a/godtools/App/Features/ToolScreenShare/Presentation/ToolScreenShareTutorial/ToolScreenShareTutorialView.swift
+++ b/godtools/App/Features/ToolScreenShare/Presentation/ToolScreenShareTutorial/ToolScreenShareTutorialView.swift
@@ -29,13 +29,33 @@ struct ToolScreenShareTutorialView: View {
                 
                 FixedVerticalSpacer(height: 50)
                 
-                PagedView(numberOfPages: viewModel.tutorialPages.count, currentPage: $viewModel.currentPage) { (index: Int) in
+                TabView(selection: $viewModel.currentPage) {
                     
-                    ToolScreenShareTutorialPageView(
-                        tutorialPage: viewModel.tutorialPages[index],
-                        geometry: geometry
-                    )
+                    Group {
+                        
+                        if ApplicationLayout.shared.layoutDirection == .rightToLeft {
+                            
+                            ForEach((0 ..< viewModel.tutorialPages.count).reversed(), id: \.self) { index in
+                                
+                                getToolScreenShareTutorialPage(index: index, geometry: geometry)
+                                    .environment(\.layoutDirection, ApplicationLayout.shared.layoutDirection)
+                                    .tag(index)
+                            }
+                        }
+                        else {
+                            
+                            ForEach(0 ..< viewModel.tutorialPages.count, id: \.self) { index in
+                                
+                                getToolScreenShareTutorialPage(index: index, geometry: geometry)
+                                    .environment(\.layoutDirection, ApplicationLayout.shared.layoutDirection)
+                                    .tag(index)
+                            }
+                        }
+                    }
                 }
+                .environment(\.layoutDirection, .leftToRight)
+                .tabViewStyle(.page(indexDisplayMode: .never))
+                .animation(.easeOut, value: viewModel.currentPage)
                 
                 GTBlueButton(title: viewModel.continueTitle, font: FontLibrary.sfProTextRegular.font(size: 18), width: geometry.size.width - (continueButtonHorizontalPadding * 2), height: continueButtonHeight) {
                     
@@ -52,5 +72,13 @@ struct ToolScreenShareTutorialView: View {
             .frame(maxWidth: .infinity)
         }
         .environment(\.layoutDirection, ApplicationLayout.shared.layoutDirection)
+    }
+    
+    private func getToolScreenShareTutorialPage(index: Int, geometry: GeometryProxy) -> ToolScreenShareTutorialPageView {
+        
+        return ToolScreenShareTutorialPageView(
+            tutorialPage: viewModel.tutorialPages[index],
+            geometry: geometry
+        )
     }
 }

--- a/godtools/App/Features/Tutorial/Presentation/Tutorial/TutorialView.swift
+++ b/godtools/App/Features/Tutorial/Presentation/Tutorial/TutorialView.swift
@@ -29,16 +29,33 @@ struct TutorialView: View {
                 
                 FixedVerticalSpacer(height: 50)
                 
-                PagedView(numberOfPages: viewModel.tutorialPages.count, currentPage: $viewModel.currentPage) { (index: Int) in
+                TabView(selection: $viewModel.currentPage) {
                     
-                    TutorialItemView(
-                        tutorialPage: viewModel.tutorialPages[index],
-                        geometry: geometry,
-                        videoPlayingClosure: {
-                            viewModel.tutorialVideoPlayTapped(tutorialPageIndex: index)
+                    Group {
+                        
+                        if ApplicationLayout.shared.layoutDirection == .rightToLeft {
+                            
+                            ForEach((0 ..< viewModel.tutorialPages.count).reversed(), id: \.self) { index in
+                                
+                                getTutorialItemView(index: index, geometry: geometry)
+                                    .environment(\.layoutDirection, ApplicationLayout.shared.layoutDirection)
+                                    .tag(index)
+                            }
                         }
-                    )
+                        else {
+                            
+                            ForEach(0 ..< viewModel.tutorialPages.count, id: \.self) { index in
+                                
+                                getTutorialItemView(index: index, geometry: geometry)
+                                    .environment(\.layoutDirection, ApplicationLayout.shared.layoutDirection)
+                                    .tag(index)
+                            }
+                        }
+                    }
                 }
+                .environment(\.layoutDirection, .leftToRight)
+                .tabViewStyle(.page(indexDisplayMode: .never))
+                .animation(.easeOut, value: viewModel.currentPage)
                 
                 GTBlueButton(title: viewModel.continueTitle, font: FontLibrary.sfProTextRegular.font(size: 18), width: geometry.size.width - (continueButtonHorizontalPadding * 2), height: continueButtonHeight) {
                     
@@ -54,5 +71,16 @@ struct TutorialView: View {
             }
             .frame(maxWidth: .infinity)
         }
+    }
+    
+    private func getTutorialItemView(index: Int, geometry: GeometryProxy) -> TutorialItemView {
+        
+        return TutorialItemView(
+            tutorialPage: viewModel.tutorialPages[index],
+            geometry: geometry,
+            videoPlayingClosure: {
+                viewModel.tutorialVideoPlayTapped(tutorialPageIndex: index)
+            }
+        )
     }
 }

--- a/godtools/App/Share/SwiftUI Views/PagedView/PagedView.swift
+++ b/godtools/App/Share/SwiftUI Views/PagedView/PagedView.swift
@@ -23,6 +23,8 @@ struct PagedView<Content: View>: View {
         self.numberOfPages = numberOfPages
         self._currentPage = currentPage
         self.content = content
+        
+        assertionFailure("Don't allocate PagedView directly.  There is a possible retain cycle happening with @ViewBuilder content: @escaping (_ page: Int) -> Content.  Instead copy the TabView portion (be sure to include modifiers when copying) and paste into desired location of custom paged view.")
     }
     
     var body: some View {

--- a/godtools/App/Share/SwiftUI Views/PagedView/PagedView.swift
+++ b/godtools/App/Share/SwiftUI Views/PagedView/PagedView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 // NOTE: This view is a wrapper around TabView and was created to fix a bug specifically to iOS 16 where a TabView page index would get reversed when the device settings is using a right to left language.
 // This would cause the TabBar tied to the TabView to reverse as well and navigation was also reversed when tapping Tabs to navigate the TabView. ~Levi
 
+@available(iOS, obsoleted: 14.0, message: "Marking as obsoleted due to a retain cycle happening in @ViewBuilder content: @escaping (_ page: Int) -> Content that was unable to be resolved.")
 struct PagedView<Content: View>: View {
     
     private let numberOfPages: Int


### PR DESCRIPTION
This PR fixes retain cycles happening everywhere ```PagedView``` was implemented.

For some reason using ```ViewBuilder content: @escaping (_ page: Int) -> Content``` with ```PagedView``` in a ```ForEach``` was causing a reference cycle.  I wasn't able to figure out a way to make ```ViewBuilder``` work without causing the retain cycle in PagedView.

The current fix is not to use PagedView and instead use TabView directly.