### PR TITLE
GT Update RealmDatabase read extension to include a mapping closure

### DIFF
--- a/godtools/App/Features/AppLanguage/Data/DownloadedLanguagesRepository/Cache/RealmDownloadedLanguagesCache.swift
+++ b/godtools/App/Features/AppLanguage/Data/DownloadedLanguagesRepository/Cache/RealmDownloadedLanguagesCache.swift
@@ -52,20 +52,18 @@ class RealmDownloadedLanguagesCache {
     
     func getDownloadedLanguagePublisher(languageId: String) -> AnyPublisher<DownloadedLanguageDataModel?, Never> {
         
-        return realmDatabase.readObjectPublisher(primaryKey: languageId)
-            .flatMap { (object: RealmDownloadedLanguage?) in
-                
-                guard let object = object else {
-                    return Just<DownloadedLanguageDataModel?>(nil)
-                        .eraseToAnyPublisher()
-                }
-                
-                let dataModel = DownloadedLanguageDataModel(realmDownloadedLanguage: object)
-                
-                return Just(dataModel)
-                    .eraseToAnyPublisher()
+        return realmDatabase.readAndMapObjectPublisher(primaryKey: languageId) { (object: RealmDownloadedLanguage?) in
+            guard let realmDownloadedLanguage = object else {
+                return nil
             }
-            .eraseToAnyPublisher()
+            return DownloadedLanguageDataModel(realmDownloadedLanguage: realmDownloadedLanguage)
+        }
+        .flatMap { (dataModel: DownloadedLanguageDataModel?) in
+
+            return Just(dataModel)
+                .eraseToAnyPublisher()
+        }
+        .eraseToAnyPublisher()
     }
     
     func storeDownloadedLanguage(languageId: String, downloadComplete: Bool) {

--- a/godtools/App/Share/Data/RealmDatabase/RealmDatabase+Read.swift
+++ b/godtools/App/Share/Data/RealmDatabase/RealmDatabase+Read.swift
@@ -10,6 +10,8 @@ import Foundation
 import RealmSwift
 import Combine
 
+// MARK: - Read Object
+
 extension RealmDatabase {
     
     func readObjectElseCreateNew<T: IdentifiableRealmObject>(realm: Realm, primaryKey: String) -> T {
@@ -58,6 +60,102 @@ extension RealmDatabase {
             self.readObjectInBackground(primaryKey: primaryKey) { (realmObject: T?) in
                 
                 promise(.success(realmObject))
+            }
+        }
+        .eraseToAnyPublisher()
+    }
+}
+
+// MARK: - Read Object With Mapping
+
+extension RealmDatabase {
+    
+    func readAndMapObjectInBackground<T: Object, U>(primaryKey: String, mapInBackgroundClosure: @escaping ((_ object: T?) -> U?), completion: @escaping ((_ mappedObject: U?) -> Void)) {
+        
+        background { realm in
+            
+            let realmObject: T? = self.readObject(realm: realm, primaryKey: primaryKey)
+            
+            let mappedObject: U? = mapInBackgroundClosure(realmObject)
+
+            completion(mappedObject)
+        }
+    }
+    
+    func readAndMapObjectPublisher<T: Object, U>(primaryKey: String, mapInBackgroundClosure: @escaping ((_ object: T?) -> U?)) -> AnyPublisher<U?, Never> {
+        
+        return Future() { promise in
+            
+            self.readAndMapObjectInBackground(primaryKey: primaryKey, mapInBackgroundClosure: mapInBackgroundClosure) { (mappedObject: U?) in
+                
+                promise(.success(mappedObject))
+            }
+        }
+        .eraseToAnyPublisher()
+    }
+}
+
+// MARK: - Read Objects
+
+extension RealmDatabase {
+    
+    func readObjects<T: Object>(realm: Realm) -> Results<T> {
+        return realm.objects(T.self)
+    }
+    
+    func readObjects<T: Object>() -> Results<T> {
+          
+        let realm: Realm = openRealm()
+        
+        return readObjects(realm: realm)
+    }
+    
+    func readObjectsInBackground<T: Object>(completion: @escaping ((_ results: Results<T>) -> Void)) {
+        
+        background { realm in
+            
+            let results: Results<T> = self.readObjects(realm: realm)
+
+            completion(results)
+        }
+    }
+    
+    func readObjectsPublisher<T: Object>() -> AnyPublisher<Results<T>, Never> {
+        
+        return Future() { promise in
+            
+            self.readObjectsInBackground() { (results: Results<T>) in
+                
+                promise(.success(results))
+            }
+        }
+        .eraseToAnyPublisher()
+    }
+}
+
+// MARK: - Read Objects With Mapping
+
+extension RealmDatabase {
+    
+    func readAndMapObjectsInBackground<T: Object, U>(mapInBackgroundClosure: @escaping ((_ results: Results<T>) -> [U]), completion: @escaping ((_ mappedObjects: [U]) -> Void)) {
+        
+        background { realm in
+            
+            let results: Results<T> = self.readObjects(realm: realm)
+            
+            let mappedObjects: [U] = mapInBackgroundClosure(results)
+
+            completion(mappedObjects)
+        }
+    }
+    
+    func readAndMapObjectsPublisher<T: Object, U>(mapInBackgroundClosure: @escaping ((_ results: Results<T>) -> [U])) -> AnyPublisher<[U], Never> {
+        
+        return Future() { promise in
+            
+            self.readAndMapObjectsInBackground(mapInBackgroundClosure: mapInBackgroundClosure) { (mappedObjects: [U]) in
+                
+                promise(.success(mappedObjects))
             }
         }
         .eraseToAnyPublisher()


### PR DESCRIPTION
As I've been adding tests I came across a crash when I attempted to read an object from Realm using extension ```RealmDatabase+Read``` ```readObjectPublisher``` method.

The crash occurred in a ```map``` after the call to ```readObjectPublisher``` when mapping the returned realmObject to a dataModel.  

I'm updating the extension to include a ```mapInBackgroundClosure``` which is called within the background queue this way we can map realm objects within the same closure it is fetched from.  I'm hoping this will resolve any crashes when attempting to use ```readObjectPublisher``` with ```map``` or ```flatMap``` since realm objects aren't thread safe.
