### PR TITLE
GT-2335 Replace LocaleLanguageName dependency with TranslatedLanguageNameRepository

### DIFF
--- a/godtools/App/DependencyContainer/AppDataLayerDependencies.swift
+++ b/godtools/App/DependencyContainer/AppDataLayerDependencies.swift
@@ -180,18 +180,6 @@ class AppDataLayerDependencies {
         )
     }
     
-    func getLocaleLanguageName() -> LocaleLanguageName {
-        return LocaleLanguageName()
-    }
-    
-    func getLocaleLanguageRegionName() -> LocaleLanguageRegionName {
-        return LocaleLanguageRegionName()
-    }
-    
-    func getLocaleLanguageScriptName() -> LocaleLanguageScriptName {
-        return LocaleLanguageScriptName()
-    }
-    
     func getLocalizationServices() -> LocalizationServices {
         return LocalizationServices(localizableStringsFilesBundle: Bundle.main)
     }
@@ -335,6 +323,15 @@ class AppDataLayerDependencies {
         )
     }
     
+    private func getTranslatedLanguageName() -> GetTranslatedLanguageName {
+        return GetTranslatedLanguageName(
+            localizationServices: getLocalizationServices(),
+            localeLanguageName: LocaleLanguageName(),
+            localeRegionName: LocaleLanguageRegionName(),
+            localeScriptName: LocaleLanguageScriptName()
+        )
+    }
+    
     func getTranslatedToolCategory() -> GetTranslatedToolCategory {
         return GetTranslatedToolCategory(
             localizationServices: getLocalizationServices(),
@@ -443,15 +440,6 @@ class AppDataLayerDependencies {
     func getInterfaceStringForLanguageRepositoryInterface() -> GetInterfaceStringForLanguageRepositoryInterface {
         return GetInterfaceStringForLanguageRepository(
             localizationServices: getLocalizationServices()
-        )
-    }
-
-    private func getTranslatedLanguageName() -> GetTranslatedLanguageName {
-        return GetTranslatedLanguageName(
-            localizationServices: getLocalizationServices(),
-            localeLanguageName: getLocaleLanguageName(),
-            localeRegionName: getLocaleLanguageRegionName(),
-            localeScriptName: getLocaleLanguageScriptName()
         )
     }
 }

--- a/godtools/App/Features/AppLanguage/Data-DomainInterface/GetConfirmAppLanguageInterfaceStringsRepository.swift
+++ b/godtools/App/Features/AppLanguage/Data-DomainInterface/GetConfirmAppLanguageInterfaceStringsRepository.swift
@@ -12,12 +12,12 @@ import Combine
 class GetConfirmAppLanguageInterfaceStringsRepository: GetConfirmAppLanguageInterfaceStringsRepositoryInterface {
     
     private let localizationServices: LocalizationServices
-    private let localeLanguageName: LocaleLanguageName
+    private let translatedLanguageNameRepository: TranslatedLanguageNameRepository
     
-    init(localizationServices: LocalizationServices, localeLanguageName: LocaleLanguageName) {
+    init(localizationServices: LocalizationServices, translatedLanguageNameRepository: TranslatedLanguageNameRepository) {
         
         self.localizationServices = localizationServices
-        self.localeLanguageName = localeLanguageName
+        self.translatedLanguageNameRepository = translatedLanguageNameRepository
     }
     
     func getStringsPublisher(translateInAppLanguage: AppLanguageDomainModel, selectedLanguage: AppLanguageDomainModel) -> AnyPublisher<ConfirmAppLanguageInterfaceStringsDomainModel, Never> {
@@ -39,7 +39,7 @@ class GetConfirmAppLanguageInterfaceStringsRepository: GetConfirmAppLanguageInte
         
         let formatString = localizationServices.stringForLocaleElseEnglish(localeIdentifier: localeId, key: "languageSettings.confirmAppLanguage.message")
         
-        let languageName = self.localeLanguageName.getLanguageName(forLanguageCode: selectedLanguage, translatedInLanguageId: localeId) ?? ""
+        let languageName = translatedLanguageNameRepository.getLanguageName(language: selectedLanguage, translatedInLanguage: localeId)
         let languageNameAttributed = NSAttributedString(
             string: languageName,
             attributes: [NSAttributedString.Key.foregroundColor: ColorPalette.gtBlue.uiColor]

--- a/godtools/App/Features/AppLanguage/Data-DomainInterface/GetLanguageSettingsInterfaceStringsRepository.swift
+++ b/godtools/App/Features/AppLanguage/Data-DomainInterface/GetLanguageSettingsInterfaceStringsRepository.swift
@@ -12,13 +12,13 @@ import Combine
 class GetLanguageSettingsInterfaceStringsRepository: GetLanguageSettingsInterfaceStringsRepositoryInterface {
     
     private let localizationServices: LocalizationServices
-    private let localeLanguageName: LocaleLanguageName
+    private let translatedLanguageNameRepository: TranslatedLanguageNameRepository
     private let appLanguagesRepository: AppLanguagesRepository
     
-    init(localizationServices: LocalizationServices, localeLanguageName: LocaleLanguageName, appLanguagesRepository: AppLanguagesRepository) {
+    init(localizationServices: LocalizationServices, translatedLanguageNameRepository: TranslatedLanguageNameRepository, appLanguagesRepository: AppLanguagesRepository) {
         
         self.localizationServices = localizationServices
-        self.localeLanguageName = localeLanguageName
+        self.translatedLanguageNameRepository = translatedLanguageNameRepository
         self.appLanguagesRepository = appLanguagesRepository
     }
     
@@ -31,7 +31,7 @@ class GetLanguageSettingsInterfaceStringsRepository: GetLanguageSettingsInterfac
             appInterfaceLanguageTitle: localizationServices.stringForLocaleElseEnglish(localeIdentifier: localeId, key: "languageSettings.appInterface.title"),
             numberOfAppLanguagesAvailable: getNumberOfAppLanguagesAvailableString(translateInAppLanguage: translateInAppLanguage),
             setAppLanguageMessage: localizationServices.stringForLocaleElseEnglish(localeIdentifier: localeId, key: "languageSettings.appInterface.message"),
-            chooseAppLanguageButtonTitle: localeLanguageName.getLanguageName(forLanguageCode: translateInAppLanguage, translatedInLanguageId: translateInAppLanguage) ?? "",
+            chooseAppLanguageButtonTitle: translatedLanguageNameRepository.getLanguageName(language: translateInAppLanguage, translatedInLanguage: translateInAppLanguage),
             toolLanguagesAvailableOfflineTitle: localizationServices.stringForLocaleElseEnglish(localeIdentifier: localeId, key: "languageSettings.toolLanguagesAvailableOffline.title"),
             downloadToolsForOfflineMessage: localizationServices.stringForLocaleElseEnglish(localeIdentifier: localeId, key: "languageSettings.toolLanguagesAvailableOffline.message"),
             editDownloadedLanguagesButtonTitle: localizationServices.stringForLocaleElseEnglish(localeIdentifier: localeId, key: "languageSettings.toolLanguagesAvailableOffline.editDownloadedLanguagesButton.title")

--- a/godtools/App/Features/AppLanguage/DependencyContainer/AppLanguageFeatureDataLayerDependencies.swift
+++ b/godtools/App/Features/AppLanguage/DependencyContainer/AppLanguageFeatureDataLayerDependencies.swift
@@ -92,7 +92,7 @@ class AppLanguageFeatureDataLayerDependencies {
     func getConfirmAppLanguageInterfaceStringsRepositoryInterface() -> GetConfirmAppLanguageInterfaceStringsRepositoryInterface {
         return GetConfirmAppLanguageInterfaceStringsRepository(
             localizationServices: coreDataLayer.getLocalizationServices(),
-            localeLanguageName: coreDataLayer.getLocaleLanguageName()
+            translatedLanguageNameRepository: coreDataLayer.getTranslatedLanguageNameRepository()
         )
     }
     
@@ -131,7 +131,7 @@ class AppLanguageFeatureDataLayerDependencies {
     func getLanguageSettingsInterfaceStringsRepositoryInterface() -> GetLanguageSettingsInterfaceStringsRepositoryInterface {
         return GetLanguageSettingsInterfaceStringsRepository(
             localizationServices: coreDataLayer.getLocalizationServices(),
-            localeLanguageName: coreDataLayer.getLocaleLanguageName(),
+            translatedLanguageNameRepository: coreDataLayer.getTranslatedLanguageNameRepository(),
             appLanguagesRepository: getAppLanguagesRepository()
         )
     }

--- a/godtools/App/Features/ToolsFilter/Data-DomainInterface/GetToolFilterCategoriesRepository.swift
+++ b/godtools/App/Features/ToolsFilter/Data-DomainInterface/GetToolFilterCategoriesRepository.swift
@@ -13,13 +13,11 @@ class GetToolFilterCategoriesRepository: GetToolFilterCategoriesRepositoryInterf
     
     private let resourcesRepository: ResourcesRepository
     private let localizationServices: LocalizationServices
-    private let localeLanguageName: LocaleLanguageName
 
-    init(resourcesRepository: ResourcesRepository, localizationServices: LocalizationServices, localeLanguageName: LocaleLanguageName) {
+    init(resourcesRepository: ResourcesRepository, localizationServices: LocalizationServices) {
         
         self.resourcesRepository = resourcesRepository
         self.localizationServices = localizationServices
-        self.localeLanguageName = localeLanguageName
     }
     
     func getToolFilterCategoriesPublisher(translatedInAppLanguage: AppLanguageDomainModel, filteredByLanguageId: BCP47LanguageIdentifier?) -> AnyPublisher<[CategoryFilterDomainModel], Never> {

--- a/godtools/App/Features/ToolsFilter/Data-DomainInterface/GetToolFilterLanguagesRepository.swift
+++ b/godtools/App/Features/ToolsFilter/Data-DomainInterface/GetToolFilterLanguagesRepository.swift
@@ -13,14 +13,14 @@ class GetToolFilterLanguagesRepository: GetToolFilterLanguagesRepositoryInterfac
     
     private let resourcesRepository: ResourcesRepository
     private let languagesRepository: LanguagesRepository
-    private let localeLanguageName: LocaleLanguageName
+    private let translatedLanguageNameRepository: TranslatedLanguageNameRepository
     private let localizationServices: LocalizationServices
     
-    init(resourcesRepository: ResourcesRepository, languagesRepository: LanguagesRepository, localeLanguageName: LocaleLanguageName, localizationServices: LocalizationServices) {
+    init(resourcesRepository: ResourcesRepository, languagesRepository: LanguagesRepository, translatedLanguageNameRepository: TranslatedLanguageNameRepository, localizationServices: LocalizationServices) {
         
         self.resourcesRepository = resourcesRepository
         self.languagesRepository = languagesRepository
-        self.localeLanguageName = localeLanguageName
+        self.translatedLanguageNameRepository = translatedLanguageNameRepository
         self.localizationServices = localizationServices
     }
     
@@ -103,8 +103,8 @@ extension GetToolFilterLanguagesRepository {
         
         let toolsAvailableCount: Int = getToolsAvailableCount(for: languageModel.code, filteredByCategoryId: filteredByCategoryId)
         
-        let languageName = self.localeLanguageName.getLanguageName(forLanguageCode: languageModel.code, translatedInLanguageId: languageModel.code) ?? ""
-        let translatedLanguageName = self.localeLanguageName.getLanguageName(forLanguageCode: languageModel.code, translatedInLanguageId: translatedInAppLanguage) ?? ""
+        let languageName = translatedLanguageNameRepository.getLanguageName(language: languageModel.code, translatedInLanguage: languageModel.code)
+        let translatedLanguageName = translatedLanguageNameRepository.getLanguageName(language: languageModel.code, translatedInLanguage: translatedInAppLanguage)
         
         let languageDomainModel = LanguageDomainModel(
             analyticsContentLanguage: languageModel.code,

--- a/godtools/App/Features/ToolsFilter/DependencyContainer/ToolsFilterFeatureDataLayerDependencies.swift
+++ b/godtools/App/Features/ToolsFilter/DependencyContainer/ToolsFilterFeatureDataLayerDependencies.swift
@@ -30,8 +30,7 @@ class ToolsFilterFeatureDataLayerDependencies {
     func getToolFilterCategoriesRepository() -> GetToolFilterCategoriesRepository {
         return GetToolFilterCategoriesRepository(
             resourcesRepository: coreDataLayer.getResourcesRepository(),
-            localizationServices: coreDataLayer.getLocalizationServices(),
-            localeLanguageName: coreDataLayer.getLocaleLanguageName()
+            localizationServices: coreDataLayer.getLocalizationServices()
         )
     }
     
@@ -45,7 +44,7 @@ class ToolsFilterFeatureDataLayerDependencies {
         return GetToolFilterLanguagesRepository(
             resourcesRepository: coreDataLayer.getResourcesRepository(),
             languagesRepository: coreDataLayer.getLanguagesRepository(),
-            localeLanguageName: coreDataLayer.getLocaleLanguageName(),
+            translatedLanguageNameRepository: coreDataLayer.getTranslatedLanguageNameRepository(),
             localizationServices: coreDataLayer.getLocalizationServices()
         )
     }


### PR DESCRIPTION
This PR updates a few places where LocaleLanguageName is being used.  Since then TranslatedLanguageNameRepository has been created in order to resolve performance issues when attempting to translate languages from OneSky.

- Removes get method for fetching LocaleLanguageName from AppDataLayerDependencies in order to avoid any confusion.  Instead, TranslatedLanguageNameRepository should be used when translating a language name.
- Replaces occurrences of LocaleLanguageName with TranslatedLanguageNameRepository for translating a language name in GetConfirmAppLanguageInterfaceStringsRepository.swift, GetLanguageSettingsInterfaceStringsRepository.swift, and GetToolFilterLanguagesRepository.swift.