### PR TITLE
GT-2254 update string localized and date formatting locale for app language

### DIFF
--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -669,6 +669,7 @@
 		45860A8C29242DC30089C836 /* AccountGlobalActivityAnalyticsItemViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45860A8B29242DC30089C836 /* AccountGlobalActivityAnalyticsItemViewModel.swift */; };
 		45860A95292437420089C836 /* DownloadProgressView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 45860A93292437420089C836 /* DownloadProgressView.xib */; };
 		45860A96292437420089C836 /* DownloadProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45860A94292437420089C836 /* DownloadProgressView.swift */; };
+		458A2E582BACBBEB00F00704 /* String+Format.swift in Sources */ = {isa = PBXBuildFile; fileRef = 458A2E572BACBBEB00F00704 /* String+Format.swift */; };
 		458B91AA2B7D5D6800785C6F /* FavoritesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 458B91922B7D5D6700785C6F /* FavoritesViewModel.swift */; };
 		458B91AB2B7D5D6800785C6F /* FavoritesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 458B91932B7D5D6700785C6F /* FavoritesView.swift */; };
 		458B91AC2B7D5D6800785C6F /* OpenTutorialBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 458B91962B7D5D6700785C6F /* OpenTutorialBannerView.swift */; };
@@ -2196,6 +2197,7 @@
 		45860A8B29242DC30089C836 /* AccountGlobalActivityAnalyticsItemViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountGlobalActivityAnalyticsItemViewModel.swift; sourceTree = "<group>"; };
 		45860A93292437420089C836 /* DownloadProgressView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = DownloadProgressView.xib; sourceTree = "<group>"; };
 		45860A94292437420089C836 /* DownloadProgressView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DownloadProgressView.swift; sourceTree = "<group>"; };
+		458A2E572BACBBEB00F00704 /* String+Format.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+Format.swift"; sourceTree = "<group>"; };
 		458B91922B7D5D6700785C6F /* FavoritesViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FavoritesViewModel.swift; sourceTree = "<group>"; };
 		458B91932B7D5D6700785C6F /* FavoritesView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FavoritesView.swift; sourceTree = "<group>"; };
 		458B91962B7D5D6700785C6F /* OpenTutorialBannerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpenTutorialBannerView.swift; sourceTree = "<group>"; };
@@ -5012,6 +5014,7 @@
 		45430CF42B1FB62A002B94A3 /* String */ = {
 			isa = PBXGroup;
 			children = (
+				458A2E572BACBBEB00F00704 /* String+Format.swift */,
 				45430CF52B1FB638002B94A3 /* String+ToUrlMarkdown.swift */,
 				45D00A192B1FD0E3007D2B65 /* String+ParseUrls.swift */,
 			);
@@ -11792,6 +11795,7 @@
 				45D814DB2B8105BE00AD00C5 /* GetSpotlightToolsRepositoryInterface.swift in Sources */,
 				45070A7F2ACF42AD00229EDD /* AppLayoutDirectionBasedBarItem.swift in Sources */,
 				45AC9DDD2B28A98800DEEBFE /* DownloadableLanguageListItemDomainModel.swift in Sources */,
+				458A2E582BACBBEB00F00704 /* String+Format.swift in Sources */,
 				45558405269F2DA500C3FF14 /* MobileContentPagesView.swift in Sources */,
 				4504BA2C2AF3EEE5001151E5 /* TutorialFeatureDiContainer.swift in Sources */,
 				45227BB02A1D030D0021C131 /* DeleteAccountProgressViewModel.swift in Sources */,

--- a/godtools/App/Features/AppLanguage/Data-DomainInterface/GetDownloadableLanguagesListRepository.swift
+++ b/godtools/App/Features/AppLanguage/Data-DomainInterface/GetDownloadableLanguagesListRepository.swift
@@ -98,7 +98,11 @@ extension GetDownloadableLanguagesListRepository {
             fileType: .stringsdict
         )
         
-        return String.localizedStringWithFormat(formatString, numberOfTools)
+        return String.localizedStringWithFormat(
+            format: formatString,
+            localeIdentifier: translationLanguage,
+            arguments: numberOfTools
+        )
     }
     
     private func getDownloadStatus(for languageId: String) -> LanguageDownloadStatusDomainModel {

--- a/godtools/App/Features/Menu/Data-DomainInterface/GetAccountInterfaceStringsRepository.swift
+++ b/godtools/App/Features/Menu/Data-DomainInterface/GetAccountInterfaceStringsRepository.swift
@@ -38,8 +38,11 @@ class GetAccountInterfaceStringsRepository: GetAccountInterfaceStringsRepository
     
         let localizedGlobalActivityTitle = localizationServices.stringForLocaleElseEnglish(localeIdentifier: localeId, key: MenuStringKeys.Account.globalAnalyticsTitle.rawValue)
         
+        var calendar: Calendar = Calendar.current
+        calendar.locale = Locale(identifier: localeId)
+        
         let todaysDate: Date = Date()
-        let todaysYearComponents: DateComponents = Calendar.current.dateComponents([.year], from: todaysDate)
+        let todaysYearComponents: DateComponents = calendar.dateComponents([.year], from: todaysDate)
                 
         if let year = todaysYearComponents.year {
             return "\(year) \(localizedGlobalActivityTitle)"

--- a/godtools/App/Features/Menu/Domain/UseCases/GetUserAccountDetailsUseCase/GetUserAccountDetailsUseCase.swift
+++ b/godtools/App/Features/Menu/Domain/UseCases/GetUserAccountDetailsUseCase/GetUserAccountDetailsUseCase.swift
@@ -86,12 +86,17 @@ class GetUserAccountDetailsUseCase {
         }
         
         let dateFormatter = DateFormatter()
+        dateFormatter.locale = Locale(identifier: translatedInAppLanguage)
         dateFormatter.dateStyle = .medium
         dateFormatter.timeStyle = .none
         
         let formattedCreatedAtDateString: String = dateFormatter.string(from: createdAtDate)
         
-        let joinedOnString: String = String.localizedStringWithFormat(localizationServices.stringForLocaleElseEnglish(localeIdentifier: translatedInAppLanguage.localeId, key: "account.joinedOn"), formattedCreatedAtDateString)
+        let joinedOnString: String = String.localizedStringWithFormat(
+            format: localizationServices.stringForLocaleElseEnglish(localeIdentifier: translatedInAppLanguage.localeId, key: "account.joinedOn"),
+            localeIdentifier: translatedInAppLanguage,
+            arguments: formattedCreatedAtDateString
+        )
         
         return joinedOnString
     }

--- a/godtools/App/Features/Menu/Domain/UseCases/GetUserActivityBadgeUseCase/GetUserActivityBadgeUseCase.swift
+++ b/godtools/App/Features/Menu/Domain/UseCases/GetUserActivityBadgeUseCase/GetUserActivityBadgeUseCase.swift
@@ -84,8 +84,12 @@ class GetUserActivityBadgeUseCase {
             fileType: .stringsdict
         )
         
-        let badgeText: String = String.localizedStringWithFormat(formatString, progressTarget)
-        
+        let badgeText: String = String.localizedStringWithFormat(
+            format: formatString,
+            localeIdentifier: translatedInAppLanguage,
+            arguments: progressTarget
+        )
+
         return badgeText
     }
     

