### PR TITLE
GT Remove publisher as argument in UseCase

### DIFF
--- a/godtools/App/Features/AppLanguage/Domain/UseCases/GetInterfaceLayoutDirectionUseCase.swift
+++ b/godtools/App/Features/AppLanguage/Domain/UseCases/GetInterfaceLayoutDirectionUseCase.swift
@@ -18,14 +18,10 @@ class GetInterfaceLayoutDirectionUseCase {
         self.getLayoutDirectionInterface = getLayoutDirectionInterface
     }
     
-    func getLayoutDirectionPublisher(appLanguagePublisher: AnyPublisher<AppLanguageDomainModel, Never>) -> AnyPublisher<AppInterfaceLayoutDirectionDomainModel, Never> {
+    func getLayoutDirectionPublisher(appLanguage: AppLanguageDomainModel) -> AnyPublisher<AppInterfaceLayoutDirectionDomainModel, Never> {
         
-        return appLanguagePublisher
-            .flatMap({ (appLanguage: AppLanguageDomainModel) -> AnyPublisher<AppInterfaceLayoutDirectionDomainModel, Never> in
-                
-                return self.getLayoutDirectionInterface.getLayoutDirectionPublisher(appLanguage: appLanguage)
-                    .eraseToAnyPublisher()
-            })
+        return getLayoutDirectionInterface
+            .getLayoutDirectionPublisher(appLanguage: appLanguage)
             .eraseToAnyPublisher()
     }
 }

--- a/godtools/App/Share/Application/ApplicationLayout/ApplicationLayout.swift
+++ b/godtools/App/Share/Application/ApplicationLayout/ApplicationLayout.swift
@@ -51,11 +51,15 @@ class ApplicationLayout: ObservableObject {
             .getLanguagePublisher()
             .assign(to: &$appLanguage)
         
-        
         let getInterfaceLayoutDirectionUseCase = appLanguageFeatureDiContainer.domainLayer.getInterfaceLayoutDirectionUseCase()
 
-        getInterfaceLayoutDirectionUseCase
-            .getLayoutDirectionPublisher(appLanguagePublisher: $appLanguage.eraseToAnyPublisher())
+        $appLanguage.eraseToAnyPublisher()
+            .flatMap({ (appLanguage: AppLanguageDomainModel) -> AnyPublisher<AppInterfaceLayoutDirectionDomainModel, Never> in
+                
+                return getInterfaceLayoutDirectionUseCase
+                    .getLayoutDirectionPublisher(appLanguage: appLanguage)
+                    .eraseToAnyPublisher()
+            })
             .receive(on: DispatchQueue.main)
             .sink { (interfaceLayoutDirection: AppInterfaceLayoutDirectionDomainModel) in
                 


### PR DESCRIPTION
As part of our architecture guidelines we will no longer be injecting publishers into UseCases as inputs.