### PR TITLE
GT-2298 tools filter remove deprecations

### DIFF
--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -1475,6 +1475,9 @@
 		D496B9062A9E702200CBEA19 /* SearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = D496B9052A9E702200CBEA19 /* SearchBar.swift */; };
 		D496B90E2A9FD39500CBEA19 /* ToolFilterSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = D496B90D2A9FD39500CBEA19 /* ToolFilterSelection.swift */; };
 		D4997E0E28D4CED800205B4C /* YouTubeiOSPlayerHelper in Frameworks */ = {isa = PBXBuildFile; productRef = D4997E0D28D4CED800205B4C /* YouTubeiOSPlayerHelper */; };
+		D4AFA4452BAC93B400318023 /* ToolFilterLanguagesInterfaceStringsDomainModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4AFA4442BAC93B400318023 /* ToolFilterLanguagesInterfaceStringsDomainModel.swift */; };
+		D4AFA4472BAC950800318023 /* GetToolFilterLanguagesInterfaceStringsRepositoryInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4AFA4462BAC950800318023 /* GetToolFilterLanguagesInterfaceStringsRepositoryInterface.swift */; };
+		D4AFA4492BAC955E00318023 /* GetToolFilterLanguagesInterfaceStringsRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4AFA4482BAC955E00318023 /* GetToolFilterLanguagesInterfaceStringsRepository.swift */; };
 		D4B05FF529106212005852D0 /* MobileContentAuthTokenRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B05FF429106212005852D0 /* MobileContentAuthTokenRepository.swift */; };
 		D4B05FF929106462005852D0 /* MobileContentAuthTokenAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B05FF829106462005852D0 /* MobileContentAuthTokenAPI.swift */; };
 		D4B05FFF2911BAE2005852D0 /* MobileContentAuthTokenDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B05FFE2911BAE2005852D0 /* MobileContentAuthTokenDecodable.swift */; };
@@ -3017,6 +3020,9 @@
 		D487087EDFEFD1AF7B39128C /* Pods_godtoolsTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_godtoolsTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D496B9052A9E702200CBEA19 /* SearchBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBar.swift; sourceTree = "<group>"; };
 		D496B90D2A9FD39500CBEA19 /* ToolFilterSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolFilterSelection.swift; sourceTree = "<group>"; };
+		D4AFA4442BAC93B400318023 /* ToolFilterLanguagesInterfaceStringsDomainModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolFilterLanguagesInterfaceStringsDomainModel.swift; sourceTree = "<group>"; };
+		D4AFA4462BAC950800318023 /* GetToolFilterLanguagesInterfaceStringsRepositoryInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetToolFilterLanguagesInterfaceStringsRepositoryInterface.swift; sourceTree = "<group>"; };
+		D4AFA4482BAC955E00318023 /* GetToolFilterLanguagesInterfaceStringsRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetToolFilterLanguagesInterfaceStringsRepository.swift; sourceTree = "<group>"; };
 		D4B05FF429106212005852D0 /* MobileContentAuthTokenRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileContentAuthTokenRepository.swift; sourceTree = "<group>"; };
 		D4B05FF829106462005852D0 /* MobileContentAuthTokenAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileContentAuthTokenAPI.swift; sourceTree = "<group>"; };
 		D4B05FFE2911BAE2005852D0 /* MobileContentAuthTokenDecodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileContentAuthTokenDecodable.swift; sourceTree = "<group>"; };
@@ -4149,6 +4155,7 @@
 				45B6FF392BAA39840037B240 /* SearchToolFilterCategoriesRepository.swift */,
 				45B6FF382BAA39840037B240 /* SearchToolFilterLanguagesRepository.swift */,
 				452486DF2B07C9A5007AD932 /* StoreUserFiltersRepository.swift */,
+				D4AFA4482BAC955E00318023 /* GetToolFilterLanguagesInterfaceStringsRepository.swift */,
 			);
 			path = "Data-DomainInterface";
 			sourceTree = "<group>";
