### PR TITLE
GT-2116 increase search bar tap area

### DIFF
--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -1491,6 +1491,7 @@
 		D4BC79E629AFCE870040651B /* TrainingTipDomainModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4BC79E529AFCE870040651B /* TrainingTipDomainModel.swift */; };
 		D4BC79E829B130970040651B /* SetCompletedTrainingTipUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4BC79E729B130970040651B /* SetCompletedTrainingTipUseCase.swift */; };
 		D4C14E9229411A35001465F1 /* MobileContentAuthTokenDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C14E9129411A35001465F1 /* MobileContentAuthTokenDataModel.swift */; };
+		D4C759212BB643EF00D6AEB2 /* SearchBarLegacy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C759202BB643EF00D6AEB2 /* SearchBarLegacy.swift */; };
 		D4E243CC29EDC6A100EA4BB7 /* SendFeedbackWebContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E243CB29EDC6A100EA4BB7 /* SendFeedbackWebContent.swift */; };
 		D4E243CE29EDCA5700EA4BB7 /* ReportABugWebContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E243CD29EDCA5700EA4BB7 /* ReportABugWebContent.swift */; };
 		D4E243D029EDD2E800EA4BB7 /* AskAQuestionWebContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E243CF29EDD2E800EA4BB7 /* AskAQuestionWebContent.swift */; };
@@ -3100,6 +3101,7 @@
 		D4BC79E529AFCE870040651B /* TrainingTipDomainModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrainingTipDomainModel.swift; sourceTree = "<group>"; };
 		D4BC79E729B130970040651B /* SetCompletedTrainingTipUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetCompletedTrainingTipUseCase.swift; sourceTree = "<group>"; };
 		D4C14E9129411A35001465F1 /* MobileContentAuthTokenDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileContentAuthTokenDataModel.swift; sourceTree = "<group>"; };
+		D4C759202BB643EF00D6AEB2 /* SearchBarLegacy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBarLegacy.swift; sourceTree = "<group>"; };
 		D4E243CB29EDC6A100EA4BB7 /* SendFeedbackWebContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendFeedbackWebContent.swift; sourceTree = "<group>"; };
 		D4E243CD29EDCA5700EA4BB7 /* ReportABugWebContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportABugWebContent.swift; sourceTree = "<group>"; };
 		D4E243CF29EDD2E800EA4BB7 /* AskAQuestionWebContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AskAQuestionWebContent.swift; sourceTree = "<group>"; };
@@ -10479,6 +10481,7 @@
 			isa = PBXGroup;
 			children = (
 				D496B9052A9E702200CBEA19 /* SearchBar.swift */,
+				D4C759202BB643EF00D6AEB2 /* SearchBarLegacy.swift */,
 				45ACEE1B2AD0493F004B62E4 /* SearchBarView.swift */,
 				D40D77BE2AB36766008D3642 /* SearchBarViewModel.swift */,
 			);
@@ -12470,6 +12473,7 @@
 				455EE83C2AEC586200C3205C /* GetDownloadToolProgressInterfaceStringsUseCase.swift in Sources */,
 				D4B05FF529106212005852D0 /* MobileContentAuthTokenRepository.swift in Sources */,
 				45F7B0B32AF18E3D00A0E7B4 /* GetMenuInterfaceStringsUseCase.swift in Sources */,
+				D4C759212BB643EF00D6AEB2 /* SearchBarLegacy.swift in Sources */,
 				45FE825A2ACE5D8C00930C39 /* NavBarItemController.swift in Sources */,
 				4570C3032ADDC86600F0B83B /* AppNavigationBarAppearance.swift in Sources */,
 				452F6E872B69A3420012AF9C /* FavoritedToolsLatestToolDownloader.swift in Sources */,

