### PR TITLE
GT-2363 Fix lesson evaluation scale slider disappearing in iOS 17

### DIFF
--- a/godtools/App/Features/LessonEvaluation/Presentation/LessonEvaluation/LessonEvaluationView.swift
+++ b/godtools/App/Features/LessonEvaluation/Presentation/LessonEvaluation/LessonEvaluationView.swift
@@ -87,15 +87,24 @@ struct LessonEvaluationView: View {
                         .padding([.top], 30)
                         .padding([.leading], contentInsets.leading)
                     
-                    ScaleValueSliderView(
-                        viewWidth: geometry.size.width - viewInsets.leading - viewInsets.trailing,
-                        tintColor: ColorPalette.gtBlue.color,
-                        minScale: ScaleValue(lessonEvaluationScale: viewModel.readyToShareFaithScale.minScale),
-                        maxScale: ScaleValue(lessonEvaluationScale: viewModel.readyToShareFaithScale.maxScale),
-                        scaleIntValue: $viewModel.readyToShareFaithScaleIntValue,
-                        scaleDisplayValue: viewModel.readyToShareFaithScale.scale.valueTranslatedInAppLanguage
-                    )
-                    .padding([.top], 14)
+                    if let readyToShareFaithScale = viewModel.readyToShareFaithScale {
+                        
+                        ScaleValueSliderView(
+                            viewWidth: geometry.size.width - viewInsets.leading - viewInsets.trailing,
+                            tintColor: ColorPalette.gtBlue.color,
+                            minScale: ScaleValue(lessonEvaluationScale: readyToShareFaithScale.minScale),
+                            maxScale: ScaleValue(lessonEvaluationScale: readyToShareFaithScale.maxScale),
+                            scaleIntValue: $viewModel.readyToShareFaithScaleIntValue,
+                            scaleDisplayValue: readyToShareFaithScale.scale.valueTranslatedInAppLanguage
+                        )
+                        .padding([.top], 14)
+                    }
+                    else {
+                        
+                        Rectangle()
+                            .fill(Color.clear)
+                            .frame(width: geometry.size.width, height: ScaleValueSliderView.scrubberSize)
+                    }
                     
                     GTBlueButton(
                         title: viewModel.sendFeedbackButtonTitle,

--- a/godtools/App/Features/LessonEvaluation/Presentation/LessonEvaluation/LessonEvaluationViewModel.swift
+++ b/godtools/App/Features/LessonEvaluation/Presentation/LessonEvaluation/LessonEvaluationViewModel.swift
@@ -36,7 +36,7 @@ class LessonEvaluationViewModel: ObservableObject {
     @Published var noButtonTitle: String = ""
     @Published var shareFaithReadiness: String = ""
     @Published var sendFeedbackButtonTitle: String = ""
-    @Published var readyToShareFaithScale: SpiritualConversationReadinessScaleDomainModel = LessonEvaluationViewModel.getEmptyReadinessScale()
+    @Published var readyToShareFaithScale: SpiritualConversationReadinessScaleDomainModel? = nil
     @Published var readyToShareFaithScaleIntValue: Int = 6
     
     init(flowDelegate: FlowDelegate, lessonId: String, pageIndexReached: Int, getCurrentAppLanguageUseCase: GetCurrentAppLanguageUseCase, getLessonEvaluationInterfaceStringsUseCase: GetLessonEvaluationInterfaceStringsUseCase, didChangeScaleForSpiritualConversationReadinessUseCase: DidChangeScaleForSpiritualConversationReadinessUseCase, evaluateLessonUseCase: EvaluateLessonUseCase, cancelLessonEvaluationUseCase: CancelLessonEvaluationUseCase) {
@@ -89,14 +89,6 @@ class LessonEvaluationViewModel: ObservableObject {
             self?.readyToShareFaithScale = domainModel
         }
         .store(in: &cancellables)
-    }
-    
-    private static func getEmptyReadinessScale() -> SpiritualConversationReadinessScaleDomainModel {
-        return SpiritualConversationReadinessScaleDomainModel(
-            minScale: LessonEvaluationScaleDomainModel(integerValue: 0, valueTranslatedInAppLanguage: ""),
-            maxScale: LessonEvaluationScaleDomainModel(integerValue: 0, valueTranslatedInAppLanguage: ""),
-            scale: LessonEvaluationScaleDomainModel(integerValue: 0, valueTranslatedInAppLanguage: "")
-        )
     }
     
     deinit {

--- a/godtools/App/Share/SwiftUI Views/ScaleValueSlider/ScaleValueSliderView.swift
+++ b/godtools/App/Share/SwiftUI Views/ScaleValueSlider/ScaleValueSliderView.swift
@@ -13,12 +13,13 @@ struct ScaleValueSliderView: View {
     private static let defaultMinScale: ScaleValue = ScaleValue(integerValue: 0, displayValue: "0")
     private static let defaultMaxScale: ScaleValue = ScaleValue(integerValue: 10, displayValue: "10")
     
+    static let scrubberSize: CGFloat = 44
+    
     private let viewWidth: CGFloat
     private let backgroundColor: Color = Color.white
     private let textBoundsWidth: CGFloat = 40
     private let scrubberBarLeading: CGFloat
     private let scrubberBarWidth: CGFloat
-    private let scrubberSize: CGFloat = 44
     private let tintColor: Color
     private let lineWidth: CGFloat = 1
     private let minScale: ScaleValue
@@ -73,7 +74,7 @@ struct ScaleValueSliderView: View {
             
             Rectangle()
                 .foregroundColor(backgroundColor)
-                .frame(width: viewWidth, height: scrubberSize)
+                .frame(width: viewWidth, height: ScaleValueSliderView.scrubberSize)
                 .gesture(dragGesture)
             
             HStack(alignment: .center, spacing: 0) {
@@ -96,11 +97,11 @@ struct ScaleValueSliderView: View {
                 backgroundColor: .white,
                 tintColor: tintColor,
                 lineWidth: lineWidth,
-                size: CGSize(width: scrubberSize, height: scrubberSize),
+                size: CGSize(width: ScaleValueSliderView.scrubberSize, height: ScaleValueSliderView.scrubberSize),
                 text: scaleDisplayValue
             )
             .allowsHitTesting(false)
-            .padding([.leading], scrubberBarLeading + (progress * scrubberBarWidth) - (scrubberSize / 2))
+            .padding([.leading], scrubberBarLeading + (progress * scrubberBarWidth) - (ScaleValueSliderView.scrubberSize / 2))
         }
         .frame(width: viewWidth)
     }


### PR DESCRIPTION
In iOS 17 the lesson evaluation ready to share faith scale slider would sometimes not render.  Was about 50/50.  It seemed due to the fact that it was initially being drawn with min scale 0 and max scale 0 and when the publisher would update with actual scale values it wouldn't update the view.  However, iOS 15 this wasn't an issue.  Not sure what the difference is between iOS 17 and iOS 15, but I'm curious to explore that more.

The fix was to change the published property on the ViewModel to optional and only draw the scale slider view once we have data.