### PR TITLE
GT Add some behavior tests for tools category filter searching

### DIFF
--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -346,6 +346,7 @@
 		453F84DA2A02A0390005101E /* ArticleManifestAemRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 453F84D72A02A0390005101E /* ArticleManifestAemRepository.swift */; };
 		453F84DB2A02A0390005101E /* ArticleManifestDownloadArticlesReceipt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 453F84D82A02A0390005101E /* ArticleManifestDownloadArticlesReceipt.swift */; };
 		453F84DC2A02A0390005101E /* ArticleCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 453F84D92A02A0390005101E /* ArticleCategory.swift */; };
+		453FE09F2BBEDC770090DED1 /* SearchToolFilterCategoriesRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 453FE09E2BBEDC770090DED1 /* SearchToolFilterCategoriesRepositoryTests.swift */; };
 		45430CF12B1FB43E002B94A3 /* TextWithLinksView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45430CF02B1FB43E002B94A3 /* TextWithLinksView.swift */; };
 		45430CF62B1FB638002B94A3 /* String+ToUrlMarkdown.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45430CF52B1FB638002B94A3 /* String+ToUrlMarkdown.swift */; };
 		45430CF82B1FBA2A002B94A3 /* BackwardsCompatibleTextWithLinks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45430CF72B1FBA2A002B94A3 /* BackwardsCompatibleTextWithLinks.swift */; };
@@ -1886,6 +1887,7 @@
 		453F84D72A02A0390005101E /* ArticleManifestAemRepository.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArticleManifestAemRepository.swift; sourceTree = "<group>"; };
 		453F84D82A02A0390005101E /* ArticleManifestDownloadArticlesReceipt.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArticleManifestDownloadArticlesReceipt.swift; sourceTree = "<group>"; };
 		453F84D92A02A0390005101E /* ArticleCategory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArticleCategory.swift; sourceTree = "<group>"; };
+		453FE09E2BBEDC770090DED1 /* SearchToolFilterCategoriesRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchToolFilterCategoriesRepositoryTests.swift; sourceTree = "<group>"; };
 		45430CF02B1FB43E002B94A3 /* TextWithLinksView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextWithLinksView.swift; sourceTree = "<group>"; };
 		45430CF52B1FB638002B94A3 /* String+ToUrlMarkdown.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+ToUrlMarkdown.swift"; sourceTree = "<group>"; };
 		45430CF72B1FBA2A002B94A3 /* BackwardsCompatibleTextWithLinks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackwardsCompatibleTextWithLinks.swift; sourceTree = "<group>"; };
@@ -4564,6 +4566,7 @@
 			children = (
 				45BA7B832AF2E0AC001BAB31 /* DownloadToolProgress */,
 				459DF8E42AE17A350035D97B /* Onboarding */,
+				453FE09C2BBEDBF00090DED1 /* ToolsFilter */,
 			);
 			path = Features;
 			sourceTree = "<group>";
@@ -5026,6 +5029,22 @@
 				453F84B02A029FC00005101E /* ArticleJcrContentType.swift */,
 			);
 			path = Models;