@@ -4167,6 +4174,7 @@
 			isa = PBXGroup;
 			children = (
 				45B6FF2D2BAA39710037B240 /* GetToolFilterCategoriesRepositoryInterface.swift */,
+				D4AFA4462BAC950800318023 /* GetToolFilterLanguagesInterfaceStringsRepositoryInterface.swift */,
 				45B6FF2E2BAA39710037B240 /* GetToolFilterLanguagesRepositoryInterface.swift */,
 				452486D02B07C98B007AD932 /* GetUserFiltersRepositoryInterface.swift */,
 				45B6FF2F2BAA39710037B240 /* SearchToolFilterCategoriesRepositoryInterface.swift */,
@@ -4194,6 +4202,7 @@
 			children = (
 				452486D52B07C991007AD932 /* CategoryFilterDomainModel.swift */,
 				452486D62B07C991007AD932 /* LanguageFilterDomainModel.swift */,
+				D4AFA4442BAC93B400318023 /* ToolFilterLanguagesInterfaceStringsDomainModel.swift */,
 				452486D42B07C991007AD932 /* UserFiltersDomainModel.swift */,
 				45B6FF342BAA39790037B240 /* ViewToolFilterCategoriesDomainModel.swift */,
 				45B6FF352BAA39790037B240 /* ViewToolFilterLanguagesDomainModel.swift */,
@@ -11429,6 +11438,7 @@
 				45D63E86288F75B0009B4610 /* RealmAttachment.swift in Sources */,
 				45C649C22B31E212000249E0 /* GetShareToolInterfaceStringsRepositoryInterface.swift in Sources */,
 				45A8BDE32ACC9F47007A1EBB /* LessonsViewModel.swift in Sources */,
+				D4AFA4452BAC93B400318023 /* ToolFilterLanguagesInterfaceStringsDomainModel.swift in Sources */,
 				45EA5AAE2B22481700D9E330 /* ToolSettingsDiContainer.swift in Sources */,
 				45B6FF492BAA39DE0037B240 /* SearchAppLanguageInAppLanguagesListRepositoryInterface.swift in Sources */,
 				45E39EC927457A14006A59E4 /* AnimatedView.swift in Sources */,
@@ -11643,6 +11653,7 @@
 				45860A512923E73A0089C836 /* AccountUserDetailsView.swift in Sources */,
 				458CFE8D29D4E0B9007B423C /* LoadingArticleView.swift in Sources */,
 				454B47E22AE0228200C7B5E7 /* GetOnboardingTutorialInterfaceStringsRepository.swift in Sources */,
+				D4AFA4492BAC955E00318023 /* GetToolFilterLanguagesInterfaceStringsRepository.swift in Sources */,
 				45039E122B1F5AEA009E1D96 /* ViewToolDetailsDomainModel.swift in Sources */,
 				45F7162C290A12D70019B715 /* ShareAStoryWithUsWebContent.swift in Sources */,
 				D47DF0422B28F94A0079219B /* RealmDownloadedLanguage.swift in Sources */,
@@ -11997,6 +12008,7 @@
 				450D7B0528E32965006C3FDF /* DownloadedTranslationDataModelType.swift in Sources */,
 				45AD1F7425938A9800A096A0 /* ViewedTrainingTipsCacheType.swift in Sources */,
 				D43FC1CA2B6997B600F8310E /* GetDownloadedLanguagesListRepository.swift in Sources */,
+				D4AFA4472BAC950800318023 /* GetToolFilterLanguagesInterfaceStringsRepositoryInterface.swift in Sources */,
 				456D44382AF2A457008F61B9 /* AuthenticateUserInterface.swift in Sources */,
 				45F379092B23642C00EEF039 /* ViewLearnToShareToolDomainModel.swift in Sources */,
 				453F84D12A029FC00005101E /* ArticleAemDownloadGetCacheTimeInterval.swift in Sources */,

--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -1478,6 +1478,9 @@
 		D4AFA4452BAC93B400318023 /* ToolFilterLanguagesInterfaceStringsDomainModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4AFA4442BAC93B400318023 /* ToolFilterLanguagesInterfaceStringsDomainModel.swift */; };
 		D4AFA4472BAC950800318023 /* GetToolFilterLanguagesInterfaceStringsRepositoryInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4AFA4462BAC950800318023 /* GetToolFilterLanguagesInterfaceStringsRepositoryInterface.swift */; };
 		D4AFA4492BAC955E00318023 /* GetToolFilterLanguagesInterfaceStringsRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4AFA4482BAC955E00318023 /* GetToolFilterLanguagesInterfaceStringsRepository.swift */; };
+		D4AFA44B2BAD0A1B00318023 /* ToolFilterCategoriesInterfaceStringsDomainModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4AFA44A2BAD0A1B00318023 /* ToolFilterCategoriesInterfaceStringsDomainModel.swift */; };
+		D4AFA44D2BAD0A4500318023 /* GetToolFilterCategoriesInterfaceStringsRepositoryInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4AFA44C2BAD0A4500318023 /* GetToolFilterCategoriesInterfaceStringsRepositoryInterface.swift */; };
+		D4AFA44F2BAD0A9200318023 /* GetToolFilterCategoriesInterfaceStringsRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4AFA44E2BAD0A9200318023 /* GetToolFilterCategoriesInterfaceStringsRepository.swift */; };
 		D4B05FF529106212005852D0 /* MobileContentAuthTokenRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B05FF429106212005852D0 /* MobileContentAuthTokenRepository.swift */; };
 		D4B05FF929106462005852D0 /* MobileContentAuthTokenAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B05FF829106462005852D0 /* MobileContentAuthTokenAPI.swift */; };
 		D4B05FFF2911BAE2005852D0 /* MobileContentAuthTokenDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B05FFE2911BAE2005852D0 /* MobileContentAuthTokenDecodable.swift */; };