--- a/godtools/App/Features/Menu/Domain/UseCases/GetUserActivityStatsUseCase/GetUserActivityStatsUseCase.swift
+++ b/godtools/App/Features/Menu/Domain/UseCases/GetUserActivityStatsUseCase/GetUserActivityStatsUseCase.swift
@@ -74,6 +74,10 @@ class GetUserActivityStatsUseCase {
             fileType: .stringsdict
         )
         
-        return String.localizedStringWithFormat(formatString, activityCount)
+        return String.localizedStringWithFormat(
+            format: formatString,
+            localeIdentifier: translatedInAppLanguage,
+            arguments: activityCount
+        )
     }
 }

--- a/godtools/App/Features/ToolSettings/Data-DomainInterface/GetShareToolInterfaceStringsRepository.swift
+++ b/godtools/App/Features/ToolSettings/Data-DomainInterface/GetShareToolInterfaceStringsRepository.swift
@@ -39,9 +39,13 @@ class GetShareToolInterfaceStringsRepository: GetShareToolInterfaceStringsReposi
         }
         
         toolUrl = toolUrl.replacingOccurrences(of: " ", with: "").appending("?icid=gtshare ")
-
-        let shareMessageWithToolUrl: String = String.localizedStringWithFormat(localizedShareToolMessage, toolUrl)
         
