### PR TITLE
GT-2340 format number counts based on app language

### DIFF
--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -541,6 +541,7 @@
 		4564E20C2B1E181000DA4040 /* ToolShortcutLinksDataLayerDependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4564E2022B1E180F00DA4040 /* ToolShortcutLinksDataLayerDependencies.swift */; };
 		4564E20D2B1E181000DA4040 /* ToolShortcutLinksDomainLayerDependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4564E2032B1E180F00DA4040 /* ToolShortcutLinksDomainLayerDependencies.swift */; };
 		4564E20E2B1E181000DA4040 /* ToolShortcutLinksDiContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4564E2042B1E180F00DA4040 /* ToolShortcutLinksDiContainer.swift */; };
+		4565BA9B2BBB3B0E002688C1 /* GetTranslatedNumberCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4565BA9A2BBB3B0E002688C1 /* GetTranslatedNumberCount.swift */; };
 		4566DCAE2A2686C000B989A2 /* RealmMobileContentAuthTokenCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4566DCAD2A2686C000B989A2 /* RealmMobileContentAuthTokenCache.swift */; };
 		4566DCB02A2686C900B989A2 /* RealmMobileContentAuthToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4566DCAF2A2686C900B989A2 /* RealmMobileContentAuthToken.swift */; };
 		456714142B7E9FDC00C6E7A2 /* GetTranslatedToolName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456714132B7E9FDC00C6E7A2 /* GetTranslatedToolName.swift */; };
