### PR TITLE
GT-2351 Fix openers cards resetting to card 1 when toggling language

### DIFF
--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/Pages/MobileContentPagesViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/Pages/MobileContentPagesViewModel.swift
@@ -249,6 +249,8 @@ class MobileContentPagesViewModel: NSObject, ObservableObject {
             
         countLanguageUsageIfLanguageChanged(updatedLanguage: pageRenderer.language)
         
+        rendererWillChangeSignal.accept()
+        
         currentPageRenderer.send(pageRenderer)
         
         let isInitialPageRender: Bool = pageModels.isEmpty


### PR DESCRIPTION
Somewhere during a refactor of the renderer page navigation a call to ```rendererWillChangeSignal.accept()``` was removed.  This signal tells the View that the renderer is about to change and allows the View to save it's current state this way when the page renderer does change the View can restore its state.