### PR TITLE
GT Check Copy only when installing in Build Phases Embed Frameworks

### DIFF
--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -1570,14 +1570,14 @@
 /* Begin PBXCopyFilesBuildPhase section */
 		45B10ADF2BF3F270004342AB /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
+			buildActionMask = 8;
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
 				45B10ADE2BF3F270004342AB /* RealmSwift in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
-			runOnlyForDeploymentPostprocessing = 0;
+			runOnlyForDeploymentPostprocessing = 1;
 		};
 		45C382C02BF3FC5600378656 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;


### PR DESCRIPTION
After adding RealmSwift 10.50.0 which embeds and signs as a framework I was getting a cycle error in the Build Phases.  Checking Copy only when installing seemed to fix the build error.  Not sure if this will introduce any other problems when building?

<img width="1665" alt="check-copy-only-when-installing" src="https://github.com/CruGlobal/godtools-swift/assets/59846460/c653673d-9261-4121-83f7-3a5d8b291c8d">