@@ -2080,6 +2081,7 @@
 		4564E2022B1E180F00DA4040 /* ToolShortcutLinksDataLayerDependencies.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToolShortcutLinksDataLayerDependencies.swift; sourceTree = "<group>"; };
 		4564E2032B1E180F00DA4040 /* ToolShortcutLinksDomainLayerDependencies.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToolShortcutLinksDomainLayerDependencies.swift; sourceTree = "<group>"; };
 		4564E2042B1E180F00DA4040 /* ToolShortcutLinksDiContainer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToolShortcutLinksDiContainer.swift; sourceTree = "<group>"; };
+		4565BA9A2BBB3B0E002688C1 /* GetTranslatedNumberCount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetTranslatedNumberCount.swift; sourceTree = "<group>"; };
 		4566DCAD2A2686C000B989A2 /* RealmMobileContentAuthTokenCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealmMobileContentAuthTokenCache.swift; sourceTree = "<group>"; };
 		4566DCAF2A2686C900B989A2 /* RealmMobileContentAuthToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealmMobileContentAuthToken.swift; sourceTree = "<group>"; };
 		456714132B7E9FDC00C6E7A2 /* GetTranslatedToolName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetTranslatedToolName.swift; sourceTree = "<group>"; };
@@ -6223,6 +6225,14 @@
 			path = DependencyContainer;
 			sourceTree = "<group>";
 		};
+		4565BA992BBB3B05002688C1 /* GetTranslatedNumberCount */ = {
+			isa = PBXGroup;
+			children = (
+				4565BA9A2BBB3B0E002688C1 /* GetTranslatedNumberCount.swift */,
+			);
+			path = GetTranslatedNumberCount;
+			sourceTree = "<group>";
+		};
 		4566DCAC2A2686AB00B989A2 /* Realm */ = {
 			isa = PBXGroup;
 			children = (
@@ -10301,6 +10311,7 @@
 			children = (
 				452DFB352B7FAAE5003A4A59 /* GetToolListItemInterfaceStringsRepository */,
 				45DAC8C72B2BBA1200A138C0 /* GetTranslatedLanguageName */,
+				4565BA992BBB3B05002688C1 /* GetTranslatedNumberCount */,
 				456714152B7EA1C900C6E7A2 /* GetTranslatedToolCategory */,
 				452DFB422B7FBB43003A4A59 /* GetTranslatedToolLanguageAvailability */,
 				456714122B7E9FD000C6E7A2 /* GetTranslatedToolName */,
@@ -12088,6 +12099,7 @@
 				45B6FF362BAA39790037B240 /* ViewToolFilterCategoriesDomainModel.swift in Sources */,
 				45965D4B2B4486E1001C9AA5 /* DashboardInterfaceStringsDomainModel.swift in Sources */,
 				45F71679290A13530019B715 /* EmailSignUpApi.swift in Sources */,
+				4565BA9B2BBB3B0E002688C1 /* GetTranslatedNumberCount.swift in Sources */,
 				45FB161027DBDDB60009DF8E /* LearnToShareToolFlow.swift in Sources */,
 				45DAC8C62B2BB9E500A138C0 /* AppLanguageDataModel+TranslatableLanguage.swift in Sources */,
 				45F71625290A12D70019B715 /* CopyrightInfoWebContent.swift in Sources */,

--- a/godtools/App/DependencyContainer/AppDataLayerDependencies.swift
+++ b/godtools/App/DependencyContainer/AppDataLayerDependencies.swift
@@ -326,6 +326,10 @@ class AppDataLayerDependencies {
         )
     }
     
+    func getTranslatedNumberCount() -> GetTranslatedNumberCount {
+        return GetTranslatedNumberCount()
+    }
+    
     func getTranslatedToolCategory() -> GetTranslatedToolCategory {
         return GetTranslatedToolCategory(
             localizationServices: getLocalizationServices(),

--- a/godtools/App/DependencyContainer/AppDomainLayerDependencies.swift
+++ b/godtools/App/DependencyContainer/AppDomainLayerDependencies.swift
@@ -152,7 +152,8 @@ class AppDomainLayerDependencies {
     
     func getUserActivityStatsUseCase() -> GetUserActivityStatsUseCase {
         return GetUserActivityStatsUseCase(
-            localizationServices: dataLayer.getLocalizationServices()
+            localizationServices: dataLayer.getLocalizationServices(),
+            getTranslatedNumberCount: dataLayer.getTranslatedNumberCount()
         )
     }
     

--- a/godtools/App/Features/AppLanguage/Data-DomainInterface/GetDownloadableLanguagesListRepository.swift
+++ b/godtools/App/Features/AppLanguage/Data-DomainInterface/GetDownloadableLanguagesListRepository.swift
@@ -98,7 +98,7 @@ extension GetDownloadableLanguagesListRepository {
             fileType: .stringsdict
         )
         
-        return String.localizedStringWithFormat(formatString, numberOfTools)
+        return String(format: formatString, locale: Locale(identifier: localeId), numberOfTools)
     }
     
     private func getDownloadStatus(for languageId: String) -> LanguageDownloadStatusDomainModel {

--- a/godtools/App/Features/GlobalActivity/Data-DomainInterface/GetGlobalActivityThisWeekRepository.swift
+++ b/godtools/App/Features/GlobalActivity/Data-DomainInterface/GetGlobalActivityThisWeekRepository.swift
@@ -13,12 +13,13 @@ class GetGlobalActivityThisWeekRepository: GetGlobalActivityThisWeekRepositoryIn
     
     private let globalAnalyticsRepository: GlobalAnalyticsRepository
     private let localizationServices: LocalizationServices
-    private let formatNumberWithCommas: NumberFormatter = NumberFormatter()
+    private let getTranslatedNumberCount: GetTranslatedNumberCount
     
-    init(globalAnalyticsRepository: GlobalAnalyticsRepository, localizationServices: LocalizationServices) {
+    init(globalAnalyticsRepository: GlobalAnalyticsRepository, localizationServices: LocalizationServices, getTranslatedNumberCount: GetTranslatedNumberCount) {
         
         self.globalAnalyticsRepository = globalAnalyticsRepository
         self.localizationServices = localizationServices
+        self.getTranslatedNumberCount = getTranslatedNumberCount
     }
     
     func getActivityPublisher(translateInLanguage: AppLanguageDomainModel) -> AnyPublisher<[GlobalActivityThisWeekDomainModel], Never> {
@@ -35,22 +36,22 @@ class GetGlobalActivityThisWeekRepository: GetGlobalActivityThisWeekRepositoryIn
             let localeId = translateInLanguage
             
             let usersAnalytics = GlobalActivityThisWeekDomainModel(
-                count: self.getFormattedCount(translateInLanguage: translateInLanguage, count: dataModel.users),
+                count: self.getTranslatedNumberCount.getTranslatedCount(count: dataModel.users, translateInLanguage: translateInLanguage),
                 label: self.localizationServices.stringForLocaleElseEnglish(localeIdentifier: localeId, key: "accountActivity.globalAnalytics.users.title")
             )
             
             let gospelPresentationAnalytics = GlobalActivityThisWeekDomainModel(
-                count: self.getFormattedCount(translateInLanguage: translateInLanguage, count: dataModel.gospelPresentations),
+                count: self.getTranslatedNumberCount.getTranslatedCount(count: dataModel.gospelPresentations, translateInLanguage: translateInLanguage),
                 label: self.localizationServices.stringForLocaleElseEnglish(localeIdentifier: localeId, key: "accountActivity.globalAnalytics.gospelPresentation.title")
             )
             
             let launchesAnalytics = GlobalActivityThisWeekDomainModel(
-                count: self.getFormattedCount(translateInLanguage: translateInLanguage, count: dataModel.launches),
+                count: self.getTranslatedNumberCount.getTranslatedCount(count: dataModel.launches, translateInLanguage: translateInLanguage),
                 label: self.localizationServices.stringForLocaleElseEnglish(localeIdentifier: localeId, key: "accountActivity.globalAnalytics.launches.title")
             )
             
             let countriesAnalytics = GlobalActivityThisWeekDomainModel(
-                count: self.getFormattedCount(translateInLanguage: translateInLanguage, count: dataModel.countries),
+                count: self.getTranslatedNumberCount.getTranslatedCount(count: dataModel.countries, translateInLanguage: translateInLanguage),
                 label: self.localizationServices.stringForLocaleElseEnglish(localeIdentifier: localeId, key: "accountActivity.globalAnalytics.countries.title")
             )
             
@@ -60,13 +61,5 @@ class GetGlobalActivityThisWeekRepository: GetGlobalActivityThisWeekRepositoryIn
                 .eraseToAnyPublisher()
         })
         .eraseToAnyPublisher()
-    }
-    
-    private func getFormattedCount(translateInLanguage: AppLanguageDomainModel, count: Int) -> String {
-        
-        formatNumberWithCommas.numberStyle = .decimal
-        formatNumberWithCommas.locale = Locale(identifier: translateInLanguage)
-        
-        return formatNumberWithCommas.string(from: NSNumber(value: count)) ?? ""
     }
 }

--- a/godtools/App/Features/GlobalActivity/DependencyContainer/GlobalActivityDataLayerDependencies.swift
+++ b/godtools/App/Features/GlobalActivity/DependencyContainer/GlobalActivityDataLayerDependencies.swift
@@ -38,7 +38,8 @@ class GlobalActivityDataLayerDependencies {
         
         return GetGlobalActivityThisWeekRepository(
             globalAnalyticsRepository: getGlobalAnalyticsRepository(),
-            localizationServices: coreDataLayer.getLocalizationServices()
+            localizationServices: coreDataLayer.getLocalizationServices(),
+            getTranslatedNumberCount: coreDataLayer.getTranslatedNumberCount()
         )
     }
 }

--- a/godtools/App/Features/Menu/Domain/UseCases/GetUserActivityBadgeUseCase/GetUserActivityBadgeUseCase.swift
+++ b/godtools/App/Features/Menu/Domain/UseCases/GetUserActivityBadgeUseCase/GetUserActivityBadgeUseCase.swift
@@ -84,8 +84,8 @@ class GetUserActivityBadgeUseCase {
             fileType: .stringsdict
         )
         
-        let badgeText: String = String.localizedStringWithFormat(formatString, progressTarget)
-
+        let badgeText: String = String(format: formatString, locale: Locale(identifier: translatedInAppLanguage), progressTarget)
+        
         return badgeText
     }
     

--- a/godtools/App/Features/Menu/Domain/UseCases/GetUserActivityStatsUseCase/GetUserActivityStatsUseCase.swift
+++ b/godtools/App/Features/Menu/Domain/UseCases/GetUserActivityStatsUseCase/GetUserActivityStatsUseCase.swift
@@ -13,10 +13,12 @@ import SwiftUI
 class GetUserActivityStatsUseCase {
     
     private let localizationServices: LocalizationServices
+    private let getTranslatedNumberCount: GetTranslatedNumberCount
     
-    init(localizationServices: LocalizationServices) {
+    init(localizationServices: LocalizationServices, getTranslatedNumberCount: GetTranslatedNumberCount) {
         
         self.localizationServices = localizationServices
+        self.getTranslatedNumberCount = getTranslatedNumberCount
     }
     
     func getUserActivityStats(from userActivity: UserActivity, translatedInAppLanguage: AppLanguageDomainModel) -> [UserActivityStatDomainModel] {
@@ -25,42 +27,42 @@ class GetUserActivityStatsUseCase {
             iconImageName: ImageCatalog.userActivityToolOpens.name,
             text: getUserActivityText(stringKey: MenuStringKeys.Account.Activity.toolOpens.rawValue, activityCount: userActivity.toolOpens, translatedInAppLanguage: translatedInAppLanguage),
             textColor: Color.getColorWithRGB(red: 5, green: 105, blue: 155, opacity: 1),
-            value: String(userActivity.toolOpens)
+            value: getUserActivityFormattedCount(activityCount: userActivity.toolOpens, translatedInAppLanguage: translatedInAppLanguage)
         )
         
         let lessonCompletionsStat = UserActivityStatDomainModel(
             iconImageName: ImageCatalog.userActivityLessonCompletions.name,
             text: getUserActivityText(stringKey: MenuStringKeys.Account.Activity.lessonCompletions.rawValue, activityCount: userActivity.lessonCompletions, translatedInAppLanguage: translatedInAppLanguage),
             textColor: Color.getColorWithRGB(red: 55, green: 167, blue: 160, opacity: 1),
-            value: String(userActivity.lessonCompletions)
+            value: getUserActivityFormattedCount(activityCount: userActivity.lessonCompletions, translatedInAppLanguage: translatedInAppLanguage)
         )
         
         let screenSharesStat = UserActivityStatDomainModel(
             iconImageName: ImageCatalog.userActivityScreenShares.name,
             text: getUserActivityText(stringKey: MenuStringKeys.Account.Activity.screenShares.rawValue, activityCount: userActivity.screenShares, translatedInAppLanguage: translatedInAppLanguage),
             textColor: Color.getColorWithRGB(red: 229, green: 91, blue: 54, opacity: 1),
-            value: String(userActivity.screenShares)
+            value: getUserActivityFormattedCount(activityCount: userActivity.screenShares, translatedInAppLanguage: translatedInAppLanguage)
         )
         
         let linksSharedStat = UserActivityStatDomainModel(
             iconImageName: ImageCatalog.userActivityLinksShared.name,
             text: getUserActivityText(stringKey: MenuStringKeys.Account.Activity.linksShared.rawValue, activityCount: userActivity.linksShared, translatedInAppLanguage: translatedInAppLanguage),
             textColor: Color.getColorWithRGB(red: 47, green: 54, blue: 118, opacity: 1),
-            value: String(userActivity.linksShared)
+            value: getUserActivityFormattedCount(activityCount: userActivity.linksShared, translatedInAppLanguage: translatedInAppLanguage)
         )
         
         let languagesUsedStat = UserActivityStatDomainModel(
             iconImageName: ImageCatalog.userActivityLanguagesUsed.name,
             text: getUserActivityText(stringKey: MenuStringKeys.Account.Activity.languagesUsed.rawValue, activityCount: userActivity.languagesUsed, translatedInAppLanguage: translatedInAppLanguage),
             textColor: Color.getColorWithRGB(red: 110, green: 220, blue: 80, opacity: 1),
-            value: String(userActivity.languagesUsed)
+            value: getUserActivityFormattedCount(activityCount: userActivity.languagesUsed, translatedInAppLanguage: translatedInAppLanguage)
         )
         
         let sessionsStat = UserActivityStatDomainModel(
             iconImageName: ImageCatalog.userActivitySessions.name,
             text: getUserActivityText(stringKey: MenuStringKeys.Account.Activity.sessions.rawValue, activityCount: userActivity.sessions, translatedInAppLanguage: translatedInAppLanguage),
             textColor: Color.getColorWithRGB(red: 224, green: 206, blue: 38, opacity: 1),
-            value: String(userActivity.sessions)
+            value: getUserActivityFormattedCount(activityCount: userActivity.sessions, translatedInAppLanguage: translatedInAppLanguage)
         )
         
         return [toolOpensStat, lessonCompletionsStat, screenSharesStat, linksSharedStat, languagesUsedStat, sessionsStat]
@@ -75,5 +77,10 @@ class GetUserActivityStatsUseCase {
         )
         
         return String.localizedStringWithFormat(formatString, activityCount)
+    }
+    
+    private func getUserActivityFormattedCount(activityCount: Int32, translatedInAppLanguage: AppLanguageDomainModel) -> String {
+                        
+        return getTranslatedNumberCount.getTranslatedCount(count: Int(activityCount), translateInLanguage: translatedInAppLanguage)
     }
 }

--- a/godtools/App/Features/Menu/Domain/UseCases/GetUserActivityStatsUseCase/GetUserActivityStatsUseCase.swift
+++ b/godtools/App/Features/Menu/Domain/UseCases/GetUserActivityStatsUseCase/GetUserActivityStatsUseCase.swift
@@ -76,7 +76,7 @@ class GetUserActivityStatsUseCase {
             fileType: .stringsdict
         )
         
-        return String.localizedStringWithFormat(formatString, activityCount)
+        return String(format: formatString, locale: Locale(identifier: translatedInAppLanguage), activityCount)
     }
     
     private func getUserActivityFormattedCount(activityCount: Int32, translatedInAppLanguage: AppLanguageDomainModel) -> String {

--- a/godtools/App/Features/ToolsFilter/Data-DomainInterface/GetToolFilterCategoriesRepository.swift
+++ b/godtools/App/Features/ToolsFilter/Data-DomainInterface/GetToolFilterCategoriesRepository.swift
@@ -122,7 +122,7 @@ extension GetToolFilterCategoriesRepository {
             fileType: .stringsdict
         )
         
-        return String.localizedStringWithFormat(formatString, toolsAvailableCount)
+        return String(format: formatString, locale: Locale(identifier: translatedInAppLanguage), toolsAvailableCount)
     }
 }
 