--- a/godtools/App/Features/AppLanguage/Presentation/AppLanguages/AppLanguagesViewModel.swift
+++ b/godtools/App/Features/AppLanguage/Presentation/AppLanguages/AppLanguagesViewModel.swift
@@ -20,6 +20,7 @@ class AppLanguagesViewModel: ObservableObject {
     private var cancellables: Set<AnyCancellable> = Set()
     
     private weak var flowDelegate: FlowDelegate?
+    private lazy var searchBarViewModel = SearchBarViewModel(getCurrentAppLanguageUseCase: getCurrentAppLanguageUseCase, viewSearchBarUseCase: viewSearchBarUseCase)
     
     @Published private var appLanguage: AppLanguageDomainModel = LanguageCodeDomainModel.english.rawValue
     @Published private var appLanguagesList: [AppLanguageListItemDomainModel] = Array()
@@ -95,9 +96,6 @@ extension AppLanguagesViewModel {
     
     func getSearchBarViewModel() -> SearchBarViewModel {
         
-        return SearchBarViewModel(
-            getCurrentAppLanguageUseCase: getCurrentAppLanguageUseCase,
-            viewSearchBarUseCase: viewSearchBarUseCase
-        )
+        return searchBarViewModel
     }
 }

--- a/godtools/App/Features/AppLanguage/Presentation/DownloadableLanguages/DownloadableLanguagesViewModel.swift
+++ b/godtools/App/Features/AppLanguage/Presentation/DownloadableLanguages/DownloadableLanguagesViewModel.swift
@@ -22,6 +22,7 @@ class DownloadableLanguagesViewModel: ObservableObject {
     private static var backgrounDownloadCancellables = Set<AnyCancellable>()
     
     private weak var flowDelegate: FlowDelegate?
+    private lazy var searchBarViewModel = SearchBarViewModel(getCurrentAppLanguageUseCase: getCurrentAppLanguageUseCase, viewSearchBarUseCase: viewSearchBarUseCase)
     
     @Published private var appLanguage: AppLanguageDomainModel = LanguageCodeDomainModel.english.rawValue
     @Published private var downloadableLanguages: [DownloadableLanguageListItemDomainModel] = Array()
@@ -123,7 +124,7 @@ extension DownloadableLanguagesViewModel {
     
     func getSearchBarViewModel() -> SearchBarViewModel {
         
-        return SearchBarViewModel(getCurrentAppLanguageUseCase: getCurrentAppLanguageUseCase, viewSearchBarUseCase: viewSearchBarUseCase)
+        return searchBarViewModel
     }
     
     func downloadLanguage(_ downloadableLanguage: DownloadableLanguageListItemDomainModel) {

--- a/godtools/App/Features/ToolsFilter/Presentation/ToolFilterCategorySelectionView/ToolFilterCategorySelectionViewModel.swift
+++ b/godtools/App/Features/ToolsFilter/Presentation/ToolFilterCategorySelectionView/ToolFilterCategorySelectionViewModel.swift
@@ -22,6 +22,7 @@ class ToolFilterCategorySelectionViewModel: ObservableObject {
     private var cancellables: Set<AnyCancellable> = Set()
     private static var staticCancellables: Set<AnyCancellable> = Set()
     private weak var flowDelegate: FlowDelegate?
+    private lazy var searchBarViewModel = SearchBarViewModel(getCurrentAppLanguageUseCase: getCurrentAppLanguageUseCase, viewSearchBarUseCase: viewSearchBarUseCase)
     
     @Published private var appLanguage: AppLanguageDomainModel = LanguageCodeDomainModel.english.rawValue
     @Published private var allCategories: [CategoryFilterDomainModel] = [CategoryFilterDomainModel]()
@@ -86,10 +87,7 @@ extension ToolFilterCategorySelectionViewModel {
     
     func getSearchBarViewModel() -> SearchBarViewModel {
         
-        return SearchBarViewModel(
-            getCurrentAppLanguageUseCase: getCurrentAppLanguageUseCase,
-            viewSearchBarUseCase: viewSearchBarUseCase
-        )
+        return searchBarViewModel
     }
     
     func rowTapped(with category: CategoryFilterDomainModel) {

--- a/godtools/App/Features/ToolsFilter/Presentation/ToolFilterLanguageSelectionView/ToolFilterLanguageSelectionViewModel.swift
+++ b/godtools/App/Features/ToolsFilter/Presentation/ToolFilterLanguageSelectionView/ToolFilterLanguageSelectionViewModel.swift
@@ -22,6 +22,7 @@ class ToolFilterLanguageSelectionViewModel: ObservableObject {
     private var cancellables: Set<AnyCancellable> = Set()
     private static var staticCancellables: Set<AnyCancellable> = Set()
     private weak var flowDelegate: FlowDelegate?
+    private lazy var searchBarViewModel = SearchBarViewModel(getCurrentAppLanguageUseCase: getCurrentAppLanguageUseCase, viewSearchBarUseCase: viewSearchBarUseCase)
         
     @Published private var appLanguage: AppLanguageDomainModel = LanguageCodeDomainModel.english.rawValue
     @Published private var allLanguages: [LanguageFilterDomainModel] = [LanguageFilterDomainModel]()
@@ -87,10 +88,7 @@ extension ToolFilterLanguageSelectionViewModel {
     
     func getSearchBarViewModel() -> SearchBarViewModel {
         
-        return SearchBarViewModel(
-            getCurrentAppLanguageUseCase: getCurrentAppLanguageUseCase,
-            viewSearchBarUseCase: viewSearchBarUseCase
-        )
+        return searchBarViewModel
     }
         
     func rowTapped(with language: LanguageFilterDomainModel) {

--- a/godtools/App/Share/SwiftUI Views/SearchBar/SearchBar.swift
+++ b/godtools/App/Share/SwiftUI Views/SearchBar/SearchBar.swift
@@ -15,7 +15,6 @@ struct SearchBar: View {
     
     @ObservedObject private var viewModel: SearchBarViewModel
 
-    @State private var isEditing = false
     @Binding private var searchText: String
     @FocusState private var textFieldIsFocused: Bool
     

--- a/godtools/App/Share/SwiftUI Views/SearchBar/SearchBarLegacy.swift
+++ b/godtools/App/Share/SwiftUI Views/SearchBar/SearchBarLegacy.swift
@@ -1,23 +1,21 @@
 //
-//  SearchBar.swift
+//  SearchBarLegacy.swift
 //  godtools
 //
-//  Created by Rachael Skeath on 8/29/23.
-//  Copyright © 2023 Cru. All rights reserved.
+//  Created by Rachael Skeath on 3/28/24.
+//  Copyright © 2024 Cru. All rights reserved.
 //
 
 import SwiftUI
 
-// adapted from https://www.appcoda.com/swiftui-search-bar/
-
-@available(iOS 15.0, *)
-struct SearchBar: View {
+// Replaced by SearchBar for iOS 15+
+@available(*, deprecated)
+struct SearchBarLegacy: View {
     
     @ObservedObject private var viewModel: SearchBarViewModel
 
     @State private var isEditing = false
     @Binding private var searchText: String
-    @FocusState private var textFieldIsFocused: Bool
     
     init(viewModel: SearchBarViewModel, searchText: Binding<String>) {
         
@@ -28,15 +26,18 @@ struct SearchBar: View {
     var body: some View {
         HStack {
          
-            TextField("", text: $searchText)
+            TextField("", text: $searchText, onEditingChanged: { _ in
+                self.isEditing = true
+            }, onCommit: {
+                DispatchQueue.main.async {
+                    
+                    self.isEditing = false
+                }
+            })
             .padding(7)
             .padding(.horizontal, 27)
             .background(Color.white)
             .cornerRadius(6)
-            .focused($textFieldIsFocused)
-            .onTapGesture {
-                textFieldIsFocused = true
-            }
             .overlay(
                 HStack {
                     
@@ -45,7 +46,7 @@ struct SearchBar: View {
                         .frame(minWidth: 0, maxWidth: .infinity, alignment: .leading)
                         .padding(.leading, 10)
                     
-                    if textFieldIsFocused {
+                    if isEditing {
                         Button(action: {
                             self.searchText = ""
                             
@@ -58,11 +59,14 @@ struct SearchBar: View {
                 }
             )
             
-            if textFieldIsFocused {
+            if isEditing {
                 Button(action: {
-                    self.searchText = ""
-                    self.textFieldIsFocused = false
-
+                    DispatchQueue.main.async {
+                        self.isEditing = false
+                        self.searchText = ""
+                    }
+                    
+                    UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
                 }) {
                     Text(viewModel.cancelText)
                 }
@@ -70,3 +74,4 @@ struct SearchBar: View {
         }
     }
 }
+

--- a/godtools/App/Share/SwiftUI Views/SearchBar/SearchBarView.swift
+++ b/godtools/App/Share/SwiftUI Views/SearchBar/SearchBarView.swift
@@ -28,8 +28,16 @@ struct SearchBarView: View {
             Rectangle()
                 .fill(SearchBarView.ultraLightGrey)
 
-            SearchBar(viewModel: viewModel, searchText: $searchText)
-                .padding(10)
+            if #available(iOS 15.0, *) {
+                
+                SearchBar(viewModel: viewModel, searchText: $searchText)
+                    .padding(10)
+                
+            } else {
+                
+                SearchBarLegacy(viewModel: viewModel, searchText: $searchText)
+                    .padding(10)
+            }
         }
         .fixedSize(horizontal: false, vertical: true)
     }


### PR DESCRIPTION
Hey @levieggertcru, this was simple enough to accomplish using the `FocusState` property wrapper, which is really cool!  But it's only available on iOS 15+, and it looked like maybe the only possible way to accomplish the same thing on iOS 14 was to use `UIViewRepresentable`, and it seemed like a lot more effort than it would be worth.  So I copied the existing SearchBar implementation into a legacy version without `FocusState` and made the changes only for iOS 15+, which also allowed me to clean up several other things in the new version.

Also fixed some glitchiness with the "Cancel" button--  the SearchBarViewModel was getting re-initialized every time the view changed, so just needed to keep a reference to it.