@@ -3023,6 +3026,9 @@
 		D4AFA4442BAC93B400318023 /* ToolFilterLanguagesInterfaceStringsDomainModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolFilterLanguagesInterfaceStringsDomainModel.swift; sourceTree = "<group>"; };
 		D4AFA4462BAC950800318023 /* GetToolFilterLanguagesInterfaceStringsRepositoryInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetToolFilterLanguagesInterfaceStringsRepositoryInterface.swift; sourceTree = "<group>"; };
 		D4AFA4482BAC955E00318023 /* GetToolFilterLanguagesInterfaceStringsRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetToolFilterLanguagesInterfaceStringsRepository.swift; sourceTree = "<group>"; };
+		D4AFA44A2BAD0A1B00318023 /* ToolFilterCategoriesInterfaceStringsDomainModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolFilterCategoriesInterfaceStringsDomainModel.swift; sourceTree = "<group>"; };
+		D4AFA44C2BAD0A4500318023 /* GetToolFilterCategoriesInterfaceStringsRepositoryInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetToolFilterCategoriesInterfaceStringsRepositoryInterface.swift; sourceTree = "<group>"; };
+		D4AFA44E2BAD0A9200318023 /* GetToolFilterCategoriesInterfaceStringsRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetToolFilterCategoriesInterfaceStringsRepository.swift; sourceTree = "<group>"; };
 		D4B05FF429106212005852D0 /* MobileContentAuthTokenRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileContentAuthTokenRepository.swift; sourceTree = "<group>"; };
 		D4B05FF829106462005852D0 /* MobileContentAuthTokenAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileContentAuthTokenAPI.swift; sourceTree = "<group>"; };
 		D4B05FFE2911BAE2005852D0 /* MobileContentAuthTokenDecodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileContentAuthTokenDecodable.swift; sourceTree = "<group>"; };
@@ -4149,13 +4155,14 @@
 		4524869F2B07C894007AD932 /* Data-DomainInterface */ = {
 			isa = PBXGroup;
 			children = (
+				D4AFA44E2BAD0A9200318023 /* GetToolFilterCategoriesInterfaceStringsRepository.swift */,
 				45B6FF3A2BAA39840037B240 /* GetToolFilterCategoriesRepository.swift */,
+				D4AFA4482BAC955E00318023 /* GetToolFilterLanguagesInterfaceStringsRepository.swift */,
 				45B6FF3B2BAA39840037B240 /* GetToolFilterLanguagesRepository.swift */,
 				452486DE2B07C9A5007AD932 /* GetUserFiltersRepository.swift */,
 				45B6FF392BAA39840037B240 /* SearchToolFilterCategoriesRepository.swift */,
 				45B6FF382BAA39840037B240 /* SearchToolFilterLanguagesRepository.swift */,
 				452486DF2B07C9A5007AD932 /* StoreUserFiltersRepository.swift */,
-				D4AFA4482BAC955E00318023 /* GetToolFilterLanguagesInterfaceStringsRepository.swift */,
 			);
 			path = "Data-DomainInterface";
 			sourceTree = "<group>";
@@ -4173,6 +4180,7 @@
 		452486A12B07C894007AD932 /* Interface */ = {
 			isa = PBXGroup;
 			children = (
+				D4AFA44C2BAD0A4500318023 /* GetToolFilterCategoriesInterfaceStringsRepositoryInterface.swift */,
 				45B6FF2D2BAA39710037B240 /* GetToolFilterCategoriesRepositoryInterface.swift */,
 				D4AFA4462BAC950800318023 /* GetToolFilterLanguagesInterfaceStringsRepositoryInterface.swift */,
 				45B6FF2E2BAA39710037B240 /* GetToolFilterLanguagesRepositoryInterface.swift */,
@@ -4202,6 +4210,7 @@
 			children = (
 				452486D52B07C991007AD932 /* CategoryFilterDomainModel.swift */,
 				452486D62B07C991007AD932 /* LanguageFilterDomainModel.swift */,
+				D4AFA44A2BAD0A1B00318023 /* ToolFilterCategoriesInterfaceStringsDomainModel.swift */,
 				D4AFA4442BAC93B400318023 /* ToolFilterLanguagesInterfaceStringsDomainModel.swift */,
 				452486D42B07C991007AD932 /* UserFiltersDomainModel.swift */,
 				45B6FF342BAA39790037B240 /* ViewToolFilterCategoriesDomainModel.swift */,
@@ -11922,6 +11931,7 @@
 				D4C14E9229411A35001465F1 /* MobileContentAuthTokenDataModel.swift in Sources */,
 				459BF77F2AFEE0320053BA09 /* RealmToolScreenShareTutorialViewsCache.swift in Sources */,
 				45EA98FC2AFD683100E7EA9A /* CreatingToolScreenShareSessionTimedOutDomainModel.swift in Sources */,
+				D4AFA44D2BAD0A4500318023 /* GetToolFilterCategoriesInterfaceStringsRepositoryInterface.swift in Sources */,
 				453C9D192A97C11700177499 /* MobileContentViewRenderer.swift in Sources */,
 				45AE973B27C97A9400C2CB33 /* MultiplatformHeading.swift in Sources */,
 				4512D4E02B29129100DFAFB3 /* ToolSettingsToolLanguagesListView.swift in Sources */,
@@ -12255,6 +12265,7 @@
 				4581D97F297AD21E00D056D6 /* JsonApiResponseData.swift in Sources */,
 				456D44362AF290F6008F61B9 /* SocialSignInButtonType.swift in Sources */,
 				45920D592A8D4F2800E336A8 /* ToolCardLayout.swift in Sources */,
+				D4AFA44B2BAD0A1B00318023 /* ToolFilterCategoriesInterfaceStringsDomainModel.swift in Sources */,
 				454ADAD62ABDD9D400037C27 /* AppInterfaceLanguageButtonView.swift in Sources */,
 				458CFE9B29D4E0B9007B423C /* ArticleCategoryCellViewModel.swift in Sources */,
 				D47DF0462B2A3D5D0079219B /* DownloadedLanguageDataModel.swift in Sources */,
@@ -12337,6 +12348,7 @@
 				45AC9DEC2B28A9CD00DEEBFE /* DownloadableLanguageItemView.swift in Sources */,
 				45AE974C27C97A9500C2CB33 /* Tabs+MobileContentRenderableModel.swift in Sources */,
 				45AE974427C97A9400C2CB33 /* Modal+MobileContentRenderableModel.swift in Sources */,
+				D4AFA44F2BAD0A9200318023 /* GetToolFilterCategoriesInterfaceStringsRepository.swift in Sources */,
 				4529B96E289345480011F16B /* TranslationManifestParserType.swift in Sources */,
 				4555840C269F2DA500C3FF14 /* MobileContentErrorViewModel.swift in Sources */,
 				45AD1BDA25938A4F00A096A0 /* AlertMessageViewModelType.swift in Sources */,

--- a/godtools/App/Features/ToolsFilter/Data-DomainInterface/GetToolFilterCategoriesInterfaceStringsRepository.swift
+++ b/godtools/App/Features/ToolsFilter/Data-DomainInterface/GetToolFilterCategoriesInterfaceStringsRepository.swift
@@ -1,0 +1,31 @@
+//
+//  GetToolFilterCategoriesInterfaceStringsRepository.swift
+//  godtools
+//
+//  Created by Rachael Skeath on 3/21/24.
+//  Copyright © 2024 Cru. All rights reserved.
+//
+
+import Foundation
+import Combine
+
+class GetToolFilterCategoriesInterfaceStringsRepository: GetToolFilterCategoriesInterfaceStringsRepositoryInterface {
+    
+    private let localizationServices: LocalizationServices
+    
+    init(localizationServices: LocalizationServices) {
+        self.localizationServices = localizationServices
+    }
+    
+    func getStringsPublisher(translateInAppLanguage: AppLanguageDomainModel) -> AnyPublisher<ToolFilterCategoriesInterfaceStringsDomainModel, Never> {
+        
+        let localeId: String = translateInAppLanguage.localeId
+
+        let interfaceStrings = ToolFilterCategoriesInterfaceStringsDomainModel(
+            navTitle: localizationServices.stringForLocaleElseEnglish(localeIdentifier: localeId, key: ToolStringKeys.ToolFilter.categoryFilterNavTitle.rawValue)
+        )
+        
+        return Just(interfaceStrings)
+            .eraseToAnyPublisher()
+    }
+}

--- a/godtools/App/Features/ToolsFilter/Data-DomainInterface/GetToolFilterLanguagesInterfaceStringsRepository.swift
+++ b/godtools/App/Features/ToolsFilter/Data-DomainInterface/GetToolFilterLanguagesInterfaceStringsRepository.swift
@@ -1,0 +1,31 @@
+//
+//  GetToolFilterLanguagesInterfaceStringsRepository.swift
+//  godtools
+//
+//  Created by Rachael Skeath on 3/21/24.
+//  Copyright © 2024 Cru. All rights reserved.
+//
+
+import Foundation
+import Combine
+
+class GetToolFilterLanguagesInterfaceStringsRepository: GetToolFilterLanguagesInterfaceStringsRepositoryInterface {
+    
+    private let localizationServices: LocalizationServices
+    
+    init(localizationServices: LocalizationServices) {
+        self.localizationServices = localizationServices
+    }
+    
+    func getStringsPublisher(translateInAppLanguage: AppLanguageDomainModel) -> AnyPublisher<ToolFilterLanguagesInterfaceStringsDomainModel, Never> {
+        
+        let localeId: String = translateInAppLanguage.localeId
+        
+        let interfaceStrings = ToolFilterLanguagesInterfaceStringsDomainModel(
+            navTitle: localizationServices.stringForLocaleElseEnglish(localeIdentifier: localeId, key: ToolStringKeys.ToolFilter.languageFilterNavTitle.rawValue)
+        )
+        
+        return Just(interfaceStrings)
+            .eraseToAnyPublisher()
+    }
+}

--- a/godtools/App/Features/ToolsFilter/DependencyContainer/ToolsFilterFeatureDataLayerDependencies.swift
+++ b/godtools/App/Features/ToolsFilter/DependencyContainer/ToolsFilterFeatureDataLayerDependencies.swift
@@ -35,6 +35,12 @@ class ToolsFilterFeatureDataLayerDependencies {
         )
     }
     
+    func getToolFilterCategoriesInterfaceStringsRepository() -> GetToolFilterCategoriesInterfaceStringsRepository {
+        return GetToolFilterCategoriesInterfaceStringsRepository(
+            localizationServices: coreDataLayer.getLocalizationServices()
+        )
+    }
+    
     func getToolFilterLanguagesRepository() -> GetToolFilterLanguagesRepository {
         return GetToolFilterLanguagesRepository(
             resourcesRepository: coreDataLayer.getResourcesRepository(),
@@ -70,6 +76,10 @@ class ToolsFilterFeatureDataLayerDependencies {
     
     func getToolFilterCategoriesRepositoryInterface() -> GetToolFilterCategoriesRepositoryInterface {
         return getToolFilterCategoriesRepository()
+    }
+    
+    func getToolFilterCategoriesInterfaceStringsRepositoryInterface() ->  GetToolFilterCategoriesInterfaceStringsRepositoryInterface {
+        return getToolFilterCategoriesInterfaceStringsRepository()
     }
     
     func getToolFilterLanguagesRepositoryInterface() -> GetToolFilterLanguagesRepositoryInterface {

--- a/godtools/App/Features/ToolsFilter/DependencyContainer/ToolsFilterFeatureDataLayerDependencies.swift
+++ b/godtools/App/Features/ToolsFilter/DependencyContainer/ToolsFilterFeatureDataLayerDependencies.swift
@@ -44,6 +44,12 @@ class ToolsFilterFeatureDataLayerDependencies {
         )
     }
     
+    func getToolFilterLanguagesInterfaceStringsRepository() -> GetToolFilterLanguagesInterfaceStringsRepository {
+        return GetToolFilterLanguagesInterfaceStringsRepository(
+            localizationServices: coreDataLayer.getLocalizationServices()
+        )
+    }
+    
     // MARK: - Domain Interface
     
     func getSearchToolFilterCategoriesRepositoryInterface() -> SearchToolFilterCategoriesRepositoryInterface {
@@ -68,6 +74,10 @@ class ToolsFilterFeatureDataLayerDependencies {
     
     func getToolFilterLanguagesRepositoryInterface() -> GetToolFilterLanguagesRepositoryInterface {
         return getToolFilterLanguagesRepository()
+    }
+    
+    func getToolFilterLanguagesInterfaceStringsRepositoryInterface() ->  GetToolFilterLanguagesInterfaceStringsRepositoryInterface {
+        return getToolFilterLanguagesInterfaceStringsRepository()
     }
     
     func getUserFiltersRepositoryInterface() -> GetUserFiltersRepositoryInterface {

--- a/godtools/App/Features/ToolsFilter/DependencyContainer/ToolsFilterFeatureDomainLayerDependencies.swift
+++ b/godtools/App/Features/ToolsFilter/DependencyContainer/ToolsFilterFeatureDomainLayerDependencies.swift
@@ -47,6 +47,7 @@ class ToolsFilterFeatureDomainLayerDependencies {
     
     func getViewToolFilterCategoriesUseCase() -> ViewToolFilterCategoriesUseCase {
         return ViewToolFilterCategoriesUseCase(
+            getInterfaceStringsRepository: dataLayer.getToolFilterCategoriesInterfaceStringsRepositoryInterface(), 
             getToolFilterCategoriesRepository: dataLayer.getToolFilterCategoriesRepositoryInterface()
         )
     }

--- a/godtools/App/Features/ToolsFilter/DependencyContainer/ToolsFilterFeatureDomainLayerDependencies.swift
+++ b/godtools/App/Features/ToolsFilter/DependencyContainer/ToolsFilterFeatureDomainLayerDependencies.swift
@@ -53,7 +53,8 @@ class ToolsFilterFeatureDomainLayerDependencies {
     
     func getViewToolFilterLanguagesUseCase() -> ViewToolFilterLanguagesUseCase {
         return ViewToolFilterLanguagesUseCase(
-            getToolFilterLanguagesRepository: dataLayer.getToolFilterLanguagesRepositoryInterface()
+            getToolFilterLanguagesRepository: dataLayer.getToolFilterLanguagesRepositoryInterface(),
+            getInterfaceStringsRepository: dataLayer.getToolFilterLanguagesInterfaceStringsRepositoryInterface()
         )
     }
 }

--- a/godtools/App/Features/ToolsFilter/Domain/Entities/ToolFilterCategoriesInterfaceStringsDomainModel.swift
+++ b/godtools/App/Features/ToolsFilter/Domain/Entities/ToolFilterCategoriesInterfaceStringsDomainModel.swift
@@ -1,0 +1,14 @@
+//
+//  ToolFilterCategoriesInterfaceStringsDomainModel.swift
+//  godtools
+//
+//  Created by Rachael Skeath on 3/21/24.
+//  Copyright © 2024 Cru. All rights reserved.
+//
+
+import Foundation
+
+struct ToolFilterCategoriesInterfaceStringsDomainModel {
+    
+    let navTitle: String
+}

--- a/godtools/App/Features/ToolsFilter/Domain/Entities/ToolFilterLanguagesInterfaceStringsDomainModel.swift
+++ b/godtools/App/Features/ToolsFilter/Domain/Entities/ToolFilterLanguagesInterfaceStringsDomainModel.swift
@@ -1,0 +1,14 @@
+//
+//  ToolFilterLanguagesInterfaceStringsDomainModel.swift
+//  godtools
+//
+//  Created by Rachael Skeath on 3/21/24.
+//  Copyright © 2024 Cru. All rights reserved.
+//
+
+import Foundation
+
+struct ToolFilterLanguagesInterfaceStringsDomainModel {
+    
+    let navTitle: String
+}

--- a/godtools/App/Features/ToolsFilter/Domain/Entities/ViewToolFilterCategoriesDomainModel.swift
+++ b/godtools/App/Features/ToolsFilter/Domain/Entities/ViewToolFilterCategoriesDomainModel.swift
@@ -10,5 +10,6 @@ import Foundation
 
 struct ViewToolFilterCategoriesDomainModel {
     
+    let interfaceStrings: ToolFilterCategoriesInterfaceStringsDomainModel
     let categoryFilters: [CategoryFilterDomainModel]
 }

--- a/godtools/App/Features/ToolsFilter/Domain/Entities/ViewToolFilterLanguagesDomainModel.swift
+++ b/godtools/App/Features/ToolsFilter/Domain/Entities/ViewToolFilterLanguagesDomainModel.swift
@@ -10,5 +10,6 @@ import Foundation
 
 struct ViewToolFilterLanguagesDomainModel {
     
+    let interfaceStrings: ToolFilterLanguagesInterfaceStringsDomainModel
     let languageFilters: [LanguageFilterDomainModel]
 }

--- a/godtools/App/Features/ToolsFilter/Domain/Interface/GetToolFilterCategoriesInterfaceStringsRepositoryInterface.swift
+++ b/godtools/App/Features/ToolsFilter/Domain/Interface/GetToolFilterCategoriesInterfaceStringsRepositoryInterface.swift
@@ -1,0 +1,15 @@
+//
+//  GetToolFilterCategoriesInterfaceStringsRepositoryInterface.swift
+//  godtools
+//
+//  Created by Rachael Skeath on 3/21/24.
+//  Copyright © 2024 Cru. All rights reserved.
+//
+
+import Foundation
+import Combine
+
+protocol GetToolFilterCategoriesInterfaceStringsRepositoryInterface {
+    
+    func getStringsPublisher(translateInAppLanguage: AppLanguageDomainModel) -> AnyPublisher<ToolFilterCategoriesInterfaceStringsDomainModel, Never>
+}

--- a/godtools/App/Features/ToolsFilter/Domain/Interface/GetToolFilterLanguagesInterfaceStringsRepositoryInterface.swift
+++ b/godtools/App/Features/ToolsFilter/Domain/Interface/GetToolFilterLanguagesInterfaceStringsRepositoryInterface.swift
@@ -1,0 +1,15 @@
+//
+//  GetToolFilterLanguagesInterfaceStringsRepositoryInterface.swift
+//  godtools
+//
+//  Created by Rachael Skeath on 3/21/24.
+//  Copyright © 2024 Cru. All rights reserved.
+//
+
+import Foundation
+import Combine
+
+protocol GetToolFilterLanguagesInterfaceStringsRepositoryInterface {
+    
+    func getStringsPublisher(translateInAppLanguage: AppLanguageDomainModel) -> AnyPublisher<ToolFilterLanguagesInterfaceStringsDomainModel, Never>
+}

--- a/godtools/App/Features/ToolsFilter/Domain/Interface/GetToolFilterLanguagesRepositoryInterface.swift
+++ b/godtools/App/Features/ToolsFilter/Domain/Interface/GetToolFilterLanguagesRepositoryInterface.swift
@@ -12,5 +12,4 @@ import Combine
 protocol GetToolFilterLanguagesRepositoryInterface {
     
     func getToolFilterLanguagesPublisher(translatedInAppLanguage: AppLanguageDomainModel, filteredByCategoryId: String?) -> AnyPublisher<[LanguageFilterDomainModel], Never>
-    func getAnyLanguageFilterDomainModel(translatedInAppLanguage: AppLanguageDomainModel) -> LanguageFilterDomainModel
 }

--- a/godtools/App/Features/ToolsFilter/Domain/UseCases/ViewToolFilterCategoriesUseCase.swift
+++ b/godtools/App/Features/ToolsFilter/Domain/UseCases/ViewToolFilterCategoriesUseCase.swift
@@ -11,22 +11,28 @@ import Combine
 
 class ViewToolFilterCategoriesUseCase {
     
+    private let getInterfaceStringsRepository: GetToolFilterCategoriesInterfaceStringsRepositoryInterface
     private let getToolFilterCategoriesRepository: GetToolFilterCategoriesRepositoryInterface
     
-    init(getToolFilterCategoriesRepository: GetToolFilterCategoriesRepositoryInterface) {
+    init(getInterfaceStringsRepository: GetToolFilterCategoriesInterfaceStringsRepositoryInterface, getToolFilterCategoriesRepository: GetToolFilterCategoriesRepositoryInterface) {
         
+        self.getInterfaceStringsRepository = getInterfaceStringsRepository
         self.getToolFilterCategoriesRepository = getToolFilterCategoriesRepository
     }
     
     func viewPublisher(filteredByLanguageId: String?, translatedInAppLanguage: AppLanguageDomainModel) -> AnyPublisher<ViewToolFilterCategoriesDomainModel, Never> {
         
-        return getToolFilterCategoriesRepository.getToolFilterCategoriesPublisher(translatedInAppLanguage: translatedInAppLanguage, filteredByLanguageId: filteredByLanguageId)
-            .map { categoryFilters in
+        return Publishers.CombineLatest(
+            getInterfaceStringsRepository.getStringsPublisher(translateInAppLanguage: translatedInAppLanguage),
+            getToolFilterCategoriesRepository.getToolFilterCategoriesPublisher(translatedInAppLanguage: translatedInAppLanguage, filteredByLanguageId: filteredByLanguageId)
+        )
+        .map { interfaceStrings, categoryFilters in
             
-                return ViewToolFilterCategoriesDomainModel(
-                    categoryFilters: categoryFilters
-                )
-            }
-            .eraseToAnyPublisher()
+            return ViewToolFilterCategoriesDomainModel(
+                interfaceStrings: interfaceStrings,
+                categoryFilters: categoryFilters
+            )
+        }
+        .eraseToAnyPublisher()
     }
 }

--- a/godtools/App/Features/ToolsFilter/Domain/UseCases/ViewToolFilterLanguagesUseCase.swift
+++ b/godtools/App/Features/ToolsFilter/Domain/UseCases/ViewToolFilterLanguagesUseCase.swift
@@ -12,21 +12,27 @@ import Combine
 class ViewToolFilterLanguagesUseCase {
     
     private let getToolFilterLanguagesRepository: GetToolFilterLanguagesRepositoryInterface
+    private let getInterfaceStringsRepository: GetToolFilterLanguagesInterfaceStringsRepositoryInterface
     
-    init(getToolFilterLanguagesRepository: GetToolFilterLanguagesRepositoryInterface) {
+    init(getToolFilterLanguagesRepository: GetToolFilterLanguagesRepositoryInterface, getInterfaceStringsRepository: GetToolFilterLanguagesInterfaceStringsRepositoryInterface) {
         
         self.getToolFilterLanguagesRepository = getToolFilterLanguagesRepository
+        self.getInterfaceStringsRepository = getInterfaceStringsRepository
     }
     
     func viewPublisher(filteredByCategoryId: String?, translatedInAppLanguage: AppLanguageDomainModel) -> AnyPublisher<ViewToolFilterLanguagesDomainModel, Never> {
         
-        return getToolFilterLanguagesRepository.getToolFilterLanguagesPublisher(translatedInAppLanguage: translatedInAppLanguage, filteredByCategoryId: filteredByCategoryId)
-            .map { languageFilters in
-                
-                return ViewToolFilterLanguagesDomainModel(
-                    languageFilters: languageFilters
-                )
-            }
-            .eraseToAnyPublisher()
+        return Publishers.CombineLatest(
+            getInterfaceStringsRepository.getStringsPublisher(translateInAppLanguage: translatedInAppLanguage),
+            getToolFilterLanguagesRepository.getToolFilterLanguagesPublisher(translatedInAppLanguage: translatedInAppLanguage, filteredByCategoryId: filteredByCategoryId)
+        )
+        .map { interfaceStrings, languageFilters in
+            
+            return ViewToolFilterLanguagesDomainModel(
+                interfaceStrings: interfaceStrings,
+                languageFilters: languageFilters
+            )
+        }
+        .eraseToAnyPublisher()
     }
 }

--- a/godtools/App/Features/ToolsFilter/Presentation/ToolFilterCategorySelectionView/ToolFilterCategorySelectionViewModel.swift
+++ b/godtools/App/Features/ToolsFilter/Presentation/ToolFilterCategorySelectionView/ToolFilterCategorySelectionViewModel.swift
@@ -14,7 +14,6 @@ class ToolFilterCategorySelectionViewModel: ObservableObject {
     private let viewToolFilterCategoriesUseCase: ViewToolFilterCategoriesUseCase
     private let searchToolFilterCategoriesUseCase: SearchToolFilterCategoriesUseCase
     private let storeUserFiltersUseCase: StoreUserFiltersUseCase
-    private let getInterfaceStringInAppLanguageUseCase: GetInterfaceStringInAppLanguageUseCase
     private let getCurrentAppLanguageUseCase: GetCurrentAppLanguageUseCase
     private let viewSearchBarUseCase: ViewSearchBarUseCase
     private let categoryFilterSelectionPublisher: CurrentValueSubject<CategoryFilterDomainModel, Never>
@@ -32,12 +31,11 @@ class ToolFilterCategorySelectionViewModel: ObservableObject {
     @Published var navTitle: String = ""
     @Published var categorySearchResults: [CategoryFilterDomainModel] = [CategoryFilterDomainModel]()
     
-    init(viewToolFilterCategoriesUseCase: ViewToolFilterCategoriesUseCase, searchToolFilterCategoriesUseCase: SearchToolFilterCategoriesUseCase, storeUserFiltersUseCase: StoreUserFiltersUseCase, categoryFilterSelectionPublisher: CurrentValueSubject<CategoryFilterDomainModel, Never>, selectedLanguage: LanguageFilterDomainModel, getInterfaceStringInAppLanguageUseCase: GetInterfaceStringInAppLanguageUseCase, getCurrentAppLanguageUseCase: GetCurrentAppLanguageUseCase, viewSearchBarUseCase: ViewSearchBarUseCase, flowDelegate: FlowDelegate) {
+    init(viewToolFilterCategoriesUseCase: ViewToolFilterCategoriesUseCase, searchToolFilterCategoriesUseCase: SearchToolFilterCategoriesUseCase, storeUserFiltersUseCase: StoreUserFiltersUseCase, categoryFilterSelectionPublisher: CurrentValueSubject<CategoryFilterDomainModel, Never>, selectedLanguage: LanguageFilterDomainModel, getCurrentAppLanguageUseCase: GetCurrentAppLanguageUseCase, viewSearchBarUseCase: ViewSearchBarUseCase, flowDelegate: FlowDelegate) {
         
         self.viewToolFilterCategoriesUseCase = viewToolFilterCategoriesUseCase
         self.searchToolFilterCategoriesUseCase = searchToolFilterCategoriesUseCase
         self.storeUserFiltersUseCase = storeUserFiltersUseCase
-        self.getInterfaceStringInAppLanguageUseCase = getInterfaceStringInAppLanguageUseCase
         self.categoryFilterSelectionPublisher = categoryFilterSelectionPublisher
         self.getCurrentAppLanguageUseCase = getCurrentAppLanguageUseCase
         self.viewSearchBarUseCase = viewSearchBarUseCase
@@ -56,15 +54,14 @@ class ToolFilterCategorySelectionViewModel: ObservableObject {
             }
             .receive(on: DispatchQueue.main)
             .sink { [weak self] viewCategoryFiltersDomainModel in
+                guard let self = self else { return }
                 
-                self?.allCategories = viewCategoryFiltersDomainModel.categoryFilters
+                let interfaceStrings = viewCategoryFiltersDomainModel.interfaceStrings
+                
+                self.navTitle = interfaceStrings.navTitle
+                self.allCategories = viewCategoryFiltersDomainModel.categoryFilters
             }
             .store(in: &cancellables)
-        
-        getInterfaceStringInAppLanguageUseCase
-            .getStringPublisher(id: ToolStringKeys.ToolFilter.categoryFilterNavTitle.rawValue)
-            .receive(on: DispatchQueue.main)
-            .assign(to: &$navTitle)
         
         Publishers.CombineLatest(
             $searchText.eraseToAnyPublisher(),

--- a/godtools/App/Features/ToolsFilter/Presentation/ToolFilterLanguageSelectionView/ToolFilterLanguageSelectionViewModel.swift
+++ b/godtools/App/Features/ToolsFilter/Presentation/ToolFilterLanguageSelectionView/ToolFilterLanguageSelectionViewModel.swift
@@ -14,7 +14,6 @@ class ToolFilterLanguageSelectionViewModel: ObservableObject {
     private let viewToolFilterLanguagesUseCase: ViewToolFilterLanguagesUseCase
     private let searchToolFilterLanguagesUseCase: SearchToolFilterLanguagesUseCase
     private let storeUserFilterUseCase: StoreUserFiltersUseCase
-    private let getInterfaceStringInAppLanguageUseCase: GetInterfaceStringInAppLanguageUseCase
     private let getCurrentAppLanguageUseCase: GetCurrentAppLanguageUseCase
     private let viewSearchBarUseCase: ViewSearchBarUseCase
     private let languageFilterSelectionPublisher: CurrentValueSubject<LanguageFilterDomainModel, Never>
@@ -32,12 +31,11 @@ class ToolFilterLanguageSelectionViewModel: ObservableObject {
     @Published var searchText: String = ""
     @Published var navTitle: String = ""
     
-    init(viewToolFilterLanguagesUseCase: ViewToolFilterLanguagesUseCase,  searchToolFilterLanguagesUseCase: SearchToolFilterLanguagesUseCase, storeUserFilterUseCase: StoreUserFiltersUseCase, getInterfaceStringInAppLanguageUseCase: GetInterfaceStringInAppLanguageUseCase, getCurrentAppLanguageUseCase: GetCurrentAppLanguageUseCase, viewSearchBarUseCase: ViewSearchBarUseCase, languageFilterSelectionPublisher: CurrentValueSubject<LanguageFilterDomainModel, Never>, selectedCategory: CategoryFilterDomainModel, flowDelegate: FlowDelegate) {
+    init(viewToolFilterLanguagesUseCase: ViewToolFilterLanguagesUseCase,  searchToolFilterLanguagesUseCase: SearchToolFilterLanguagesUseCase, storeUserFilterUseCase: StoreUserFiltersUseCase, getCurrentAppLanguageUseCase: GetCurrentAppLanguageUseCase, viewSearchBarUseCase: ViewSearchBarUseCase, languageFilterSelectionPublisher: CurrentValueSubject<LanguageFilterDomainModel, Never>, selectedCategory: CategoryFilterDomainModel, flowDelegate: FlowDelegate) {
         
         self.viewToolFilterLanguagesUseCase = viewToolFilterLanguagesUseCase
         self.searchToolFilterLanguagesUseCase = searchToolFilterLanguagesUseCase
         self.storeUserFilterUseCase = storeUserFilterUseCase
-        self.getInterfaceStringInAppLanguageUseCase = getInterfaceStringInAppLanguageUseCase
         self.getCurrentAppLanguageUseCase = getCurrentAppLanguageUseCase
         self.viewSearchBarUseCase = viewSearchBarUseCase
         self.languageFilterSelectionPublisher = languageFilterSelectionPublisher
@@ -56,15 +54,15 @@ class ToolFilterLanguageSelectionViewModel: ObservableObject {
             }
             .receive(on: DispatchQueue.main)
             .sink { [weak self] viewLanguageFiltersDomainModel in
+                guard let self = self else { return }
                 
-                self?.allLanguages = viewLanguageFiltersDomainModel.languageFilters
+                let interfaceStrings = viewLanguageFiltersDomainModel.interfaceStrings
+                
+                self.navTitle = interfaceStrings.navTitle
+                self.allLanguages = viewLanguageFiltersDomainModel.languageFilters
+                
             }
             .store(in: &cancellables)
-
-        getInterfaceStringInAppLanguageUseCase
-            .getStringPublisher(id: ToolStringKeys.ToolFilter.languageFilterNavTitle.rawValue)
-            .receive(on: DispatchQueue.main)
-            .assign(to: &$navTitle)
         
         Publishers.CombineLatest(
             $searchText.eraseToAnyPublisher(),

--- a/godtools/App/Flows/App/AppFlow.swift
+++ b/godtools/App/Flows/App/AppFlow.swift
@@ -972,7 +972,6 @@ extension AppFlow {
             viewToolFilterLanguagesUseCase: appDiContainer.feature.toolsFilter.domainLayer.getViewToolFilterLanguagesUseCase(),
             searchToolFilterLanguagesUseCase: appDiContainer.feature.toolsFilter.domainLayer.getSearchToolFilterLanguagesUseCase(),
             storeUserFilterUseCase: appDiContainer.feature.toolsFilter.domainLayer.getStoreUserFiltersUseCase(),
-            getInterfaceStringInAppLanguageUseCase: appDiContainer.feature.appLanguage.domainLayer.getInterfaceStringInAppLanguageUseCase(),
             getCurrentAppLanguageUseCase: appDiContainer.feature.appLanguage.domainLayer.getCurrentAppLanguageUseCase(),
             viewSearchBarUseCase: appDiContainer.domainLayer.getViewSearchBarUseCase(),
             languageFilterSelectionPublisher: toolFilterLanguageSelectionPublisher,

--- a/godtools/App/Flows/App/AppFlow.swift
+++ b/godtools/App/Flows/App/AppFlow.swift
@@ -939,7 +939,6 @@ extension AppFlow {
             storeUserFiltersUseCase: appDiContainer.feature.toolsFilter.domainLayer.getStoreUserFiltersUseCase(),
             categoryFilterSelectionPublisher: categoryFilterSelectionPublisher,
             selectedLanguage: selectedLanguage,
-            getInterfaceStringInAppLanguageUseCase: appDiContainer.feature.appLanguage.domainLayer.getInterfaceStringInAppLanguageUseCase(),
             getCurrentAppLanguageUseCase: appDiContainer.feature.appLanguage.domainLayer.getCurrentAppLanguageUseCase(),
             viewSearchBarUseCase: appDiContainer.domainLayer.getViewSearchBarUseCase(),
             flowDelegate: self


### PR DESCRIPTION
Removed `GetInterfaceStringInAppLanguageUseCase` from the 2 filter selection pages and added repos to get the interfaceStrings in each.  All the other tasks listed in the ticket were completed in a previous PR.