### PR TITLE
GT-2334 Fix line break not applied in Tool Details about text

### DIFF
--- a/godtools/App/Share/Common/SharedAppleExtensions/Swift/String/String+ToUrlMarkdown.swift
+++ b/godtools/App/Share/Common/SharedAppleExtensions/Swift/String/String+ToUrlMarkdown.swift
@@ -11,7 +11,7 @@ import Foundation
 @available(iOS 15.0, *)
 extension String {
     
-    func toUrlMarkdown() -> Result<AttributedString, Error> {
+    func toUrlMarkdown(attributedStringOptions: AttributedString.MarkdownParsingOptions? = nil) -> Result<AttributedString, Error> {
         
         let originalString: String = self
         
@@ -42,7 +42,14 @@ extension String {
                     
             do {
                 
-                let markdown = try AttributedString(markdown: textWithLinks)
+                let markdown: AttributedString
+                
+                if let options = attributedStringOptions {
+                    markdown = try AttributedString(markdown: textWithLinks, options: options)
+                }
+                else {
+                    markdown = try AttributedString(markdown: textWithLinks)
+                }
                 
                 return .success(markdown)
             }

--- a/godtools/App/Share/SwiftUI Views/TextWithLinks/TextWithLinksView.swift
+++ b/godtools/App/Share/SwiftUI Views/TextWithLinks/TextWithLinksView.swift
@@ -20,7 +20,12 @@ struct TextWithLinksView: View {
     
     init(stringContainingUrls: String, textColor: Color, font: Font, lineSpacing: CGFloat? = nil, textAlignment: TextAlignment? = nil, handleUrlClosure: ((_ url: URL) -> Void)? = nil) {
         
-        switch stringContainingUrls.toUrlMarkdown() {
+        let options = AttributedString.MarkdownParsingOptions(
+            allowsExtendedAttributes: false,
+            interpretedSyntax: .inlineOnlyPreservingWhitespace
+        )
+        
+        switch stringContainingUrls.toUrlMarkdown(attributedStringOptions: options) {
         case .success(let markdown):
             markdownText = markdown
         case .failure( _):


### PR DESCRIPTION
The Tool Details about text uses an AttributedString for formatting the URLs. 

Including option ```inlineOnlyPreservingWhitespace``` appears to preserve the line breaks when creating the AttributedString.

https://developer.apple.com/documentation/foundation/attributedstring/markdownparsingoptions/interpretedsyntax/inlineonlypreservingwhitespace