+			sourceTree = "<group>";
+		};
+		453FE09C2BBEDBF00090DED1 /* ToolsFilter */ = {
+			isa = PBXGroup;
+			children = (
+				453FE09D2BBEDC650090DED1 /* Data-DomainInterface */,
+			);
+			path = ToolsFilter;
+			sourceTree = "<group>";
+		};
+		453FE09D2BBEDC650090DED1 /* Data-DomainInterface */ = {
+			isa = PBXGroup;
+			children = (
+				453FE09E2BBEDC770090DED1 /* SearchToolFilterCategoriesRepositoryTests.swift */,
+			);
+			path = "Data-DomainInterface";
 			sourceTree = "<group>";
 		};
 		45430CF32B1FB619002B94A3 /* Swift */ = {
@@ -12851,6 +12870,7 @@
 				45368A1C2ABB2D850028A570 /* LocalizationServicesTests.swift in Sources */,
 				45CBDA0E2BA394FD0007DEC8 /* MockOnboardingTutorialViewedRepository.swift in Sources */,
 				45CBDA102BA398D90007DEC8 /* GetOnboardingTutorialInterfaceStringsRepositoryTests.swift in Sources */,
+				453FE09F2BBEDC770090DED1 /* SearchToolFilterCategoriesRepositoryTests.swift in Sources */,
 				45CBDA142BA399750007DEC8 /* MockLocalizationServices.swift in Sources */,
 				45368A162ABB2D850028A570 /* LocaleTests.swift in Sources */,
 				45E198662BA47F4400BF14F3 /* GetDownloadToolProgressInterfaceStringsRepositoryTests.swift in Sources */,

--- a/godtoolsTests/App/Features/ToolsFilter/Data-DomainInterface/SearchToolFilterCategoriesRepositoryTests.swift
+++ b/godtoolsTests/App/Features/ToolsFilter/Data-DomainInterface/SearchToolFilterCategoriesRepositoryTests.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 @testable import godtools
+import Combine
 import Quick
 import Nimble
 

--- a/godtoolsTests/App/Features/ToolsFilter/Data-DomainInterface/SearchToolFilterCategoriesRepositoryTests.swift
+++ b/godtoolsTests/App/Features/ToolsFilter/Data-DomainInterface/SearchToolFilterCategoriesRepositoryTests.swift
@@ -1,0 +1,166 @@
+//
+//  SearchToolFilterCategoriesRepositoryTests.swift
+//  godtoolsTests
+//
+//  Created by Levi Eggert on 4/4/24.
+//  Copyright © 2024 Cru. All rights reserved.
+//
+
+import Foundation
+@testable import godtools
+import Quick
+import Nimble
+
+class SearchToolFilterCategoriesRepositoryTests: QuickSpec {
+    
+    override class func spec() {
+     
+        describe("User is searching a category in the tools filter categories list.") {
+            
+            let searchCategoriesRepository = SearchToolFilterCategoriesRepository(
+                stringSearcher: StringSearcher()
+            )
+            
+            let lowercasedSingleLetterSearchString: String = "c"
+            
+            context("When a user inputs a lowercased single letter search string \(lowercasedSingleLetterSearchString)") {
+                
+                let allCategories: [CategoryFilterDomainModel] = [
+                    .category(categoryId: "", translatedName: "Church", toolsAvailableText: ""),
+                    .category(categoryId: "", translatedName: "church", toolsAvailableText: ""),
+                    .category(categoryId: "", translatedName: "food", toolsAvailableText: ""),
+                    .category(categoryId: "", translatedName: "Food", toolsAvailableText: ""),
+                    .category(categoryId: "", translatedName: "soccer", toolsAvailableText: ""),
+                    .category(categoryId: "", translatedName: "soCCer", toolsAvailableText: "")
+                ]
+                
+                it("I expect all categories that contain the lowercased single letter search string \(lowercasedSingleLetterSearchString) ignoring case.") {
+                    
+                    var searchedCategories: [String] = Array()
+                    var sinkCompleted: Bool = false
+                    
+                    waitUntil { done in
+                        
+                        _ = searchCategoriesRepository
+                            .getSearchResultsPublisher(for: lowercasedSingleLetterSearchString, in: allCategories)
+                            .sink { (categories: [CategoryFilterDomainModel]) in
+                                
+                                guard !sinkCompleted else {
+                                    return
+                                }
+                                
+                                sinkCompleted = true
+                                
+                                searchedCategories = categories.map({$0.primaryText})
+                                
+                                done()
+                            }
+                    }
+                    
+                    let expectedCategories: [String] = ["soccer", "soCCer", "Church", "church"]
+                    let shouldNotContainCategories: [String] = ["food", "Food"]
+                    
+                    expect(searchedCategories.count).to(equal(expectedCategories.count))
+                    expect(searchedCategories).to(contain(expectedCategories))
+                    expect(searchedCategories).toNot(contain(shouldNotContainCategories))
+                }
+            }
+            
+            let uppercasedSingleLetterSearchString: String = "Y"
+            
+            context("When a user inputs an uppercased single letter search string \(uppercasedSingleLetterSearchString)") {
+                
+                let allCategories: [CategoryFilterDomainModel] = [
+                    .category(categoryId: "", translatedName: "Church", toolsAvailableText: ""),
+                    .category(categoryId: "", translatedName: "church", toolsAvailableText: ""),
+                    .category(categoryId: "", translatedName: "foody", toolsAvailableText: ""),
+                    .category(categoryId: "", translatedName: "Food", toolsAvailableText: ""),
+                    .category(categoryId: "", translatedName: "soccer", toolsAvailableText: ""),
+                    .category(categoryId: "", translatedName: "soCCer", toolsAvailableText: ""),
+                    .category(categoryId: "", translatedName: "Yellow", toolsAvailableText: ""),
+                    .category(categoryId: "", translatedName: "may", toolsAvailableText: "")
+                ]
+                
+                it("I expect all categories that contain the uppercased single letter search string \(uppercasedSingleLetterSearchString) ignoring case.") {
+                    
+                    var searchedCategories: [String] = Array()
+                    var sinkCompleted: Bool = false
+                    
+                    waitUntil { done in
+                        
+                        _ = searchCategoriesRepository
+                            .getSearchResultsPublisher(for: uppercasedSingleLetterSearchString, in: allCategories)
+                            .sink { (categories: [CategoryFilterDomainModel]) in
+                                
+                                guard !sinkCompleted else {
+                                    return
+                                }
+                                
+                                sinkCompleted = true
+                                
+                                searchedCategories = categories.map({$0.primaryText})
+                                
+                                done()
+                            }
+                    }
+                    
+                    let expectedCategories: [String] = ["foody", "Yellow", "may"]
+                    let shouldNotContainCategories: [String] = ["Church", "church", "Food", "soccer", "soCCer"]
+                    
+                    expect(searchedCategories.count).to(equal(expectedCategories.count))
+                    expect(searchedCategories).to(contain(expectedCategories))
+                    expect(searchedCategories).toNot(contain(shouldNotContainCategories))
+                }
+            }
+            
+            let multiTextSearchString: String = "anD"
+            
+            context("When a user inputs a multi-text search string \(multiTextSearchString)") {
+                
+                let allCategories: [CategoryFilterDomainModel] = [
+                    .category(categoryId: "", translatedName: "blAnd", toolsAvailableText: ""),
+                    .category(categoryId: "", translatedName: "land", toolsAvailableText: ""),
+                    .category(categoryId: "", translatedName: "Canned", toolsAvailableText: ""),
+                    .category(categoryId: "", translatedName: "WAND", toolsAvailableText: ""),
+                    .category(categoryId: "", translatedName: "wander", toolsAvailableText: ""),
+                    .category(categoryId: "", translatedName: "pAnda", toolsAvailableText: ""),
+                    .category(categoryId: "", translatedName: "bran", toolsAvailableText: ""),
+                    .category(categoryId: "", translatedName: "Tan", toolsAvailableText: ""),
+                    .category(categoryId: "", translatedName: "Tanned", toolsAvailableText: ""),
+                    .category(categoryId: "", translatedName: "sanded", toolsAvailableText: "")
+                ]
+                
+                it("I expect all categories that contain the multi-text search string \(multiTextSearchString) ignoring case.") {
+                    
+                    var searchedCategories: [String] = Array()
+                    var sinkCompleted: Bool = false
+                    
+                    waitUntil { done in
+                        
+                        _ = searchCategoriesRepository
+                            .getSearchResultsPublisher(for: multiTextSearchString, in: allCategories)
+                            .sink { (categories: [CategoryFilterDomainModel]) in
+                                
+                                guard !sinkCompleted else {
+                                    return
+                                }
+                                
+                                sinkCompleted = true
+                                
+                                searchedCategories = categories.map({$0.primaryText})
+                                
+                                done()
+                            }
+                    }
+                    
+                    let expectedCategories: [String] = ["blAnd", "land", "WAND", "wander", "pAnda", "sanded"]
+                    let shouldNotContainCategories: [String] = ["Canned", "bran", "Tan", "Tanned"]
+                    
+                    expect(searchedCategories.count).to(equal(expectedCategories.count))
+                    expect(searchedCategories).to(contain(expectedCategories))
+                    expect(searchedCategories).toNot(contain(shouldNotContainCategories))
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Hey @rachaelblue this is my thinking on behavior tests for our business logic (domain interface implementations).  

This example includes tests for tools category filter searching.

These tests would mostly live in ```/godtoolsTests/App/Features/FeatureName/Data-DomainInterface/*``` to line up with the godtools target folder structure.

I will probably also include tests for the ```/App/Share/Data-DomainInterface/Supporting/*```.

This means for mocking the data layer dependencies we would need to either:

1. Create an interface to mock against.  One example of this is LocalizationServices, where GetOnboardingTutorialInterfaceStringsRepositoryTests.swift includes a mock and GetOnboardingTutorialInterfaceStringsRepository.swift points to the LocalizationServicesInterface.

That mock lives in ```/godtoolsTests/App/Share/Data/LocalizationServices/MockLocalizationServices/``` to line up with the godtools target folder structure.

2. Create a mock realm database via TestsInMemoryRealmDatabase and then create TestsDiContainer for fetching data layer classes that depend on a realm database.  An example of this is in GetDownloadToolProgressInterfaceStringsRepositoryTests.swift where I fetch a ResourcesRepository instance since creating an interface would probably be a lot of work.

The tools category filter searching was easy since the test data is injected as an input.

Let me know any thoughts or concerns you see. 

I'm hoping this is a good path and it will make sense as we add more and more tests.
