### PR TITLE
GT-2158 binding selected category and selected language

### DIFF
--- a/godtools/App/Features/ToolsFilter/Presentation/ToolFilterCategorySelectionView/Subviews/ToolFilterCategorySelectionRowView/ToolFilterCategorySelectionRowView.swift
+++ b/godtools/App/Features/ToolsFilter/Presentation/ToolFilterCategorySelectionView/Subviews/ToolFilterCategorySelectionRowView/ToolFilterCategorySelectionRowView.swift
@@ -45,7 +45,7 @@ struct ToolFilterCategorySelectionRowView: View {
             
             Spacer()
         }
-        .contentShape(Rectangle()) // This fixes tap area not taking entire card into account.  Noticeable in iOS 14.
+        .contentShape(Rectangle())
         .onTapGesture {
             
             selectedCategory = category

--- a/godtools/App/Features/ToolsFilter/Presentation/ToolFilterCategorySelectionView/Subviews/ToolFilterCategorySelectionRowView/ToolFilterCategorySelectionRowView.swift
+++ b/godtools/App/Features/ToolsFilter/Presentation/ToolFilterCategorySelectionView/Subviews/ToolFilterCategorySelectionRowView/ToolFilterCategorySelectionRowView.swift
@@ -13,11 +13,14 @@ struct ToolFilterCategorySelectionRowView: View {
     private static let lightGrey = Color.getColorWithRGB(red: 151, green: 151, blue: 151, opacity: 1)
     
     private let category: CategoryFilterDomainModel
-    private let isSelected: Bool
+    private let tappedClosure: (() -> Void)?
     
-    init(category: CategoryFilterDomainModel, isSelected: Bool) {
+    @Binding private var selectedCategory: CategoryFilterDomainModel
+    
+    init(category: CategoryFilterDomainModel, selectedCategory: Binding<CategoryFilterDomainModel>, tappedClosure: (() -> Void)?) {
         self.category = category
-        self.isSelected = isSelected
+        self._selectedCategory = selectedCategory
+        self.tappedClosure = tappedClosure
     }
     
     var body: some View {
@@ -42,6 +45,17 @@ struct ToolFilterCategorySelectionRowView: View {
             
             Spacer()
         }
+        .contentShape(Rectangle()) // This fixes tap area not taking entire card into account.  Noticeable in iOS 14.
+        .onTapGesture {
+            
+            selectedCategory = category
+            
+            tappedClosure?()
+        }
+    }
+    
+    private var isSelected: Bool {
+        return selectedCategory.id == category.id
     }
 }
 

--- a/godtools/App/Features/ToolsFilter/Presentation/ToolFilterCategorySelectionView/ToolFilterCategorySelectionView.swift
+++ b/godtools/App/Features/ToolsFilter/Presentation/ToolFilterCategorySelectionView/ToolFilterCategorySelectionView.swift
@@ -28,17 +28,13 @@ struct ToolFilterCategorySelectionView: View {
             List {
                 ForEach(viewModel.categorySearchResults, id: \.filterId) { category in
                     
-                    Button {
-                        
-                        viewModel.rowTapped(with: category)
-                        
-                    } label: {
-                        
-                        ToolFilterCategorySelectionRowView(
-                            category: category,
-                            isSelected: viewModel.selectedCategory.id == category.id
-                        )
-                    }
+                    ToolFilterCategorySelectionRowView(
+                        category: category,
+                        selectedCategory: $viewModel.selectedCategory,
+                        tappedClosure: {
+                            viewModel.categoryTapped(with: category)
+                        }
+                    )
                 }
             }
             .listStyle(.inset)

--- a/godtools/App/Features/ToolsFilter/Presentation/ToolFilterCategorySelectionView/ToolFilterCategorySelectionViewModel.swift
+++ b/godtools/App/Features/ToolsFilter/Presentation/ToolFilterCategorySelectionView/ToolFilterCategorySelectionViewModel.swift
@@ -23,13 +23,12 @@ class ToolFilterCategorySelectionViewModel: ObservableObject {
     private var cancellables: Set<AnyCancellable> = Set()
     private weak var flowDelegate: FlowDelegate?
     
-    let selectedCategory: CategoryFilterDomainModel
-    
     @Published private var appLanguage: AppLanguageDomainModel = LanguageCodeDomainModel.english.rawValue
     
     @Published private var allCategories: [CategoryFilterDomainModel] = [CategoryFilterDomainModel]()
     @Published var searchText: String = ""
     @Published var navTitle: String = ""
+    @Published var selectedCategory: CategoryFilterDomainModel
     @Published var categorySearchResults: [CategoryFilterDomainModel] = [CategoryFilterDomainModel]()
     
     init(viewToolFilterCategoriesUseCase: ViewToolFilterCategoriesUseCase, searchToolFilterCategoriesUseCase: SearchToolFilterCategoriesUseCase, storeUserFiltersUseCase: StoreUserFiltersUseCase, categoryFilterSelectionPublisher: CurrentValueSubject<CategoryFilterDomainModel, Never>, selectedLanguage: LanguageFilterDomainModel, getInterfaceStringInAppLanguageUseCase: GetInterfaceStringInAppLanguageUseCase, getCurrentAppLanguageUseCase: GetCurrentAppLanguageUseCase, viewSearchBarUseCase: ViewSearchBarUseCase, flowDelegate: FlowDelegate) {
@@ -76,6 +75,14 @@ class ToolFilterCategorySelectionViewModel: ObservableObject {
         }
         .receive(on: DispatchQueue.main)
         .assign(to: &$categorySearchResults)
+        
+        $selectedCategory
+            .eraseToAnyPublisher()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] value in
+                self?.categoryFilterSelectionPublisher.send(value)
+            }
+            .store(in: &cancellables)
     }
     
     deinit {
@@ -95,10 +102,8 @@ extension ToolFilterCategorySelectionViewModel {
         )
     }
     
-    func rowTapped(with category: CategoryFilterDomainModel) {
-                
-        categoryFilterSelectionPublisher.send(category)
-        
+    func categoryTapped(with category: CategoryFilterDomainModel) {
+                        
         storeUserFiltersUseCase.storeCategoryFilterPublisher(with: category.id)
             .sink { _ in
                 

--- a/godtools/App/Features/ToolsFilter/Presentation/ToolFilterLanguageSelectionView/Subviews/ToolFilterLanguageSelectionRowView/ToolFilterLanguageSelectionRowView.swift
+++ b/godtools/App/Features/ToolsFilter/Presentation/ToolFilterLanguageSelectionView/Subviews/ToolFilterLanguageSelectionRowView/ToolFilterLanguageSelectionRowView.swift
@@ -13,11 +13,14 @@ struct ToolFilterLanguageSelectionRowView: View {
     private static let lightGrey = Color.getColorWithRGB(red: 151, green: 151, blue: 151, opacity: 1)
     
     private let language: LanguageFilterDomainModel
-    private let isSelected: Bool
+    private let tappedClosure: (() -> Void)?
     
-    init(language: LanguageFilterDomainModel, isSelected: Bool) {
+    @Binding private var selectedLanguage: LanguageFilterDomainModel
+    
+    init(language: LanguageFilterDomainModel, selectedLanguage: Binding<LanguageFilterDomainModel>, tappedClosure: (() -> Void)?) {
         self.language = language
-        self.isSelected = isSelected
+        self._selectedLanguage = selectedLanguage
+        self.tappedClosure = tappedClosure
     }
     
     var body: some View {
@@ -49,5 +52,16 @@ struct ToolFilterLanguageSelectionRowView: View {
             
             Spacer()
         }
+        .contentShape(Rectangle()) // This fixes tap area not taking entire card into account.  Noticeable in iOS 14.
+        .onTapGesture {
+            
+            selectedLanguage = language
+            
+            tappedClosure?()
+        }
+    }
+    
+    private var isSelected: Bool {
+        return selectedLanguage.id == language.id
     }
 }

--- a/godtools/App/Features/ToolsFilter/Presentation/ToolFilterLanguageSelectionView/Subviews/ToolFilterLanguageSelectionRowView/ToolFilterLanguageSelectionRowView.swift
+++ b/godtools/App/Features/ToolsFilter/Presentation/ToolFilterLanguageSelectionView/Subviews/ToolFilterLanguageSelectionRowView/ToolFilterLanguageSelectionRowView.swift
@@ -52,7 +52,7 @@ struct ToolFilterLanguageSelectionRowView: View {
             
             Spacer()
         }
-        .contentShape(Rectangle()) // This fixes tap area not taking entire card into account.  Noticeable in iOS 14.
+        .contentShape(Rectangle())
         .onTapGesture {
             
             selectedLanguage = language

--- a/godtools/App/Features/ToolsFilter/Presentation/ToolFilterLanguageSelectionView/ToolFilterLanguageSelectionView.swift
+++ b/godtools/App/Features/ToolsFilter/Presentation/ToolFilterLanguageSelectionView/ToolFilterLanguageSelectionView.swift
@@ -28,17 +28,13 @@ struct ToolFilterLanguageSelectionView: View {
             List {
                 ForEach(viewModel.languageSearchResults, id: \.filterId) { language in
                     
-                    Button {
-                        
-                        viewModel.rowTapped(with: language)
-                        
-                    } label: {
-                        
-                        ToolFilterLanguageSelectionRowView(
-                            language: language,
-                            isSelected: viewModel.selectedLanguage.id == language.id
-                        )
-                    }
+                    ToolFilterLanguageSelectionRowView(
+                        language: language,
+                        selectedLanguage: $viewModel.selectedLanguage,
+                        tappedClosure: {
+                            viewModel.languageTapped(with: language)
+                        }
+                    )
                 }
             }
             .listStyle(.inset)

--- a/godtools/App/Features/ToolsFilter/Presentation/ToolFilterLanguageSelectionView/ToolFilterLanguageSelectionViewModel.swift
+++ b/godtools/App/Features/ToolsFilter/Presentation/ToolFilterLanguageSelectionView/ToolFilterLanguageSelectionViewModel.swift
@@ -23,14 +23,13 @@ class ToolFilterLanguageSelectionViewModel: ObservableObject {
     private var cancellables: Set<AnyCancellable> = Set()
     private weak var flowDelegate: FlowDelegate?
     
-    let selectedLanguage: LanguageFilterDomainModel
-    
     @Published private var appLanguage: AppLanguageDomainModel = LanguageCodeDomainModel.english.rawValue
     
     @Published private var allLanguages: [LanguageFilterDomainModel] = [LanguageFilterDomainModel]()
     @Published var languageSearchResults: [LanguageFilterDomainModel] = [LanguageFilterDomainModel]()
     @Published var searchText: String = ""
     @Published var navTitle: String = ""
+    @Published var selectedLanguage: LanguageFilterDomainModel
     
     init(viewToolFilterLanguagesUseCase: ViewToolFilterLanguagesUseCase,  searchToolFilterLanguagesUseCase: SearchToolFilterLanguagesUseCase, storeUserFilterUseCase: StoreUserFiltersUseCase, getInterfaceStringInAppLanguageUseCase: GetInterfaceStringInAppLanguageUseCase, getCurrentAppLanguageUseCase: GetCurrentAppLanguageUseCase, viewSearchBarUseCase: ViewSearchBarUseCase, languageFilterSelectionPublisher: CurrentValueSubject<LanguageFilterDomainModel, Never>, selectedCategory: CategoryFilterDomainModel, flowDelegate: FlowDelegate) {
         
@@ -76,6 +75,14 @@ class ToolFilterLanguageSelectionViewModel: ObservableObject {
         }
         .receive(on: DispatchQueue.main)
         .assign(to: &$languageSearchResults)
+        
+        $selectedLanguage
+            .eraseToAnyPublisher()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] value in
+                self?.languageFilterSelectionPublisher.send(value)
+            }
+            .store(in: &cancellables)
     }
     
     deinit {
@@ -95,10 +102,8 @@ extension ToolFilterLanguageSelectionViewModel {
         )
     }
         
-    func rowTapped(with language: LanguageFilterDomainModel) {
-                
-        languageFilterSelectionPublisher.send(language)
-        
+    func languageTapped(with language: LanguageFilterDomainModel) {
+                        
         storeUserFilterUseCase.storeLanguageFilterPublisher(with: language.id)
             .sink { _ in
                 


### PR DESCRIPTION
Hey @rachaelblue here's an example using Binding.  I prefer this approach to using the custom ```CombineObservableValue```.  I really don't want to introduce another type for SwiftUI and Combine.

The trick was I had to move your Button handling inside the Row views.  This way the selectedCategory and selectedLanguage could be set to the Row's category and language value.  This allows isSelected to also be handled within the Row views now that it is Binding to the selectedCategory and selectedLanguage.

Then in the ViewModel I added a sink on the Published properties for selectedCategory and selectedLanguage to update the CurrentValueSubject.