--- a/godtools/App/Features/ToolsFilter/Data-DomainInterface/GetToolFilterLanguagesRepository.swift
+++ b/godtools/App/Features/ToolsFilter/Data-DomainInterface/GetToolFilterLanguagesRepository.swift
@@ -155,8 +155,8 @@ extension GetToolFilterLanguagesRepository {
             fileType: .stringsdict
         )
         
-        let localizedString = String.localizedStringWithFormat(formatString, toolsAvailableCount)
-        
+        let localizedString = String(format: formatString, locale: Locale(identifier: translatedInAppLanguage), toolsAvailableCount)
+                
         return localizedString
     }
 }

--- a/godtools/App/Share/Data-DomainInterface/Supporting/GetTranslatedNumberCount/GetTranslatedNumberCount.swift
+++ b/godtools/App/Share/Data-DomainInterface/Supporting/GetTranslatedNumberCount/GetTranslatedNumberCount.swift
@@ -1,0 +1,32 @@
+//
+//  GetTranslatedNumberCount.swift
+//  godtools
+//
+//  Created by Levi Eggert on 4/1/24.
+//  Copyright © 2024 Cru. All rights reserved.
+//
+
+import Foundation
+
+class GetTranslatedNumberCount {
+    
+    private static let sharedNumberFormatter: NumberFormatter = NumberFormatter()
+    
+    init() {
+        
+    }
+    
+    func getTranslatedCount(count: Int, translateInLanguage: BCP47LanguageIdentifier) -> String {
+        
+        let formatter: NumberFormatter = GetTranslatedNumberCount.sharedNumberFormatter
+        
+        formatter.numberStyle = .decimal
+        formatter.locale = Locale(identifier: translateInLanguage)
+        
+        guard let formattedString = formatter.string(from: NSNumber(value: count)) else {
+            return String(count)
+        }
+        
+        return formattedString
+    }
+}


### PR DESCRIPTION
This PR updates places in the app where number counts are displayed and the goal is to format those number counts based on the provided language to translate in.  This is mostly noticeable when number counts get into the thousands.

- Any number counts that aren't part of the ```.stringsdict``` are formatted using a NumberFormatter in the shared Supporting ```GetTranslatedNumberCount.swift```.
- Any number counts that are part of a ```.stringsdict``` will provide the Locale in String formatting.  Example: ```String(format: formatString, locale: Locale(identifier: localeId), numberOfTools)```



Screenshot of Global Activity using GetTranslatedNumberCount

![Simulator Screenshot - iPhone 12 mini - 2024-04-01 at 15 27 21](https://github.com/CruGlobal/godtools-swift/assets/59846460/85066942-fc02-41f9-9d08-c12b2d80f83f)

Screenshot of downloadable languages with test count 535,123,456 and language Portuguese using String formatting with Locale.

![Portuguese-string-with-locale](https://github.com/CruGlobal/godtools-swift/assets/59846460/9e5a7a32-9c6a-4170-ba0d-5eb9b228ecb4)







