### PR TITLE
GT-2372 Fix bug where language availability checkmark was reverting to the previous language selection after a pull to refresh

### DIFF
--- a/godtools/App/Features/Dashboard/Data-DomainInterface/GetToolsRepository.swift
+++ b/godtools/App/Features/Dashboard/Data-DomainInterface/GetToolsRepository.swift
@@ -40,11 +40,9 @@ class GetToolsRepository: GetToolsRepositoryInterface {
             languageForAvailabilityTextModel = nil
         }
         
-        return Publishers.CombineLatest(
-            resourcesRepository.getResourcesChangedPublisher().prepend(Void()),
-            getToolListItemInterfaceStringsRepository.getStringsPublisher(translateInLanguage: translatedInAppLanguage)
-        )
-        .flatMap({ (resourcesChanged: Void, interfaceStrings: ToolListItemInterfaceStringsDomainModel) -> AnyPublisher<[ToolListItemDomainModel], Never> in
+        return getToolListItemInterfaceStringsRepository.getStringsPublisher(translateInLanguage: translatedInAppLanguage)
+            .eraseToAnyPublisher()
+        .flatMap({ (interfaceStrings: ToolListItemInterfaceStringsDomainModel) -> AnyPublisher<[ToolListItemDomainModel], Never> in
         
             let tools: [ResourceModel] = self.resourcesRepository.getAllToolsList(
                 filterByCategory: filterToolsByCategory?.id,

--- a/godtools/App/Features/SpotlightTools/Data-DomainInterface/GetSpotlightToolsRepository.swift
+++ b/godtools/App/Features/SpotlightTools/Data-DomainInterface/GetSpotlightToolsRepository.swift
@@ -40,11 +40,9 @@ class GetSpotlightToolsRepository: GetSpotlightToolsRepositoryInterface {
             languageForAvailabilityTextModel = nil
         }
         
-        return Publishers.CombineLatest(
-            resourcesRepository.getResourcesChangedPublisher(),
-            getToolListItemInterfaceStringsRepository.getStringsPublisher(translateInLanguage: translatedInAppLanguage)
-        )
-        .flatMap({ (resourcesChanged: Void, interfaceStrings: ToolListItemInterfaceStringsDomainModel) -> AnyPublisher<[SpotlightToolListItemDomainModel], Never> in
+        return getToolListItemInterfaceStringsRepository.getStringsPublisher(translateInLanguage: translatedInAppLanguage)
+            .eraseToAnyPublisher()
+        .flatMap({ (interfaceStrings: ToolListItemInterfaceStringsDomainModel) -> AnyPublisher<[SpotlightToolListItemDomainModel], Never> in
         
             let spotlightToolResources: [ResourceModel] = self.resourcesRepository.getSpotlightTools()
 


### PR DESCRIPTION
This bug was interesting and something we will need to pay attention to and will need to come to some type of standard to reduce the chances of similar bugs.

The main issue was where we had the ```resourcesChanged``` observing.  When that was triggered it was taking in the scope of the language availability rather than what the true language selection was.  This was fixed by removing the observer and pushing the trigger to the top of publisher chain in the ViewModel.

Need to do some more thinking here as a way to ensure we don't introduce similar bugs like this.