### PR TITLE
GT-2235 Use code instead of languageCode

### DIFF
--- a/godtools/App/Features/AppLanguage/Data-DomainInterface/GetDownloadableLanguagesListRepository.swift
+++ b/godtools/App/Features/AppLanguage/Data-DomainInterface/GetDownloadableLanguagesListRepository.swift
@@ -37,7 +37,7 @@ class GetDownloadableLanguagesListRepository: GetDownloadableLanguagesListReposi
             
             return self.languagesRepository.getLanguages().compactMap { language in
                 
-                let numberToolsAvailable = self.getNumberToolsAvailable(for: language.languageCode)
+                let numberToolsAvailable = self.getNumberToolsAvailable(for: language.code)
                 if numberToolsAvailable == 0 {
                     return nil
                 }
@@ -77,7 +77,7 @@ class GetDownloadableLanguagesListRepository: GetDownloadableLanguagesListReposi
 
 extension GetDownloadableLanguagesListRepository {
     
-    private func getNumberToolsAvailable(for languageCode: String) -> Int {
+    private func getNumberToolsAvailable(for languageCode: BCP47LanguageIdentifier) -> Int {
         
         let filter = ResourcesFilter(
             category: nil,


### PR DESCRIPTION
The downloadable languages list was missing some languages and realized because ResourcesFilter languageCode was taking the LanguageModel languageCode (equivalent of locale language code) which is different than LanguageModel code (equivalent of locale identifier).  It's a bit confusing and I may need to look into a way to avoid that confusion.
