### PR TITLE
GT Add private method for all tools list that returns type Results<RealmResource>

### DIFF
--- a/godtools/App/Share/Data/ResourcesRepository/Cache/RealmResourcesCache.swift
+++ b/godtools/App/Share/Data/ResourcesRepository/Cache/RealmResourcesCache.swift
@@ -184,8 +184,8 @@ extension RealmResourcesCache {
 
 extension RealmResourcesCache {
     
-    func getAllToolsList(filterByCategory: String?, filterByLanguageId: String?, sortByDefaultOrder: Bool) -> [ResourceModel] {
-                 
+    private func getAllToolsListResults(filterByCategory: String?, filterByLanguageId: String?, sortByDefaultOrder: Bool) -> Results<RealmResource> {
+        
         var filterByANDSubpredicates: [NSPredicate] = Array()
         
         if let filterByCategory = filterByCategory {
@@ -214,18 +214,23 @@ extension RealmResourcesCache {
         
         let filteredRealmResources: Results<RealmResource> = realmDatabase.openRealm().objects(RealmResource.self).filter(filterPredicates)
         
-        let realmResources: Results<RealmResource>
+        let allToolsListResults: Results<RealmResource>
         
         if sortByDefaultOrder {
             
-            realmResources = filteredRealmResources.sorted(byKeyPath: #keyPath(RealmResource.attrDefaultOrder), ascending: true)
+            allToolsListResults = filteredRealmResources.sorted(byKeyPath: #keyPath(RealmResource.attrDefaultOrder), ascending: true)
         }
         else {
             
-            realmResources = filteredRealmResources
+            allToolsListResults = filteredRealmResources
         }
         
-        return realmResources
+        return allToolsListResults
+    }
+    
+    func getAllToolsList(filterByCategory: String?, filterByLanguageId: String?, sortByDefaultOrder: Bool) -> [ResourceModel] {
+                 
+        return getAllToolsListResults(filterByCategory: filterByCategory, filterByLanguageId: filterByLanguageId, sortByDefaultOrder: sortByDefaultOrder)
             .map {
                 ResourceModel(model: $0)
             }


### PR DESCRIPTION
This PR adds ```private func getAllToolsListResults(filterByCategory: String?, filterByLanguageId: String?, sortByDefaultOrder: Bool) -> Results<RealmResource>``` mainly for the benefit of exposing ```Results<RealmResource>``` for using additional methods that provides.


