### PR TITLE
GT-2285 include articles in tool downloading

### DIFF
--- a/godtools/App/DependencyContainer/AppDataLayerDependencies.swift
+++ b/godtools/App/DependencyContainer/AppDataLayerDependencies.swift
@@ -281,7 +281,8 @@ class AppDataLayerDependencies {
             resourcesRepository: getResourcesRepository(),
             languagesRepository: getLanguagesRepository(),
             translationsRepository: getTranslationsRepository(),
-            attachmentsRepository: getAttachmentsRepository()
+            attachmentsRepository: getAttachmentsRepository(),
+            articleManifestAemRepository: getArticleManifestAemRepository()
         )
     }
     

--- a/godtools/App/Features/Articles/Presentation/ArticleCategories/ArticleCategoriesViewModel.swift
+++ b/godtools/App/Features/Articles/Presentation/ArticleCategories/ArticleCategoriesViewModel.swift
@@ -84,7 +84,7 @@ class ArticleCategoriesViewModel {
         
         isLoading.accept(value: true)
         
-        downloadArticlesReceipt = articleManifestAemRepository.downloadAndCacheManifestAemUris(manifest: manifest, languageCode: language.localeIdentifier, forceDownload: forceDownload, completion: { [weak self] (result: ArticleAemRepositoryResult) in
+        downloadArticlesReceipt = articleManifestAemRepository.downloadAndCacheManifestAemUrisReceipt(manifest: manifest, languageCode: language.localeIdentifier, forceDownload: forceDownload, completion: { [weak self] (result: ArticleAemRepositoryResult) in
             
             DispatchQueue.main.async { [weak self] in
                 self?.isLoading.accept(value: false)

--- a/godtools/App/Features/Articles/Presentation/Articles/ArticlesViewModel.swift
+++ b/godtools/App/Features/Articles/Presentation/Articles/ArticlesViewModel.swift
@@ -118,7 +118,7 @@ class ArticlesViewModel: NSObject {
         
         errorMessage.accept(value: nil)
         
-        downloadArticlesReceipt = articleManifestAemRepository.downloadAndCacheManifestAemUris(manifest: manifest, languageCode: language.localeIdentifier, forceDownload: forceDownload) { [weak self] (result: ArticleAemRepositoryResult) in
+        downloadArticlesReceipt = articleManifestAemRepository.downloadAndCacheManifestAemUrisReceipt(manifest: manifest, languageCode: language.localeIdentifier, forceDownload: forceDownload) { [weak self] (result: ArticleAemRepositoryResult) in
             self?.downloadArticlesReceipt = nil
             DispatchQueue.main.async { [weak self] in
                 self?.handleCompleteArticlesDownload(result: result)

--- a/godtools/App/Share/Data/TranslationsRepository/TranslationsRepository.swift
+++ b/godtools/App/Share/Data/TranslationsRepository/TranslationsRepository.swift
@@ -322,7 +322,7 @@ extension TranslationsRepository {
             .eraseToAnyPublisher()
     }
     
-    private func downloadAndCacheTranslationFiles(translation: TranslationModel) -> AnyPublisher<TranslationFilesDataModel, Error> {
+    func downloadAndCacheTranslationFiles(translation: TranslationModel) -> AnyPublisher<TranslationFilesDataModel, Error> {
         
         return getTranslationFileFromCacheElseRemote(translation: translation, fileName: translation.manifestName)
             .flatMap({ fileCacheLocation -> AnyPublisher<Manifest, Error> in


### PR DESCRIPTION
Updated the ToolDownloader to include downloading articles for offline.  Each article requires a URL to be downloaded which is found in the translation manifest.  This work includes checking to see if a downloaded translation is for an article and will then download the aem URLs for offline use.