+        let shareMessageWithToolUrl = String.localizedStringWithFormat(
+            format: localizedShareToolMessage,
+            localeIdentifier: translateInLanguage,
+            arguments: toolUrl
+        )
+
         let interfaceStrings = ShareToolInterfaceStringsDomainModel(
             shareMessage: shareMessageWithToolUrl
         )

--- a/godtools/App/Features/ToolsFilter/Data-DomainInterface/GetToolFilterCategoriesRepository.swift
+++ b/godtools/App/Features/ToolsFilter/Data-DomainInterface/GetToolFilterCategoriesRepository.swift
@@ -124,7 +124,11 @@ extension GetToolFilterCategoriesRepository {
             fileType: .stringsdict
         )
         
-        return String.localizedStringWithFormat(formatString, toolsAvailableCount)
+        return String.localizedStringWithFormat(
+            format: formatString,
+            localeIdentifier: translatedInAppLanguage,
+            arguments: toolsAvailableCount
+        )
     }
 }
 

--- a/godtools/App/Features/ToolsFilter/Data-DomainInterface/GetToolFilterLanguagesRepository.swift
+++ b/godtools/App/Features/ToolsFilter/Data-DomainInterface/GetToolFilterLanguagesRepository.swift
@@ -155,7 +155,11 @@ extension GetToolFilterLanguagesRepository {
             fileType: .stringsdict
         )
         
-        return String.localizedStringWithFormat(formatString, toolsAvailableCount)
+        return String.localizedStringWithFormat(
+            format: formatString,
+            localeIdentifier: translatedInAppLanguage,
+            arguments: toolsAvailableCount
+        )
     }
 }
 

--- a/godtools/App/Flows/ToolScreenShare/ToolScreenShareFlow.swift
+++ b/godtools/App/Flows/ToolScreenShare/ToolScreenShareFlow.swift
@@ -318,10 +318,11 @@ extension ToolScreenShareFlow {
         let interfaceStrings: ShareToolScreenShareSessionInterfaceStringsDomainModel = domainModel.interfaceStrings
         
         let shareMessage: String = String.localizedStringWithFormat(
-            interfaceStrings.shareMessage,
-            shareUrl
+            format: interfaceStrings.shareMessage, 
+            localeIdentifier: appLanguage,
+            arguments: shareUrl
         )
-        
+
         let viewModel = ShareToolScreenShareSessionViewModel(
             shareMessage: shareMessage,
             trackActionAnalyticsUseCase: appDiContainer.domainLayer.getTrackActionAnalyticsUseCase()

--- a/godtools/App/Share/Common/SharedAppleExtensions/Swift/String/String+Format.swift
+++ b/godtools/App/Share/Common/SharedAppleExtensions/Swift/String/String+Format.swift
@@ -1,0 +1,17 @@
+//
+//  String+Format.swift
+//  godtools
+//
+//  Created by Levi Eggert on 3/19/24.
+//  Copyright © 2024 Cru. All rights reserved.
+//
+
+import Foundation
+
+extension String {
+    
+    public static func localizedStringWithFormat(format: String, localeIdentifier: String, arguments: CVarArg...) -> String {
+        
+        return String(format: format, locale: Locale(identifier: localeIdentifier), arguments)
+    }
+}


### PR DESCRIPTION
Updated some of our formatting to be based on the provide localeId / translate in language.

- Updated Calendar.current to use Calendar based on provided locale.
- Updated DateFormatter locale to be based on translate in app language.
- Updated String.localizedStringWithFormat to be based on locale to translate language in (app language).