### PR TITLE
GT-2377 fix bug in favorites and lessons where data was reverting back to a previously selected app language

### DIFF
--- a/godtools/App/Features/Dashboard/Data-DomainInterface/GetToolsRepository.swift
+++ b/godtools/App/Features/Dashboard/Data-DomainInterface/GetToolsRepository.swift
@@ -40,9 +40,11 @@ class GetToolsRepository: GetToolsRepositoryInterface {
             languageForAvailabilityTextModel = nil
         }
         
-        return getToolListItemInterfaceStringsRepository.getStringsPublisher(translateInLanguage: translatedInAppLanguage)
-            .eraseToAnyPublisher()
-        .flatMap({ (interfaceStrings: ToolListItemInterfaceStringsDomainModel) -> AnyPublisher<[ToolListItemDomainModel], Never> in
+        return Publishers.CombineLatest(
+            resourcesRepository.getResourcesChangedPublisher().prepend(Void()),
+            getToolListItemInterfaceStringsRepository.getStringsPublisher(translateInLanguage: translatedInAppLanguage)
+        )
+        .flatMap({ (resourcesChanged: Void, interfaceStrings: ToolListItemInterfaceStringsDomainModel) -> AnyPublisher<[ToolListItemDomainModel], Never> in
         
             let tools: [ResourceModel] = self.resourcesRepository.getAllToolsList(
                 filterByCategory: filterToolsByCategory?.id,

--- a/godtools/App/Features/Favorites/Presentation/Favorites/FavoritesViewModel.swift
+++ b/godtools/App/Features/Favorites/Presentation/Favorites/FavoritesViewModel.swift
@@ -63,6 +63,7 @@ class FavoritesViewModel: ObservableObject {
             .assign(to: &$appLanguage)
         
         $appLanguage.eraseToAnyPublisher()
+            .dropFirst()
             .map { (appLanguage: AppLanguageDomainModel) in
                 
                 Publishers.CombineLatest(
@@ -93,6 +94,7 @@ class FavoritesViewModel: ObservableObject {
             .store(in: &cancellables)
         
         $appLanguage.eraseToAnyPublisher()
+            .dropFirst()
             .map { (appLanguage: AppLanguageDomainModel) in
                 getOptInOnboardingBannerEnabledUseCase
                     .getBannerIsEnabled(appLanguage: appLanguage)

--- a/godtools/App/Features/Favorites/Presentation/Favorites/FavoritesViewModel.swift
+++ b/godtools/App/Features/Favorites/Presentation/Favorites/FavoritesViewModel.swift
@@ -59,6 +59,7 @@ class FavoritesViewModel: ObservableObject {
                  
         getCurrentAppLanguageUseCase
             .getLanguagePublisher()
+            .receive(on: DispatchQueue.main)
             .assign(to: &$appLanguage)
         
         $appLanguage.eraseToAnyPublisher()

--- a/godtools/App/Features/Lessons/Presentation/Lessons/LessonsViewModel.swift
+++ b/godtools/App/Features/Lessons/Presentation/Lessons/LessonsViewModel.swift
@@ -42,18 +42,21 @@ class LessonsViewModel: ObservableObject {
         
         getCurrentAppLanguageUseCase
             .getLanguagePublisher()
+            .receive(on: DispatchQueue.main)
             .assign(to: &$appLanguage)
         
         $appLanguage.eraseToAnyPublisher()
-            .flatMap({ (appLanguage: AppLanguageDomainModel) -> AnyPublisher<ViewLessonsDomainModel, Never> in
+            .dropFirst()
+            .map { (appLanguage: AppLanguageDomainModel) in
             
                 return viewLessonsUseCase
                     .viewPublisher(appLanguage: appLanguage)
                     .eraseToAnyPublisher()
-            })
+            }
+            .switchToLatest()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] (domainModel: ViewLessonsDomainModel) in
-                
+                                
                 self?.sectionTitle = domainModel.interfaceStrings.title
                 self?.subtitle = domainModel.interfaceStrings.subtitle
                 

--- a/godtools/App/Features/SpotlightTools/Data-DomainInterface/GetSpotlightToolsRepository.swift
+++ b/godtools/App/Features/SpotlightTools/Data-DomainInterface/GetSpotlightToolsRepository.swift
@@ -40,9 +40,11 @@ class GetSpotlightToolsRepository: GetSpotlightToolsRepositoryInterface {
             languageForAvailabilityTextModel = nil
         }
         
-        return getToolListItemInterfaceStringsRepository.getStringsPublisher(translateInLanguage: translatedInAppLanguage)
-            .eraseToAnyPublisher()
-        .flatMap({ (interfaceStrings: ToolListItemInterfaceStringsDomainModel) -> AnyPublisher<[SpotlightToolListItemDomainModel], Never> in
+        return Publishers.CombineLatest(
+            resourcesRepository.getResourcesChangedPublisher(),
+            getToolListItemInterfaceStringsRepository.getStringsPublisher(translateInLanguage: translatedInAppLanguage)
+        )
+        .flatMap({ (resourcesChanged: Void, interfaceStrings: ToolListItemInterfaceStringsDomainModel) -> AnyPublisher<[SpotlightToolListItemDomainModel], Never> in
         
             let spotlightToolResources: [ResourceModel] = self.resourcesRepository.getSpotlightTools()
 


### PR DESCRIPTION
This bug fixes some strange behavior where interface strings in lessons and favorites were reverting back to a prior app language selection.  I also include this fix to ToolsViewModel for the language availability issue here (https://github.com/CruGlobal/godtools-swift/pull/2096/files).

These bugs had to do with how we're using Combine Published properties and flatMap and our inner Publishers using Realm objectWillChange observing.

The main fix for this was to use ```switchToLatest()``` instead of ```flatMap```. (https://developer.apple.com/documentation/combine/publisher/switchtolatest()-453ht)

A few other changes include:
- Update ```.assign(to:``` to include ```.receive(on: DispatchQueue.main)```.  Initially I thought it was okay to exclude the main thread here since UI isn't being updated.  However, Xcode is giving this warning ```Publishing changes from background threads is not allowed; make sure to publish values from the main thread (via operators like receive(on:)) on model updates.```.  It could also create potential crashes if ```assign(to:```  triggers on the background thread and observers are doing something that requires the main thread.
- Included ```dropFirst()``` in places where we don't care what the initial value is on our Published property because it's being written to in another process.  This will reduce some initial overhead.
- Replaced ```flatMap``` with ```switchToLatest()``` which flattens the stream.  This drastically reduced the number of times ```sink``` was being called after switching the app language multiple times and triggering a pull to refresh.