### PR TITLE
GT-2383 update some of our combine publishers to use switchToLatest

### DIFF
--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -1581,14 +1581,14 @@
 		};
 		45C382C02BF3FC5600378656 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
+			buildActionMask = 8;
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
 				45C382BF2BF3FC5600378656 /* RealmSwift in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
-			runOnlyForDeploymentPostprocessing = 0;
+			runOnlyForDeploymentPostprocessing = 1;
 		};
 /* End PBXCopyFilesBuildPhase section */
 

--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -13514,6 +13514,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
+					"$(FRAMEWORK_SEARCH_PATHS)",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = org.cru.godtoolsTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -13712,6 +13713,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
+					"$(FRAMEWORK_SEARCH_PATHS)",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = org.cru.godtoolsTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -13908,6 +13910,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
+					"$(FRAMEWORK_SEARCH_PATHS)",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = org.cru.godtoolsTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -14107,6 +14110,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
+					"$(FRAMEWORK_SEARCH_PATHS)",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = org.cru.godtoolsTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -14337,6 +14341,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
+					"$(FRAMEWORK_SEARCH_PATHS)",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = org.cru.godtoolsTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -177,6 +177,7 @@
 		452486E02B07C9A5007AD932 /* GetUserToolFiltersRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 452486DE2B07C9A5007AD932 /* GetUserToolFiltersRepository.swift */; };
 		452486E12B07C9A5007AD932 /* StoreUserFiltersRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 452486DF2B07C9A5007AD932 /* StoreUserFiltersRepository.swift */; };
 		452486E82B07C9AA007AD932 /* UserToolFiltersRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 452486E62B07C9AA007AD932 /* UserToolFiltersRepository.swift */; };
+		4525FB522BF7FA9A0025B905 /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 4525FB512BF7FA9A0025B905 /* RealmSwift */; };
 		4526EDD42AEB274800D1A3D4 /* EvaluationOptionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4526EDD32AEB274800D1A3D4 /* EvaluationOptionButton.swift */; };
 		4526EDD62AEB330100D1A3D4 /* OverlayNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4526EDD52AEB330100D1A3D4 /* OverlayNavigationController.swift */; };
 		4529B96628933A610011F16B /* ParseTranslationManifestForRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4529B96528933A610011F16B /* ParseTranslationManifestForRenderer.swift */; };
@@ -1001,8 +1002,6 @@
 		45AF47ED2B35E03500361EA7 /* GetToolSettingsToolHasTipsRepositoryInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45AF47EC2B35E03500361EA7 /* GetToolSettingsToolHasTipsRepositoryInterface.swift */; };
 		45AF47EF2B35E08C00361EA7 /* GetToolSettingsToolHasTipsRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45AF47EE2B35E08C00361EA7 /* GetToolSettingsToolHasTipsRepository.swift */; };
 		45AFC62D27CD74100090E381 /* MobileContentBackgroundImageAlignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4578782F27C41C08004552D5 /* MobileContentBackgroundImageAlignment.swift */; };
-		45B10ADD2BF3F270004342AB /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 45B10ADC2BF3F270004342AB /* RealmSwift */; };
-		45B10ADE2BF3F270004342AB /* RealmSwift in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 45B10ADC2BF3F270004342AB /* RealmSwift */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		45B212AC2922965F00C9A94D /* RealmDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B212AA2922965F00C9A94D /* RealmDatabase.swift */; };
 		45B212B629229CBA00C9A94D /* SwiftUIPreviewDiContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B212B529229CBA00C9A94D /* SwiftUIPreviewDiContainer.swift */; };
 		45B2E71B2BC045410077A3C3 /* GetAppLanguagesInterfaceStringsRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B2E71A2BC045410077A3C3 /* GetAppLanguagesInterfaceStringsRepositoryTests.swift */; };
@@ -1127,8 +1126,6 @@
 		45C2AF482A817621004958AB /* PageControllAttributesType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45C2AF462A817621004958AB /* PageControllAttributesType.swift */; };
 		45C2AF4A2A81764D004958AB /* GTPageControlAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45C2AF492A81764D004958AB /* GTPageControlAttributes.swift */; };
 		45C321A72ACE7A89003B4F2C /* AppInterfaceStringNavBarItemController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45C321A62ACE7A89003B4F2C /* AppInterfaceStringNavBarItemController.swift */; };
-		45C382BE2BF3FC5600378656 /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 45C382BD2BF3FC5600378656 /* RealmSwift */; };
-		45C382BF2BF3FC5600378656 /* RealmSwift in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 45C382BD2BF3FC5600378656 /* RealmSwift */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		45C5DDCE2AE6BF1300C70BBA /* AccessibilityScreenElementView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45C5DDCD2AE6BF1300C70BBA /* AccessibilityScreenElementView.swift */; };
 		45C649BC2B31E14D000249E0 /* ViewShareToolUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45C649BB2B31E14D000249E0 /* ViewShareToolUseCase.swift */; };
 		45C649BE2B31E178000249E0 /* ViewShareToolDomainModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45C649BD2B31E178000249E0 /* ViewShareToolDomainModel.swift */; };
@@ -1570,25 +1567,23 @@
 /* Begin PBXCopyFilesBuildPhase section */
 		45B10ADF2BF3F270004342AB /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 8;
+			buildActionMask = 12;
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				45B10ADE2BF3F270004342AB /* RealmSwift in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
-			runOnlyForDeploymentPostprocessing = 1;
+			runOnlyForDeploymentPostprocessing = 0;
 		};
 		45C382C02BF3FC5600378656 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 8;
+			buildActionMask = 12;
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				45C382BF2BF3FC5600378656 /* RealmSwift in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
-			runOnlyForDeploymentPostprocessing = 1;
+			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXCopyFilesBuildPhase section */
 
@@ -3272,7 +3267,7 @@
 				45D40C6B2A5315D500E8E4AE /* Fuzi in Frameworks */,
 				4F2500621F0C1E8D00364FBC /* AdSupport.framework in Frameworks */,
 				457771B229A00C5C00EA8115 /* FirebaseAnalytics in Frameworks */,
-				45B10ADD2BF3F270004342AB /* RealmSwift in Frameworks */,
+				4525FB522BF7FA9A0025B905 /* RealmSwift in Frameworks */,
 				45CF09702784B910007F13D3 /* RequestOperation in Frameworks */,
 				457771B629A00C5C00EA8115 /* FirebaseDynamicLinks in Frameworks */,
 				45E7D4C42977430A008C7503 /* ZipArchive in Frameworks */,
@@ -3291,7 +3286,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				45C382BE2BF3FC5600378656 /* RealmSwift in Frameworks */,
 				45F486F22B76D513004E0E27 /* Nimble in Frameworks */,
 				45F486EF2B76D501004E0E27 /* Quick in Frameworks */,
 				8C8C44BD9B31E90E469C99FF /* Pods_godtoolsTests.framework in Frameworks */,
@@ -11333,7 +11327,7 @@
 				45D40C672A5315B400E8E4AE /* Starscream */,
 				45D40C6A2A5315D500E8E4AE /* Fuzi */,
 				45B4FDBC2BE1787000E5E35B /* AppsFlyerLib-Strict */,
-				45B10ADC2BF3F270004342AB /* RealmSwift */,
+				4525FB512BF7FA9A0025B905 /* RealmSwift */,
 			);
 			productName = godtools;
 			productReference = 4F5732891EA69CF00082035C /* godtools.app */;
@@ -11358,7 +11352,6 @@
 			packageProductDependencies = (
 				45F486EE2B76D501004E0E27 /* Quick */,
 				45F486F12B76D513004E0E27 /* Nimble */,
-				45C382BD2BF3FC5600378656 /* RealmSwift */,
 			);
 			productName = godtoolsTests;
 			productReference = 684328F11EB7CF66005E9131 /* godtoolsTests.xctest */;
@@ -11494,7 +11487,7 @@
 				45F486ED2B76D500004E0E27 /* XCRemoteSwiftPackageReference "Quick" */,
 				45F486F02B76D512004E0E27 /* XCRemoteSwiftPackageReference "Nimble" */,
 				45B4FDBB2BE1787000E5E35B /* XCRemoteSwiftPackageReference "AppsFlyerFramework-Strict" */,
-				45B10ADB2BF3F262004342AB /* XCRemoteSwiftPackageReference "realm-swift" */,
+				4525FB502BF7FA650025B905 /* XCRemoteSwiftPackageReference "realm-cocoa" */,
 			);
 			productRefGroup = 4F57328A1EA69CF00082035C /* Products */;
 			projectDirPath = "";
@@ -13393,6 +13386,7 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
 				TEST_TARGET_NAME = godtools;
@@ -13514,7 +13508,6 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
-					"$(FRAMEWORK_SEARCH_PATHS)",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = org.cru.godtoolsTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -13522,6 +13515,7 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				TARGETED_DEVICE_FAMILY = 1;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/godtools.app/godtools";
@@ -13560,6 +13554,7 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -13592,6 +13587,7 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
 				TEST_TARGET_NAME = godtools;
@@ -13713,7 +13709,6 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
-					"$(FRAMEWORK_SEARCH_PATHS)",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = org.cru.godtoolsTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -13721,6 +13716,7 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				TARGETED_DEVICE_FAMILY = 1;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/godtools.app/godtools";
@@ -13759,6 +13755,7 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -13791,6 +13788,7 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
 				TEST_TARGET_NAME = godtools;
@@ -13910,7 +13908,6 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
-					"$(FRAMEWORK_SEARCH_PATHS)",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = org.cru.godtoolsTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -13918,6 +13915,7 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				TARGETED_DEVICE_FAMILY = 1;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/godtools.app/godtools";
@@ -13956,6 +13954,7 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -13988,6 +13987,7 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
 				TEST_TARGET_NAME = godtools;
@@ -14110,7 +14110,6 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
-					"$(FRAMEWORK_SEARCH_PATHS)",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = org.cru.godtoolsTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -14119,6 +14118,7 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				TARGETED_DEVICE_FAMILY = 1;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/godtools.app/godtools";
@@ -14157,6 +14157,7 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -14189,6 +14190,7 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
 				TEST_TARGET_NAME = godtools;
@@ -14227,6 +14229,7 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
 				TEST_TARGET_NAME = godtools;
@@ -14341,7 +14344,6 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
-					"$(FRAMEWORK_SEARCH_PATHS)",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = org.cru.godtoolsTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -14349,6 +14351,7 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				TARGETED_DEVICE_FAMILY = 1;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/godtools.app/godtools";
 			};
@@ -14420,20 +14423,20 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		4525FB502BF7FA650025B905 /* XCRemoteSwiftPackageReference "realm-cocoa" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/realm/realm-cocoa.git";
+			requirement = {
+				kind = exactVersion;
+				version = 10.49.2;
+			};
+		};
 		457771B029A00C5C00EA8115 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/firebase/firebase-ios-sdk.git";
 			requirement = {
 				kind = upToNextMinorVersion;
 				minimumVersion = 10.24.0;
-			};
-		};
-		45B10ADB2BF3F262004342AB /* XCRemoteSwiftPackageReference "realm-swift" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/realm/realm-swift.git";
-			requirement = {
-				kind = upToNextMinorVersion;
-				minimumVersion = 10.50.0;
 			};
 		};
 		45B4FDBB2BE1787000E5E35B /* XCRemoteSwiftPackageReference "AppsFlyerFramework-Strict" */ = {
@@ -14519,6 +14522,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		4525FB512BF7FA9A0025B905 /* RealmSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 4525FB502BF7FA650025B905 /* XCRemoteSwiftPackageReference "realm-cocoa" */;
+			productName = RealmSwift;
+		};
 		457771B129A00C5C00EA8115 /* FirebaseAnalytics */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 457771B029A00C5C00EA8115 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
@@ -14594,20 +14602,10 @@
 			package = 45D40C692A5315D500E8E4AE /* XCRemoteSwiftPackageReference "Fuzi" */;
 			productName = Fuzi;
 		};
-		45B10ADC2BF3F270004342AB /* RealmSwift */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 45B10ADB2BF3F262004342AB /* XCRemoteSwiftPackageReference "realm-swift" */;
-			productName = RealmSwift;
-		};
 		45B4FDBC2BE1787000E5E35B /* AppsFlyerLib-Strict */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 45B4FDBB2BE1787000E5E35B /* XCRemoteSwiftPackageReference "AppsFlyerFramework-Strict" */;
 			productName = "AppsFlyerLib-Strict";
-		};
-		45C382BD2BF3FC5600378656 /* RealmSwift */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 45B10ADB2BF3F262004342AB /* XCRemoteSwiftPackageReference "realm-swift" */;
-			productName = RealmSwift;
 		};
 		45CF096F2784B910007F13D3 /* RequestOperation */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -622,7 +622,6 @@
 		45738FA92AF067DF0006E9F0 /* YoutubePlayerParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45738FA82AF067DF0006E9F0 /* YoutubePlayerParameters.swift */; };
 		457579E226E96ABE00C898D2 /* MobileContentMultiSelectViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 457579DF26E96ABE00C898D2 /* MobileContentMultiSelectViewModel.swift */; };
 		457579E426E96ABE00C898D2 /* MobileContentMultiSelectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 457579E126E96ABE00C898D2 /* MobileContentMultiSelectView.swift */; };
-		457719A92BE00EC900E7E4D8 /* StoreInitialAppLanguageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 457719A82BE00EC900E7E4D8 /* StoreInitialAppLanguageTests.swift */; };
 		457719AB2BE00F4100E7E4D8 /* DeviceSystemLanguageInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 457719AA2BE00F4100E7E4D8 /* DeviceSystemLanguageInterface.swift */; };
 		457719AF2BE00FA600E7E4D8 /* MockDeviceSystemLanguage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 457719AE2BE00FA600E7E4D8 /* MockDeviceSystemLanguage.swift */; };
 		457739E827A0955000999270 /* MobileContentViewWidth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 457739E727A0955000999270 /* MobileContentViewWidth.swift */; };
@@ -955,7 +954,6 @@
 		45AD20EC259391B000A096A0 /* JsonServicesType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45AD20EA259391B000A096A0 /* JsonServicesType.swift */; };
 		45AD21622593A62800A096A0 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45AD21602593A62800A096A0 /* AppDelegate.swift */; };
 		45AD217F2593ABC800A096A0 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 45AD217E2593ABC800A096A0 /* README.md */; };
-		45AE8FB42BDFFA7D0065D6B4 /* SearchAppLanguageInAppLanguagesListRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45AE8FB32BDFFA7D0065D6B4 /* SearchAppLanguageInAppLanguagesListRepositoryTests.swift */; };
 		45AE973B27C97A9400C2CB33 /* MultiplatformHeading.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45AE971127C97A9400C2CB33 /* MultiplatformHeading.swift */; };
 		45AE973C27C97A9400C2CB33 /* MultiplatformCards.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45AE971227C97A9400C2CB33 /* MultiplatformCards.swift */; };
 		45AE973D27C97A9400C2CB33 /* MultiplatformCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45AE971327C97A9400C2CB33 /* MultiplatformCard.swift */; };
@@ -1001,7 +999,6 @@
 		45AFC62D27CD74100090E381 /* MobileContentBackgroundImageAlignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4578782F27C41C08004552D5 /* MobileContentBackgroundImageAlignment.swift */; };
 		45B212AC2922965F00C9A94D /* RealmDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B212AA2922965F00C9A94D /* RealmDatabase.swift */; };
 		45B212B629229CBA00C9A94D /* SwiftUIPreviewDiContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B212B529229CBA00C9A94D /* SwiftUIPreviewDiContainer.swift */; };
-		45B2E71B2BC045410077A3C3 /* GetAppLanguagesInterfaceStringsRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B2E71A2BC045410077A3C3 /* GetAppLanguagesInterfaceStringsRepositoryTests.swift */; };
 		45B3382B2AF42A3900D18C63 /* GetTutorialInterfaceStringsRepositoryInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B3382A2AF42A3900D18C63 /* GetTutorialInterfaceStringsRepositoryInterface.swift */; };
 		45B3382F2AF42A6400D18C63 /* TutorialInterfaceStringsDomainModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B3382E2AF42A6400D18C63 /* TutorialInterfaceStringsDomainModel.swift */; };
 		45B338312AF42A9400D18C63 /* GetTutorialInterfaceStringsRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B338302AF42A9400D18C63 /* GetTutorialInterfaceStringsRepository.swift */; };
@@ -1220,8 +1217,6 @@
 		45D814D92B8105AB00AD00C5 /* SpotlightToolListItemDomainModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D814D82B8105AB00AD00C5 /* SpotlightToolListItemDomainModel.swift */; };
 		45D814DB2B8105BE00AD00C5 /* GetSpotlightToolsRepositoryInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D814DA2B8105BE00AD00C5 /* GetSpotlightToolsRepositoryInterface.swift */; };
 		45D814DF2B8109D500AD00C5 /* GetSpotlightToolsUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D814DE2B8109D500AD00C5 /* GetSpotlightToolsUseCase.swift */; };
-		45D85C162BE0E5050003CE32 /* SearchLanguageInDownloadableLanguagesRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D85C152BE0E5050003CE32 /* SearchLanguageInDownloadableLanguagesRepositoryTests.swift */; };
-		45D85C182BE0E9700003CE32 /* GetLanguageSettingsInterfaceStringsRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D85C172BE0E9700003CE32 /* GetLanguageSettingsInterfaceStringsRepositoryTests.swift */; };
 		45D95CCE271F3F1100263D46 /* MobileContentRendererEventAnalyticsTracking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D95CCD271F3F1100263D46 /* MobileContentRendererEventAnalyticsTracking.swift */; };
 		45DAC8C62B2BB9E500A138C0 /* AppLanguageDataModel+TranslatableLanguage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45DAC8C52B2BB9E500A138C0 /* AppLanguageDataModel+TranslatableLanguage.swift */; };
 		45DAC8CA2B2BBA1200A138C0 /* GetTranslatedLanguageName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45DAC8C82B2BBA1200A138C0 /* GetTranslatedLanguageName.swift */; };
@@ -13142,10 +13137,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				45B2E71B2BC045410077A3C3 /* GetAppLanguagesInterfaceStringsRepositoryTests.swift in Sources */,
 				459ABF612B0BB29D0034499D /* RealmResourcesCacheTests.swift in Sources */,
 				45D7783029A572CC00F23D99 /* PassthroughValue.swift in Sources */,
-				45AE8FB42BDFFA7D0065D6B4 /* SearchAppLanguageInAppLanguagesListRepositoryTests.swift in Sources */,
 				45E198692BA4822A00BF14F3 /* TestsDiContainer.swift in Sources */,
 				45368A1A2ABB2D850028A570 /* LocalizableStringsBundleLoaderTests.swift in Sources */,
 				45A45CEE2731B8C9005D4E74 /* MobileContentBackgroundImageRendererType.swift in Sources */,
@@ -13153,7 +13146,6 @@
 				45E1986B2BA488C800BF14F3 /* TestsInMemoryRealmDatabase.swift in Sources */,
 				45368A152ABB2D850028A570 /* Collection+SafeLookupTests.swift in Sources */,
 				45368A1B2ABB2D850028A570 /* LocalizableStringsRepositoryTests.swift in Sources */,
-				457719A92BE00EC900E7E4D8 /* StoreInitialAppLanguageTests.swift in Sources */,
 				45CBDA092BA3930B0007DEC8 /* MockLaunchCountRepository.swift in Sources */,
 				45368A182ABB2D850028A570 /* TestRealmObject.swift in Sources */,
 				453E2A122BC8C8810047D4C6 /* GetToolsRepositoryTests.swift in Sources */,
@@ -13169,8 +13161,6 @@
 				45CBDA142BA399750007DEC8 /* MockLocalizationServices.swift in Sources */,
 				45368A162ABB2D850028A570 /* LocaleTests.swift in Sources */,
 				45E198662BA47F4400BF14F3 /* GetDownloadToolProgressInterfaceStringsRepositoryTests.swift in Sources */,
-				45D85C162BE0E5050003CE32 /* SearchLanguageInDownloadableLanguagesRepositoryTests.swift in Sources */,
-				45D85C182BE0E9700003CE32 /* GetLanguageSettingsInterfaceStringsRepositoryTests.swift in Sources */,
 				45AA12DB2BE55D1D00C85BFF /* TestRealmObjectMapping.swift in Sources */,
 				45CBDA062BA3928B0007DEC8 /* GetOnboardingTutorialIsAvailableTests.swift in Sources */,
 			);

--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -259,7 +259,6 @@
 		4535BE152B348BF100A8B62F /* ReviewShareShareableViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4535BE112B348BF100A8B62F /* ReviewShareShareableViewModel.swift */; };
 		4535BE162B348BF100A8B62F /* ReviewShareShareableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4535BE122B348BF100A8B62F /* ReviewShareShareableView.swift */; };
 		453649EC295E0B3F00B5B354 /* LanguageSettingsFlowCompletedState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 453649EB295E0B3F00B5B354 /* LanguageSettingsFlowCompletedState.swift */; };
-		45368A152ABB2D850028A570 /* Collection+SafeLookupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45368A022ABB2D840028A570 /* Collection+SafeLookupTests.swift */; };
 		45368A162ABB2D850028A570 /* LocaleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45368A042ABB2D840028A570 /* LocaleTests.swift */; };
 		45368A182ABB2D850028A570 /* TestRealmObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45368A082ABB2D840028A570 /* TestRealmObject.swift */; };
 		45368A192ABB2D850028A570 /* DeepLinkingServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45368A0A2ABB2D840028A570 /* DeepLinkingServiceTests.swift */; };
@@ -13144,7 +13143,6 @@
 				45A45CEE2731B8C9005D4E74 /* MobileContentBackgroundImageRendererType.swift in Sources */,
 				45AFC62D27CD74100090E381 /* MobileContentBackgroundImageAlignment.swift in Sources */,
 				45E1986B2BA488C800BF14F3 /* TestsInMemoryRealmDatabase.swift in Sources */,
-				45368A152ABB2D850028A570 /* Collection+SafeLookupTests.swift in Sources */,
 				45368A1B2ABB2D850028A570 /* LocalizableStringsRepositoryTests.swift in Sources */,
 				45CBDA092BA3930B0007DEC8 /* MockLaunchCountRepository.swift in Sources */,
 				45368A182ABB2D850028A570 /* TestRealmObject.swift in Sources */,

--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -93,6 +93,18 @@
 		450F94DA27A1F0F6009DEA43 /* MobileContentCardCollectionPageCardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450F94D627A1F0F6009DEA43 /* MobileContentCardCollectionPageCardViewModel.swift */; };
 		450F94DB27A1F0F6009DEA43 /* MobileContentCardCollectionPageCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450F94D727A1F0F6009DEA43 /* MobileContentCardCollectionPageCardView.swift */; };
 		450F94DF27A1F38E009DEA43 /* MobileContentCardCollectionPageItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450F94DE27A1F38E009DEA43 /* MobileContentCardCollectionPageItemView.swift */; };
+		450FB8872BFBA0E80015D945 /* GetOnboardingTutorialInterfaceStringsRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45CBDA0F2BA398D90007DEC8 /* GetOnboardingTutorialInterfaceStringsRepositoryTests.swift */; };
+		450FB8882BFBA0E80015D945 /* GetOnboardingTutorialIsAvailableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45CBDA052BA3928B0007DEC8 /* GetOnboardingTutorialIsAvailableTests.swift */; };
+		450FB8892BFBA0EB0015D945 /* SearchToolFilterCategoriesRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 453FE09E2BBEDC770090DED1 /* SearchToolFilterCategoriesRepositoryTests.swift */; };
+		450FB88A2BFBA0F80015D945 /* StoreInitialAppLanguageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 457719A82BE00EC900E7E4D8 /* StoreInitialAppLanguageTests.swift */; };
+		450FB88B2BFBA0F80015D945 /* GetLanguageSettingsInterfaceStringsRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D85C172BE0E9700003CE32 /* GetLanguageSettingsInterfaceStringsRepositoryTests.swift */; };
+		450FB88C2BFBA0F80015D945 /* SearchAppLanguageInAppLanguagesListRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45AE8FB32BDFFA7D0065D6B4 /* SearchAppLanguageInAppLanguagesListRepositoryTests.swift */; };
+		450FB88D2BFBA0F80015D945 /* GetAppLanguagesInterfaceStringsRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B2E71A2BC045410077A3C3 /* GetAppLanguagesInterfaceStringsRepositoryTests.swift */; };
+		450FB88E2BFBA0F80015D945 /* SearchLanguageInDownloadableLanguagesRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D85C152BE0E5050003CE32 /* SearchLanguageInDownloadableLanguagesRepositoryTests.swift */; };
+		450FB88F2BFBA0FD0015D945 /* Collection+SafeLookupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45368A022ABB2D840028A570 /* Collection+SafeLookupTests.swift */; };
+		450FB8902BFBA1060015D945 /* RealmDatabaseDeleteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 457E7A372BE5B39800265D92 /* RealmDatabaseDeleteTests.swift */; };
+		450FB8912BFBA1060015D945 /* RealmDatabaseReadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45AA12D82BE55CF300C85BFF /* RealmDatabaseReadTests.swift */; };
+		450FB8922BFBA1060015D945 /* RealmDatabaseWriteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45AA12DC2BE5741000C85BFF /* RealmDatabaseWriteTests.swift */; };
 		4512C80A2B322D5900D162F3 /* ToolSettingsShareableItemViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4512C8082B322D5900D162F3 /* ToolSettingsShareableItemViewModel.swift */; };
 		4512C80B2B322D5900D162F3 /* ToolSettingsShareableItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4512C8092B322D5900D162F3 /* ToolSettingsShareableItemView.swift */; };
 		4512C80F2B322E4900D162F3 /* ToolSettingsLanguageDropDownView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4512C80E2B322E4900D162F3 /* ToolSettingsLanguageDropDownView.swift */; };
@@ -356,7 +368,6 @@
 		453F84DA2A02A0390005101E /* ArticleManifestAemRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 453F84D72A02A0390005101E /* ArticleManifestAemRepository.swift */; };
 		453F84DB2A02A0390005101E /* ArticleManifestDownloadArticlesReceipt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 453F84D82A02A0390005101E /* ArticleManifestDownloadArticlesReceipt.swift */; };
 		453F84DC2A02A0390005101E /* ArticleCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 453F84D92A02A0390005101E /* ArticleCategory.swift */; };
-		453FE09F2BBEDC770090DED1 /* SearchToolFilterCategoriesRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 453FE09E2BBEDC770090DED1 /* SearchToolFilterCategoriesRepositoryTests.swift */; };
 		45430CF12B1FB43E002B94A3 /* TextWithLinksView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45430CF02B1FB43E002B94A3 /* TextWithLinksView.swift */; };
 		45430CF62B1FB638002B94A3 /* String+ToUrlMarkdown.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45430CF52B1FB638002B94A3 /* String+ToUrlMarkdown.swift */; };
 		45430CF82B1FBA2A002B94A3 /* BackwardsCompatibleTextWithLinks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45430CF72B1FBA2A002B94A3 /* BackwardsCompatibleTextWithLinks.swift */; };
@@ -1134,11 +1145,9 @@
 		45CBD9FD2BA343DE0007DEC8 /* GetOnboardingTutorialIsAvailable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45CBD9FC2BA343DE0007DEC8 /* GetOnboardingTutorialIsAvailable.swift */; };
 		45CBDA012BA38EF60007DEC8 /* LaunchCountRepositoryInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45CBDA002BA38EF60007DEC8 /* LaunchCountRepositoryInterface.swift */; };
 		45CBDA042BA38F200007DEC8 /* LaunchCountCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45CBDA032BA38F200007DEC8 /* LaunchCountCache.swift */; };
-		45CBDA062BA3928B0007DEC8 /* GetOnboardingTutorialIsAvailableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45CBDA052BA3928B0007DEC8 /* GetOnboardingTutorialIsAvailableTests.swift */; };
 		45CBDA092BA3930B0007DEC8 /* MockLaunchCountRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45CBDA082BA3930B0007DEC8 /* MockLaunchCountRepository.swift */; };
 		45CBDA0B2BA3948A0007DEC8 /* OnboardingTutorialViewedRepositoryInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45CBDA0A2BA3948A0007DEC8 /* OnboardingTutorialViewedRepositoryInterface.swift */; };
 		45CBDA0E2BA394FD0007DEC8 /* MockOnboardingTutorialViewedRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45CBDA0D2BA394FD0007DEC8 /* MockOnboardingTutorialViewedRepository.swift */; };
-		45CBDA102BA398D90007DEC8 /* GetOnboardingTutorialInterfaceStringsRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45CBDA0F2BA398D90007DEC8 /* GetOnboardingTutorialInterfaceStringsRepositoryTests.swift */; };
 		45CBDA122BA3993F0007DEC8 /* LocalizationServicesInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45CBDA112BA3993F0007DEC8 /* LocalizationServicesInterface.swift */; };
 		45CBDA142BA399750007DEC8 /* MockLocalizationServices.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45CBDA132BA399750007DEC8 /* MockLocalizationServices.swift */; };
 		45CCF6922B2269010017EDFE /* ToolSettingsOptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45CCF68F2B2269010017EDFE /* ToolSettingsOptionView.swift */; };
@@ -13139,10 +13148,19 @@
 				459ABF612B0BB29D0034499D /* RealmResourcesCacheTests.swift in Sources */,
 				45D7783029A572CC00F23D99 /* PassthroughValue.swift in Sources */,
 				45E198692BA4822A00BF14F3 /* TestsDiContainer.swift in Sources */,
+				450FB88A2BFBA0F80015D945 /* StoreInitialAppLanguageTests.swift in Sources */,
+				450FB88B2BFBA0F80015D945 /* GetLanguageSettingsInterfaceStringsRepositoryTests.swift in Sources */,
+				450FB88C2BFBA0F80015D945 /* SearchAppLanguageInAppLanguagesListRepositoryTests.swift in Sources */,
+				450FB88D2BFBA0F80015D945 /* GetAppLanguagesInterfaceStringsRepositoryTests.swift in Sources */,
+				450FB88E2BFBA0F80015D945 /* SearchLanguageInDownloadableLanguagesRepositoryTests.swift in Sources */,
 				45368A1A2ABB2D850028A570 /* LocalizableStringsBundleLoaderTests.swift in Sources */,
 				45A45CEE2731B8C9005D4E74 /* MobileContentBackgroundImageRendererType.swift in Sources */,
+				450FB8892BFBA0EB0015D945 /* SearchToolFilterCategoriesRepositoryTests.swift in Sources */,
 				45AFC62D27CD74100090E381 /* MobileContentBackgroundImageAlignment.swift in Sources */,
 				45E1986B2BA488C800BF14F3 /* TestsInMemoryRealmDatabase.swift in Sources */,
+				450FB8902BFBA1060015D945 /* RealmDatabaseDeleteTests.swift in Sources */,
+				450FB8912BFBA1060015D945 /* RealmDatabaseReadTests.swift in Sources */,
+				450FB8922BFBA1060015D945 /* RealmDatabaseWriteTests.swift in Sources */,
 				45368A1B2ABB2D850028A570 /* LocalizableStringsRepositoryTests.swift in Sources */,
 				45CBDA092BA3930B0007DEC8 /* MockLaunchCountRepository.swift in Sources */,
 				45368A182ABB2D850028A570 /* TestRealmObject.swift in Sources */,
@@ -13153,14 +13171,14 @@
 				45368A1C2ABB2D850028A570 /* LocalizationServicesTests.swift in Sources */,
 				457719AF2BE00FA600E7E4D8 /* MockDeviceSystemLanguage.swift in Sources */,
 				45CBDA0E2BA394FD0007DEC8 /* MockOnboardingTutorialViewedRepository.swift in Sources */,
-				45CBDA102BA398D90007DEC8 /* GetOnboardingTutorialInterfaceStringsRepositoryTests.swift in Sources */,
-				453FE09F2BBEDC770090DED1 /* SearchToolFilterCategoriesRepositoryTests.swift in Sources */,
 				45308EC52BDC317300A49D96 /* GetSpiritualConversationReadinessScaleTests.swift in Sources */,
 				45CBDA142BA399750007DEC8 /* MockLocalizationServices.swift in Sources */,
 				45368A162ABB2D850028A570 /* LocaleTests.swift in Sources */,
 				45E198662BA47F4400BF14F3 /* GetDownloadToolProgressInterfaceStringsRepositoryTests.swift in Sources */,
+				450FB8872BFBA0E80015D945 /* GetOnboardingTutorialInterfaceStringsRepositoryTests.swift in Sources */,
+				450FB88F2BFBA0FD0015D945 /* Collection+SafeLookupTests.swift in Sources */,
+				450FB8882BFBA0E80015D945 /* GetOnboardingTutorialIsAvailableTests.swift in Sources */,
 				45AA12DB2BE55D1D00C85BFF /* TestRealmObjectMapping.swift in Sources */,
-				45CBDA062BA3928B0007DEC8 /* GetOnboardingTutorialIsAvailableTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -650,7 +650,6 @@
 		457C4C742ABA315D00CFAC1D /* PagedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 457C4C732ABA315D00CFAC1D /* PagedView.swift */; };
 		457C8586242E50D70025E079 /* GoogleService-Info-Debug.plist in Resources */ = {isa = PBXBuildFile; fileRef = 457C8585242E50D70025E079 /* GoogleService-Info-Debug.plist */; };
 		457E199A27C6E3AF00BABD49 /* MobileContentRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 457E199927C6E3AF00BABD49 /* MobileContentRenderer.swift */; };
-		457E7A382BE5B39800265D92 /* RealmDatabaseDeleteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 457E7A372BE5B39800265D92 /* RealmDatabaseDeleteTests.swift */; };
 		457F6BDD28B0132F0055456C /* AttachmentsBundleCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 457F6BDC28B0132F0055456C /* AttachmentsBundleCache.swift */; };
 		4581657626F4DD4D000D660F /* MobileContentRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4581657526F4DD4D000D660F /* MobileContentRowView.swift */; };
 		4581D97F297AD21E00D056D6 /* JsonApiResponseData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4581D97E297AD21E00D056D6 /* JsonApiResponseData.swift */; };
@@ -867,9 +866,7 @@
 		45A8E4392AFC0B1A008EF03D /* GetCreatingToolScreenShareSessionInterfaceStringsRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45A8E4382AFC0B1A008EF03D /* GetCreatingToolScreenShareSessionInterfaceStringsRepository.swift */; };
 		45A8E43C2AFC1043008EF03D /* CreatingToolScreenShareSessionTimedOutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45A8E43B2AFC1043008EF03D /* CreatingToolScreenShareSessionTimedOutView.swift */; };
 		45A8E43E2AFC105E008EF03D /* CreatingToolScreenShareSessionTimedOutViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45A8E43D2AFC105E008EF03D /* CreatingToolScreenShareSessionTimedOutViewModel.swift */; };
-		45AA12D92BE55CF300C85BFF /* RealmDatabaseReadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45AA12D82BE55CF300C85BFF /* RealmDatabaseReadTests.swift */; };
 		45AA12DB2BE55D1D00C85BFF /* TestRealmObjectMapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45AA12DA2BE55D1D00C85BFF /* TestRealmObjectMapping.swift */; };
-		45AA12DD2BE5741000C85BFF /* RealmDatabaseWriteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45AA12DC2BE5741000C85BFF /* RealmDatabaseWriteTests.swift */; };
 		45AAC28E2BB3069D000AE690 /* ViewGlobalActivityThisWeekUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45AAC28A2BB3069D000AE690 /* ViewGlobalActivityThisWeekUseCase.swift */; };
 		45AAC28F2BB3069D000AE690 /* GlobalActivityThisWeekDomainModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45AAC28D2BB3069D000AE690 /* GlobalActivityThisWeekDomainModel.swift */; };
 		45AAC2912BB306C1000AE690 /* ViewGlobalActivityThisWeekDomainModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45AAC2902BB306C1000AE690 /* ViewGlobalActivityThisWeekDomainModel.swift */; };
@@ -13148,7 +13145,6 @@
 				45B2E71B2BC045410077A3C3 /* GetAppLanguagesInterfaceStringsRepositoryTests.swift in Sources */,
 				459ABF612B0BB29D0034499D /* RealmResourcesCacheTests.swift in Sources */,
 				45D7783029A572CC00F23D99 /* PassthroughValue.swift in Sources */,
-				457E7A382BE5B39800265D92 /* RealmDatabaseDeleteTests.swift in Sources */,
 				45AE8FB42BDFFA7D0065D6B4 /* SearchAppLanguageInAppLanguagesListRepositoryTests.swift in Sources */,
 				45E198692BA4822A00BF14F3 /* TestsDiContainer.swift in Sources */,
 				45368A1A2ABB2D850028A570 /* LocalizableStringsBundleLoaderTests.swift in Sources */,
@@ -13157,7 +13153,6 @@
 				45E1986B2BA488C800BF14F3 /* TestsInMemoryRealmDatabase.swift in Sources */,
 				45368A152ABB2D850028A570 /* Collection+SafeLookupTests.swift in Sources */,
 				45368A1B2ABB2D850028A570 /* LocalizableStringsRepositoryTests.swift in Sources */,
-				45AA12D92BE55CF300C85BFF /* RealmDatabaseReadTests.swift in Sources */,
 				457719A92BE00EC900E7E4D8 /* StoreInitialAppLanguageTests.swift in Sources */,
 				45CBDA092BA3930B0007DEC8 /* MockLaunchCountRepository.swift in Sources */,
 				45368A182ABB2D850028A570 /* TestRealmObject.swift in Sources */,
@@ -13177,7 +13172,6 @@
 				45D85C162BE0E5050003CE32 /* SearchLanguageInDownloadableLanguagesRepositoryTests.swift in Sources */,
 				45D85C182BE0E9700003CE32 /* GetLanguageSettingsInterfaceStringsRepositoryTests.swift in Sources */,
 				45AA12DB2BE55D1D00C85BFF /* TestRealmObjectMapping.swift in Sources */,
-				45AA12DD2BE5741000C85BFF /* RealmDatabaseWriteTests.swift in Sources */,
 				45CBDA062BA3928B0007DEC8 /* GetOnboardingTutorialIsAvailableTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/godtools.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/godtools.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "21bf5557cd80854fb30416658e2f4affd5f9a1aedfae78f9a812d457ecc91fbe",
+  "originHash" : "2554bb4e33d2e336406c5e26156a7f81df60bf92065eb02ee0206d5a4c01c55d",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -209,21 +209,21 @@
       }
     },
     {
+      "identity" : "realm-cocoa",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/realm/realm-cocoa.git",
+      "state" : {
+        "revision" : "a4d731076e6a52f4366d844c78369ac7c9c6b1c0",
+        "version" : "10.49.2"
+      }
+    },
+    {
       "identity" : "realm-core",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/realm/realm-core.git",
       "state" : {
-        "revision" : "9cf7ef4ad8e2f4c7a519c9a395ca3d253bb87aa8",
-        "version" : "14.6.2"
-      }
-    },
-    {
-      "identity" : "realm-swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/realm/realm-swift.git",
-      "state" : {
-        "revision" : "2000569f03948c281afc83c36c710ab15e5dd33c",
-        "version" : "10.50.0"
+        "revision" : "4d815c6e6883bfdcb67cf755d0f0f29a4b399ea7",
+        "version" : "14.5.2"
       }
     },
     {

--- a/godtools/App/AppBackgroundState.swift
+++ b/godtools/App/AppBackgroundState.swift
@@ -36,6 +36,7 @@ class AppBackgroundState {
         appDiContainer.feature.appLanguage.domainLayer
             .getCurrentAppLanguageUseCase()
             .getLanguagePublisher()
+            .receive(on: DispatchQueue.main)
             .assign(to: &$appLanguage)
         
         appDiContainer.feature.appLanguage.domainLayer

--- a/godtools/App/AppBackgroundState.swift
+++ b/godtools/App/AppBackgroundState.swift
@@ -48,13 +48,13 @@ class AppBackgroundState {
             .store(in: &cancellables)
         
         $appLanguage
-            .eraseToAnyPublisher()
-            .flatMap({ (appLanguage: AppLanguageDomainModel) -> AnyPublisher<Void, Never> in
-                
+            .dropFirst()
+            .map { (appLanguage: AppLanguageDomainModel) in
                 return downloadLatestToolsForFavoritedToolsUseCase
                     .downloadPublisher(appLanguage: appLanguage)
                     .eraseToAnyPublisher()
-            })
+            }
+            .switchToLatest()
             .sink { _ in
                 
             }

--- a/godtools/App/Features/AccountCreation/Domain/UseCases/GetSocialCreateAccountInterfaceStringsUseCase.swift
+++ b/godtools/App/Features/AccountCreation/Domain/UseCases/GetSocialCreateAccountInterfaceStringsUseCase.swift
@@ -18,14 +18,10 @@ class GetSocialCreateAccountInterfaceStringsUseCase {
         self.getInterfaceStringsRepositoryInterface = getInterfaceStringsRepositoryInterface
     }
     
-    func getStringsPublisher(appLanguagePublisher: AnyPublisher<AppLanguageDomainModel, Never>) -> AnyPublisher<SocialCreateAccountInterfaceStringsDomainModel, Never> {
+    func getStringsPublisher(appLanguage: AppLanguageDomainModel) -> AnyPublisher<SocialCreateAccountInterfaceStringsDomainModel, Never> {
         
-        return appLanguagePublisher
-            .flatMap({ (appLanguage: AppLanguageDomainModel) -> AnyPublisher<SocialCreateAccountInterfaceStringsDomainModel, Never> in
-                
-                return self.getInterfaceStringsRepositoryInterface.getStringsPublisher(translateInLanguage: appLanguage)
-                    .eraseToAnyPublisher()
-            })
+        return getInterfaceStringsRepositoryInterface
+            .getStringsPublisher(translateInLanguage: appLanguage)
             .eraseToAnyPublisher()
     }
 }

--- a/godtools/App/Features/AccountCreation/Domain/UseCases/GetSocialSignInInterfaceStringsUseCase.swift
+++ b/godtools/App/Features/AccountCreation/Domain/UseCases/GetSocialSignInInterfaceStringsUseCase.swift
@@ -18,14 +18,10 @@ class GetSocialSignInInterfaceStringsUseCase {
         self.getInterfaceStringsRepositoryInterface = getInterfaceStringsRepositoryInterface
     }
     
-    func getStringsPublisher(appLanguagePublisher: AnyPublisher<AppLanguageDomainModel, Never>) -> AnyPublisher<SocialSignInInterfaceStringsDomainModel, Never> {
+    func getStringsPublisher(appLanguage: AppLanguageDomainModel) -> AnyPublisher<SocialSignInInterfaceStringsDomainModel, Never> {
         
-        return appLanguagePublisher
-            .flatMap({ (appLanguage: AppLanguageDomainModel) -> AnyPublisher<SocialSignInInterfaceStringsDomainModel, Never> in
-                
-                return self.getInterfaceStringsRepositoryInterface.getStringsPublisher(translateInLanguage: appLanguage)
-                    .eraseToAnyPublisher()
-            })
+        return getInterfaceStringsRepositoryInterface
+            .getStringsPublisher(translateInLanguage: appLanguage)
             .eraseToAnyPublisher()
     }
 }

--- a/godtools/App/Features/AccountCreation/Presentation/SocialSignIn/SocialSignInViewModel.swift
+++ b/godtools/App/Features/AccountCreation/Presentation/SocialSignIn/SocialSignInViewModel.swift
@@ -43,6 +43,7 @@ class SocialSignInViewModel: ObservableObject {
         
         getCurrentAppLanguageUseCase
             .getLanguagePublisher()
+            .receive(on: DispatchQueue.main)
             .assign(to: &$appLanguage)
         
         switch authenticationType {

--- a/godtools/App/Features/AccountCreation/Presentation/SocialSignIn/SocialSignInViewModel.swift
+++ b/godtools/App/Features/AccountCreation/Presentation/SocialSignIn/SocialSignInViewModel.swift
@@ -49,8 +49,13 @@ class SocialSignInViewModel: ObservableObject {
         switch authenticationType {
         case .createAccount:
             
-            getSocialCreateAccountInterfaceStringsUseCase
-                .getStringsPublisher(appLanguagePublisher: $appLanguage.eraseToAnyPublisher())
+            $appLanguage
+                .dropFirst()
+                .map { (appLanguage: AppLanguageDomainModel) in
+                    return getSocialCreateAccountInterfaceStringsUseCase
+                        .getStringsPublisher(appLanguage: appLanguage)
+                }
+                .switchToLatest()
                 .receive(on: DispatchQueue.main)
                 .sink { [weak self] (interfaceStrings: SocialCreateAccountInterfaceStringsDomainModel) in
                     
@@ -64,8 +69,13 @@ class SocialSignInViewModel: ObservableObject {
         
         case .login:
             
-            getSocialSignInInterfaceStringsUseCase
-                .getStringsPublisher(appLanguagePublisher: $appLanguage.eraseToAnyPublisher())
+            $appLanguage
+                .dropFirst()
+                .map { (appLanguage: AppLanguageDomainModel) in
+                    return getSocialSignInInterfaceStringsUseCase
+                        .getStringsPublisher(appLanguage: appLanguage)
+                }
+                .switchToLatest()
                 .receive(on: DispatchQueue.main)
                 .sink { [weak self] (interfaceStrings: SocialSignInInterfaceStringsDomainModel) in
                     

--- a/godtools/App/Features/AppLanguage/Domain/UseCases/GetInterfaceLayoutDirectionUseCase.swift
+++ b/godtools/App/Features/AppLanguage/Domain/UseCases/GetInterfaceLayoutDirectionUseCase.swift
@@ -18,14 +18,10 @@ class GetInterfaceLayoutDirectionUseCase {
         self.getLayoutDirectionInterface = getLayoutDirectionInterface
     }
     
-    func getLayoutDirectionPublisher(appLanguagePublisher: AnyPublisher<AppLanguageDomainModel, Never>) -> AnyPublisher<AppInterfaceLayoutDirectionDomainModel, Never> {
+    func getLayoutDirectionPublisher(appLanguage: AppLanguageDomainModel) -> AnyPublisher<AppInterfaceLayoutDirectionDomainModel, Never> {
         
-        return appLanguagePublisher
-            .flatMap({ (appLanguage: AppLanguageDomainModel) -> AnyPublisher<AppInterfaceLayoutDirectionDomainModel, Never> in
-                
-                return self.getLayoutDirectionInterface.getLayoutDirectionPublisher(appLanguage: appLanguage)
-                    .eraseToAnyPublisher()
-            })
+        return getLayoutDirectionInterface
+            .getLayoutDirectionPublisher(appLanguage: appLanguage)
             .eraseToAnyPublisher()
     }
 }

--- a/godtools/App/Features/AppLanguage/Presentation/AppLanguages/AppLanguagesViewModel.swift
+++ b/godtools/App/Features/AppLanguage/Presentation/AppLanguages/AppLanguagesViewModel.swift
@@ -40,6 +40,7 @@ class AppLanguagesViewModel: ObservableObject {
         
         getCurrentAppLanguageUseCase
             .getLanguagePublisher()
+            .receive(on: DispatchQueue.main)
             .assign(to: &$appLanguage)
         
         $appLanguage.eraseToAnyPublisher()
@@ -48,6 +49,7 @@ class AppLanguagesViewModel: ObservableObject {
                     .getAppLanguagesListPublisher(appLanguage: appLanguage)
                     .eraseToAnyPublisher()
             })
+            .receive(on: DispatchQueue.main)
             .assign(to: &$appLanguagesList)
         
         $appLanguage.eraseToAnyPublisher()

--- a/godtools/App/Features/AppLanguage/Presentation/ConfirmAppLanguage/ConfirmAppLanguageViewModel.swift
+++ b/godtools/App/Features/AppLanguage/Presentation/ConfirmAppLanguage/ConfirmAppLanguageViewModel.swift
@@ -33,16 +33,19 @@ class ConfirmAppLanguageViewModel: ObservableObject {
         self.getCurrentAppLanguageUseCase = getCurrentAppLanguageUseCase
         self.viewConfirmAppLanguageUseCase = viewConfirmAppLanguageUseCase
         
-        getCurrentAppLanguageUseCase.getLanguagePublisher()
+        getCurrentAppLanguageUseCase
+            .getLanguagePublisher()
             .receive(on: DispatchQueue.main)
             .assign(to: &$appLanguage)
         
-        $appLanguage.eraseToAnyPublisher()
-            .flatMap { appLanguage in
+        $appLanguage
+            .dropFirst()
+            .map { (appLanguage: AppLanguageDomainModel) in
                 
-                return viewConfirmAppLanguageUseCase.viewPublisher(appLanguage: appLanguage, selectedLanguage: selectedLanguage.language)
-                    .eraseToAnyPublisher()
+                viewConfirmAppLanguageUseCase
+                    .viewPublisher(appLanguage: appLanguage, selectedLanguage: selectedLanguage.language)
             }
+            .switchToLatest()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] domainModel in
                 

--- a/godtools/App/Features/AppLanguage/Presentation/DownloadableLanguages/DownloadableLanguagesViewModel.swift
+++ b/godtools/App/Features/AppLanguage/Presentation/DownloadableLanguages/DownloadableLanguagesViewModel.swift
@@ -159,6 +159,7 @@ extension DownloadableLanguagesViewModel {
     func removeDownloadedLanguage(_ downloadableLanguage: DownloadableLanguageListItemDomainModel) {
         
         removeDownloadedToolLanguageUseCase.removeDownloadedToolLanguage(downloadableLanguage.languageId)
+            .receive(on: DispatchQueue.main)
             .sink { _ in
                 
             }

--- a/godtools/App/Features/AppLanguage/Presentation/LanguageSettings/LanguageSettingsViewModel.swift
+++ b/godtools/App/Features/AppLanguage/Presentation/LanguageSettings/LanguageSettingsViewModel.swift
@@ -39,6 +39,7 @@ class LanguageSettingsViewModel: ObservableObject {
         self.trackScreenViewAnalyticsUseCase = trackScreenViewAnalyticsUseCase
         
         getCurrentAppLanguageUseCase.getLanguagePublisher()
+            .receive(on: DispatchQueue.main)
             .assign(to: &$appLanguage)
         
         $appLanguage.eraseToAnyPublisher()

--- a/godtools/App/Features/AppLanguage/Presentation/LanguageSettings/LanguageSettingsViewModel.swift
+++ b/godtools/App/Features/AppLanguage/Presentation/LanguageSettings/LanguageSettingsViewModel.swift
@@ -38,17 +38,19 @@ class LanguageSettingsViewModel: ObservableObject {
         self.viewLanguageSettingsUseCase = viewLanguageSettingsUseCase
         self.trackScreenViewAnalyticsUseCase = trackScreenViewAnalyticsUseCase
         
-        getCurrentAppLanguageUseCase.getLanguagePublisher()
+        getCurrentAppLanguageUseCase
+            .getLanguagePublisher()
             .receive(on: DispatchQueue.main)
             .assign(to: &$appLanguage)
         
-        $appLanguage.eraseToAnyPublisher()
-            .flatMap({ (appLanguage: AppLanguageDomainModel) -> AnyPublisher<ViewLanguageSettingsDomainModel, Never> in
+        $appLanguage
+            .dropFirst()
+            .map { (appLanguage: AppLanguageDomainModel) in
                 
-                return viewLanguageSettingsUseCase
+                viewLanguageSettingsUseCase
                     .viewPublisher(appLanguage: appLanguage)
-                    .eraseToAnyPublisher()
-            })
+            }
+            .switchToLatest()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] (domainModel: ViewLanguageSettingsDomainModel) in
                 

--- a/godtools/App/Features/Articles/Presentation/ArticleCategories/ArticleCategoriesViewModel.swift
+++ b/godtools/App/Features/Articles/Presentation/ArticleCategories/ArticleCategoriesViewModel.swift
@@ -106,6 +106,7 @@ extension ArticleCategoriesViewModel {
         if pageViewCount == 0 {
             
             incrementUserCounterUseCase.incrementUserCounter(for: .toolOpen(tool: resource.id))
+                .receive(on: DispatchQueue.main)
                 .sink { _ in
                     
                 } receiveValue: { _ in

--- a/godtools/App/Features/Articles/Presentation/ArticlesWeb/ArticleWebViewModel.swift
+++ b/godtools/App/Features/Articles/Presentation/ArticlesWeb/ArticleWebViewModel.swift
@@ -174,6 +174,7 @@ extension ArticleWebViewModel {
         )
         
         incrementUserCounterUseCase.incrementUserCounter(for: .articleOpen(uri: aemCacheObject.aemUri))
+            .receive(on: DispatchQueue.main)
             .sink { _ in
                 
             } receiveValue: { _ in

--- a/godtools/App/Features/Dashboard/Domain/UseCases/StoreInitialFavoritedToolsUseCase.swift
+++ b/godtools/App/Features/Dashboard/Domain/UseCases/StoreInitialFavoritedToolsUseCase.swift
@@ -36,7 +36,8 @@ class StoreInitialFavoritedToolsUseCase {
             
             let favoritedResourceIdsToStore: [String] = ["2", "1", "4", "8"]
             
-            return self.favoritedResourcesRepository.storeFavoritedResourcesPublisher(ids: favoritedResourceIdsToStore)
+            return favoritedResourcesRepository
+                .storeFavoritedResourcesPublisher(ids: favoritedResourceIdsToStore)
                 .eraseToAnyPublisher()
             
         })

--- a/godtools/App/Features/Dashboard/Presentation/Dashboard/DashboardViewModel.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Dashboard/DashboardViewModel.swift
@@ -37,6 +37,7 @@ class DashboardViewModel: ObservableObject {
         
         getCurrentAppLanguageUseCase
             .getLanguagePublisher()
+            .receive(on: DispatchQueue.main)
             .assign(to: &$appLanguage)
         
         $appLanguage.eraseToAnyPublisher()

--- a/godtools/App/Features/Dashboard/Presentation/Dashboard/DashboardViewModel.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Dashboard/DashboardViewModel.swift
@@ -40,12 +40,14 @@ class DashboardViewModel: ObservableObject {
             .receive(on: DispatchQueue.main)
             .assign(to: &$appLanguage)
         
-        $appLanguage.eraseToAnyPublisher()
-            .flatMap({ (appLanguage: AppLanguageDomainModel) -> AnyPublisher<ViewDashboardDomainModel, Never> in
-                return viewDashboardUseCase
+        $appLanguage
+            .dropFirst()
+            .map { (appLanguage: AppLanguageDomainModel) in
+                
+                viewDashboardUseCase
                     .viewPublisher(appLanguage: appLanguage)
-                    .eraseToAnyPublisher()
-            })
+            }
+            .switchToLatest()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] (domainModel: ViewDashboardDomainModel) in
                 

--- a/godtools/App/Features/Dashboard/Presentation/Tools/ToolsViewModel.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Tools/ToolsViewModel.swift
@@ -207,6 +207,7 @@ extension ToolsViewModel {
     func pullToRefresh() {
         
         resourcesRepository.syncLanguagesAndResourcesPlusLatestTranslationsAndLatestAttachments()
+            .receive(on: DispatchQueue.main)
             .sink(receiveCompletion: { completed in
 
             }, receiveValue: { (result: RealmResourcesCacheSyncResult) in

--- a/godtools/App/Features/Dashboard/Presentation/Tools/ToolsViewModel.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Tools/ToolsViewModel.swift
@@ -74,7 +74,7 @@ class ToolsViewModel: ObservableObject {
             $toolFilterCategorySelection.eraseToAnyPublisher().dropFirst(),
             $toolFilterLanguageSelection.eraseToAnyPublisher().dropFirst()
         )
-        .map{ (appLanguage, toolFilterCategory, toolFilterLanguage) -> AnyPublisher<(ViewToolsDomainModel, [SpotlightToolListItemDomainModel]), Never> in
+        .map{ (appLanguage, toolFilterCategory, toolFilterLanguage) in
                                     
             Publishers.CombineLatest(
                 viewToolsUseCase.viewPublisher(
@@ -88,7 +88,6 @@ class ToolsViewModel: ObservableObject {
                     languageForAvailabilityText: toolFilterLanguage.language
                 )
             )
-            .eraseToAnyPublisher()
         }
         .switchToLatest()
         .receive(on: DispatchQueue.main)
@@ -106,12 +105,12 @@ class ToolsViewModel: ObservableObject {
         }
         .store(in: &cancellables)
         
-        $appLanguage.eraseToAnyPublisher()
+        $appLanguage
             .dropFirst()
             .map { (appLanguage: AppLanguageDomainModel) in
                 
-                return getUserToolFiltersUseCase.getUserToolFiltersPublisher(translatedInAppLanguage: appLanguage)
-                    .eraseToAnyPublisher()
+                getUserToolFiltersUseCase
+                    .getUserToolFiltersPublisher(translatedInAppLanguage: appLanguage)
             }
             .switchToLatest()
             .receive(on: DispatchQueue.main)

--- a/godtools/App/Features/DownloadToolProgress/Domain/UseCases/GetDownloadToolProgressInterfaceStringsUseCase.swift
+++ b/godtools/App/Features/DownloadToolProgress/Domain/UseCases/GetDownloadToolProgressInterfaceStringsUseCase.swift
@@ -18,14 +18,10 @@ class GetDownloadToolProgressInterfaceStringsUseCase {
         self.getInterfaceStringsRepositoryInterface = getInterfaceStringsRepositoryInterface
     }
     
-    func getStringsPublisher(toolId: String?, appLanguagePublisher: AnyPublisher<AppLanguageDomainModel, Never>) -> AnyPublisher<DownloadToolProgressInterfaceStringsDomainModel, Never> {
+    func getStringsPublisher(toolId: String?, appLanguage: AppLanguageDomainModel) -> AnyPublisher<DownloadToolProgressInterfaceStringsDomainModel, Never> {
         
-        appLanguagePublisher
-            .flatMap({ (appLanguage: AppLanguageDomainModel) -> AnyPublisher<DownloadToolProgressInterfaceStringsDomainModel, Never> in
-                
-                return self.getInterfaceStringsRepositoryInterface.getStringsPublisher(toolId: toolId, translateInAppLanguage: appLanguage)
-                    .eraseToAnyPublisher()
-            })
+        return getInterfaceStringsRepositoryInterface
+            .getStringsPublisher(toolId: toolId, translateInAppLanguage: appLanguage)
             .eraseToAnyPublisher()
     }
 }

--- a/godtools/App/Features/DownloadToolProgress/Presentation/DownloadToolProgress/DownloadToolProgressViewModel.swift
+++ b/godtools/App/Features/DownloadToolProgress/Presentation/DownloadToolProgress/DownloadToolProgressViewModel.swift
@@ -43,8 +43,14 @@ class DownloadToolProgressViewModel: ObservableObject {
             self?.didCompleteProgressTimerClosure?()
         })
         
-        getDownloadToolProgressInterfaceStringsUseCase
-            .getStringsPublisher(toolId: toolId, appLanguagePublisher: $appLanguage.eraseToAnyPublisher())
+        $appLanguage
+            .dropFirst()
+            .map { (appLanguage: AppLanguageDomainModel) in
+                
+                getDownloadToolProgressInterfaceStringsUseCase
+                    .getStringsPublisher(toolId: toolId, appLanguage: appLanguage)
+            }
+            .switchToLatest()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] (interfaceStrings: DownloadToolProgressInterfaceStringsDomainModel) in
                 

--- a/godtools/App/Features/Favorites/Presentation/AllYourFavoriteTools/AllYourFavoriteToolsViewModel.swift
+++ b/godtools/App/Features/Favorites/Presentation/AllYourFavoriteTools/AllYourFavoriteToolsViewModel.swift
@@ -41,6 +41,7 @@ class AllYourFavoriteToolsViewModel: ObservableObject {
         
         getCurrentAppLanguageUseCase
             .getLanguagePublisher()
+            .receive(on: DispatchQueue.main)
             .assign(to: &$appLanguage)
         
         $appLanguage.eraseToAnyPublisher()

--- a/godtools/App/Features/Favorites/Presentation/AllYourFavoriteTools/AllYourFavoriteToolsViewModel.swift
+++ b/godtools/App/Features/Favorites/Presentation/AllYourFavoriteTools/AllYourFavoriteToolsViewModel.swift
@@ -44,13 +44,14 @@ class AllYourFavoriteToolsViewModel: ObservableObject {
             .receive(on: DispatchQueue.main)
             .assign(to: &$appLanguage)
         
-        $appLanguage.eraseToAnyPublisher()
-            .flatMap({ (appLanguage: AppLanguageDomainModel) -> AnyPublisher<(ViewAllYourFavoritedToolsDomainModel), Never> in
+        $appLanguage
+            .dropFirst()
+            .map { (appLanguage: AppLanguageDomainModel) in
                 
-                return viewAllYourFavoritedToolsUseCase
+                viewAllYourFavoritedToolsUseCase
                     .viewPublisher(appLanguage: appLanguage)
-                    .eraseToAnyPublisher()
-            })
+            }
+            .switchToLatest()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] (domainModel: ViewAllYourFavoritedToolsDomainModel) in
                 

--- a/godtools/App/Features/Favorites/Presentation/ConfirmRemoveToolFromFavorites/ConfirmRemoveToolFromFavoritesAlertViewModel.swift
+++ b/godtools/App/Features/Favorites/Presentation/ConfirmRemoveToolFromFavorites/ConfirmRemoveToolFromFavoritesAlertViewModel.swift
@@ -45,6 +45,7 @@ class ConfirmRemoveToolFromFavoritesAlertViewModel: AlertMessageViewModelType {
         didConfirmToolRemovalSubject?.send(Void())
         
         ConfirmRemoveToolFromFavoritesAlertViewModel.removeToolFromFavoritesCancellable = removeFavoritedToolUseCase.removeToolPublisher(toolId: toolId)
+            .receive(on: DispatchQueue.main)
             .sink { _ in
                 
             }

--- a/godtools/App/Features/Favorites/Presentation/ConfirmRemoveToolFromFavorites/ConfirmRemoveToolFromFavoritesAlertViewModel.swift
+++ b/godtools/App/Features/Favorites/Presentation/ConfirmRemoveToolFromFavorites/ConfirmRemoveToolFromFavoritesAlertViewModel.swift
@@ -44,7 +44,8 @@ class ConfirmRemoveToolFromFavoritesAlertViewModel: AlertMessageViewModelType {
         
         didConfirmToolRemovalSubject?.send(Void())
         
-        ConfirmRemoveToolFromFavoritesAlertViewModel.removeToolFromFavoritesCancellable = removeFavoritedToolUseCase.removeToolPublisher(toolId: toolId)
+        ConfirmRemoveToolFromFavoritesAlertViewModel.removeToolFromFavoritesCancellable = removeFavoritedToolUseCase
+            .removeToolPublisher(toolId: toolId)
             .receive(on: DispatchQueue.main)
             .sink { _ in
                 

--- a/godtools/App/Features/Favorites/Presentation/Favorites/FavoritesViewModel.swift
+++ b/godtools/App/Features/Favorites/Presentation/Favorites/FavoritesViewModel.swift
@@ -219,6 +219,7 @@ extension FavoritesViewModel {
     func pullToRefresh() {
         
         resourcesRepository.syncLanguagesAndResourcesPlusLatestTranslationsAndLatestAttachments()
+            .receive(on: DispatchQueue.main)
             .sink(receiveCompletion: { completed in
 
             }, receiveValue: { (result: RealmResourcesCacheSyncResult) in

--- a/godtools/App/Features/Favorites/Presentation/Favorites/FavoritesViewModel.swift
+++ b/godtools/App/Features/Favorites/Presentation/Favorites/FavoritesViewModel.swift
@@ -62,7 +62,7 @@ class FavoritesViewModel: ObservableObject {
             .receive(on: DispatchQueue.main)
             .assign(to: &$appLanguage)
         
-        $appLanguage.eraseToAnyPublisher()
+        $appLanguage
             .dropFirst()
             .map { (appLanguage: AppLanguageDomainModel) in
                 
@@ -70,7 +70,6 @@ class FavoritesViewModel: ObservableObject {
                     viewFavoritesUseCase.viewPublisher(appLanguage: appLanguage),
                     getFeaturedLessonsUseCase.getFeaturedLessonsPublisher(appLanguage: appLanguage)
                 )
-                .eraseToAnyPublisher()
             }
             .switchToLatest()
             .receive(on: DispatchQueue.main)
@@ -93,12 +92,12 @@ class FavoritesViewModel: ObservableObject {
             }
             .store(in: &cancellables)
         
-        $appLanguage.eraseToAnyPublisher()
+        $appLanguage
             .dropFirst()
             .map { (appLanguage: AppLanguageDomainModel) in
+                
                 getOptInOnboardingBannerEnabledUseCase
                     .getBannerIsEnabled(appLanguage: appLanguage)
-                    .eraseToAnyPublisher()
             }
             .switchToLatest()
             .receive(on: DispatchQueue.main)

--- a/godtools/App/Features/LearnToShareTool/Presentation/LearnToShareTool/LearnToShareToolViewModel.swift
+++ b/godtools/App/Features/LearnToShareTool/Presentation/LearnToShareTool/LearnToShareToolViewModel.swift
@@ -46,13 +46,13 @@ class LearnToShareToolViewModel: ObservableObject {
             .assign(to: &$appLanguage)
         
         $appLanguage
-            .eraseToAnyPublisher()
-            .flatMap({ (appLanguage: AppLanguageDomainModel) -> AnyPublisher<ViewLearnToShareToolDomainModel, Never> in
+            .dropFirst()
+            .map { (appLanguage: AppLanguageDomainModel) in
                 
-                return viewLearnToShareToolUseCase
+                viewLearnToShareToolUseCase
                     .viewPublisher(appLanguage: appLanguage)
-                    .eraseToAnyPublisher()
-            })
+            }
+            .switchToLatest()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] (domainModel: ViewLearnToShareToolDomainModel) in
                 
@@ -62,8 +62,8 @@ class LearnToShareToolViewModel: ObservableObject {
             .store(in: &cancellables)
         
         Publishers.CombineLatest(
-            $viewLearnToShareToolDomainModel.eraseToAnyPublisher(),
-            $currentPage.eraseToAnyPublisher()
+            $viewLearnToShareToolDomainModel,
+            $currentPage
         )
         .receive(on: DispatchQueue.main)
         .sink { [weak self] (viewLearnToShareToolDomainModel: ViewLearnToShareToolDomainModel?, currentPage: Int) in
@@ -79,7 +79,6 @@ class LearnToShareToolViewModel: ObservableObject {
         .store(in: &cancellables)
         
         $currentPage
-            .eraseToAnyPublisher()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] (currentPage: Int) in
                 self?.hidesBackButton = currentPage == 0

--- a/godtools/App/Features/LearnToShareTool/Presentation/LearnToShareTool/LearnToShareToolViewModel.swift
+++ b/godtools/App/Features/LearnToShareTool/Presentation/LearnToShareTool/LearnToShareToolViewModel.swift
@@ -42,6 +42,7 @@ class LearnToShareToolViewModel: ObservableObject {
               
         getCurrentAppLanguageUseCase
             .getLanguagePublisher()
+            .receive(on: DispatchQueue.main)
             .assign(to: &$appLanguage)
         
         $appLanguage

--- a/godtools/App/Features/LessonEvaluation/Presentation/LessonEvaluation/LessonEvaluationViewModel.swift
+++ b/godtools/App/Features/LessonEvaluation/Presentation/LessonEvaluation/LessonEvaluationViewModel.swift
@@ -52,6 +52,7 @@ class LessonEvaluationViewModel: ObservableObject {
         
         getCurrentAppLanguageUseCase
             .getLanguagePublisher()
+            .receive(on: DispatchQueue.main)
             .assign(to: &$appLanguage)
         
         $appLanguage.eraseToAnyPublisher()

--- a/godtools/App/Features/Lessons/Presentation/Lessons/LessonsViewModel.swift
+++ b/godtools/App/Features/Lessons/Presentation/Lessons/LessonsViewModel.swift
@@ -45,13 +45,12 @@ class LessonsViewModel: ObservableObject {
             .receive(on: DispatchQueue.main)
             .assign(to: &$appLanguage)
         
-        $appLanguage.eraseToAnyPublisher()
+        $appLanguage
             .dropFirst()
             .map { (appLanguage: AppLanguageDomainModel) in
             
-                return viewLessonsUseCase
+                viewLessonsUseCase
                     .viewPublisher(appLanguage: appLanguage)
-                    .eraseToAnyPublisher()
             }
             .switchToLatest()
             .receive(on: DispatchQueue.main)
@@ -138,7 +137,8 @@ extension LessonsViewModel {
     
     func refreshData() {
         
-        resourcesRepository.syncLanguagesAndResourcesPlusLatestTranslationsAndLatestAttachments()
+        resourcesRepository
+            .syncLanguagesAndResourcesPlusLatestTranslationsAndLatestAttachments()
             .receive(on: DispatchQueue.main)
             .sink(receiveCompletion: { completed in
 

--- a/godtools/App/Features/Lessons/Presentation/Lessons/LessonsViewModel.swift
+++ b/godtools/App/Features/Lessons/Presentation/Lessons/LessonsViewModel.swift
@@ -139,6 +139,7 @@ extension LessonsViewModel {
     func refreshData() {
         
         resourcesRepository.syncLanguagesAndResourcesPlusLatestTranslationsAndLatestAttachments()
+            .receive(on: DispatchQueue.main)
             .sink(receiveCompletion: { completed in
 
             }, receiveValue: { (result: RealmResourcesCacheSyncResult) in

--- a/godtools/App/Features/Menu/Domain/UseCases/GetMenuInterfaceStringsUseCase/GetMenuInterfaceStringsUseCase.swift
+++ b/godtools/App/Features/Menu/Domain/UseCases/GetMenuInterfaceStringsUseCase/GetMenuInterfaceStringsUseCase.swift
@@ -18,14 +18,10 @@ class GetMenuInterfaceStringsUseCase {
         self.getInterfaceStringsRepositoryInterface = getInterfaceStringsRepositoryInterface
     }
     
-    func getStringsPublisher(appLanguagePublisher: AnyPublisher<AppLanguageDomainModel, Never>) -> AnyPublisher<MenuInterfaceStringsDomainModel, Never> {
+    func getStringsPublisher(appLanguage: AppLanguageDomainModel) -> AnyPublisher<MenuInterfaceStringsDomainModel, Never> {
         
-        return appLanguagePublisher
-            .flatMap({ (appLanguage: AppLanguageDomainModel) -> AnyPublisher<MenuInterfaceStringsDomainModel, Never> in
-                
-                return self.getInterfaceStringsRepositoryInterface.getStringsPublisher(translateInLanguage: appLanguage)
-                    .eraseToAnyPublisher()
-            })
+        return getInterfaceStringsRepositoryInterface
+            .getStringsPublisher(translateInLanguage: appLanguage)
             .eraseToAnyPublisher()
     }
 }

--- a/godtools/App/Features/Menu/Domain/UseCases/GetUserAccountDetailsUseCase/GetUserAccountDetailsUseCase.swift
+++ b/godtools/App/Features/Menu/Domain/UseCases/GetUserAccountDetailsUseCase/GetUserAccountDetailsUseCase.swift
@@ -20,18 +20,17 @@ class GetUserAccountDetailsUseCase {
         self.localizationServices = localizationServices
     }
     
-    func getUserAccountDetailsPublisher(appLanguagePublisher: AnyPublisher<AppLanguageDomainModel, Never>) -> AnyPublisher<UserAccountDetailsDomainModel, Never> {
+    func getUserAccountDetailsPublisher(appLanguage: AppLanguageDomainModel) -> AnyPublisher<UserAccountDetailsDomainModel, Never> {
         
-        return Publishers.CombineLatest3(
+        return Publishers.CombineLatest(
             repository.getAuthUserDetailsFromRemotePublisher().prepend(UserDetailsDataModel.emptyDataModel())
                 .catch({ _ in
                     return Just(UserDetailsDataModel.emptyDataModel())
                         .eraseToAnyPublisher()
                 }),
-            repository.getAuthUserDetailsChangedPublisher().prepend(nil),
-            appLanguagePublisher
+            repository.getAuthUserDetailsChangedPublisher().prepend(nil)
         )
-        .flatMap({ (remoteUserDetails: UserDetailsDataModel, changedUserDetails: UserDetailsDataModel?, appLanguage: AppLanguageDomainModel) -> AnyPublisher<UserAccountDetailsDomainModel, Never> in
+        .flatMap({ (remoteUserDetails: UserDetailsDataModel, changedUserDetails: UserDetailsDataModel?) -> AnyPublisher<UserAccountDetailsDomainModel, Never> in
                             
             let cachedAuthUserDetails: UserDetailsDataModel? = self.repository.getCachedAuthUserDetails()
             

--- a/godtools/App/Features/Menu/Domain/UseCases/GetUserActivityUseCase/GetUserActivityUseCase.swift
+++ b/godtools/App/Features/Menu/Domain/UseCases/GetUserActivityUseCase/GetUserActivityUseCase.swift
@@ -25,22 +25,20 @@ class GetUserActivityUseCase {
         self.completedTrainingTipRepository = completedTrainingTipRepository
     }
     
-    func getUserActivityPublisher(appLanguagePublisher: AnyPublisher<AppLanguageDomainModel, Never>) -> AnyPublisher<UserActivityDomainModel, Never> {
+    func getUserActivityPublisher(appLanguage: AppLanguageDomainModel) -> AnyPublisher<UserActivityDomainModel, Never> {
         
-        return Publishers.CombineLatest(
-            userCounterRepository.getUserCountersChanged(reloadFromRemote: true),
-            appLanguagePublisher
-        )
-        .flatMap { _, appLanguage in
-                
+        return userCounterRepository
+            .getUserCountersChanged(reloadFromRemote: true)
+            .flatMap { _ in
+                    
                 let allUserCounters = self.getAllUserCounters()
-                
-            let userActivityDomainModel = self.getUserActivityDomainModel(from: allUserCounters, translatedInAppLanguage: appLanguage)
-                
-                return Just(userActivityDomainModel)
-                
-            }
-            .eraseToAnyPublisher()
+                    
+                let userActivityDomainModel = self.getUserActivityDomainModel(from: allUserCounters, translatedInAppLanguage: appLanguage)
+                    
+                    return Just(userActivityDomainModel)
+                    
+                }
+                .eraseToAnyPublisher()
     }
     
     private func getAllUserCounters() -> [UserCounterDomainModel] {

--- a/godtools/App/Features/Menu/Domain/UseCases/ViewAccountUseCase/ViewAccountUseCase.swift
+++ b/godtools/App/Features/Menu/Domain/UseCases/ViewAccountUseCase/ViewAccountUseCase.swift
@@ -18,13 +18,10 @@ class ViewAccountUseCase {
         self.getInterfaceStringsRepository = getInterfaceStringsRepository
     }
     
-    func viewPublisher(appLanguagePublisher: AnyPublisher<AppLanguageDomainModel, Never>) -> AnyPublisher<ViewAccountDomainModel, Never> {
+    func viewPublisher(appLanguage: AppLanguageDomainModel) -> AnyPublisher<ViewAccountDomainModel, Never> {
         
-        return appLanguagePublisher
-            .flatMap { appLanguage in
-                
-                return self.getInterfaceStringsRepository.getStringsPublisher(translateInAppLanguage: appLanguage)
-            }
+        return getInterfaceStringsRepository
+            .getStringsPublisher(translateInAppLanguage: appLanguage)
             .map { interfaceStrings in
                 
                 return ViewAccountDomainModel(

--- a/godtools/App/Features/Menu/Presentation/Account/AccountViewModel.swift
+++ b/godtools/App/Features/Menu/Presentation/Account/AccountViewModel.swift
@@ -53,6 +53,7 @@ class AccountViewModel: ObservableObject {
         
         getCurrentAppLanguageUseCase
             .getLanguagePublisher()
+            .receive(on: DispatchQueue.main)
             .assign(to: &$appLanguage)
 
         viewAccountUseCase.viewPublisher(appLanguagePublisher: $appLanguage.eraseToAnyPublisher())

--- a/godtools/App/Features/Menu/Presentation/Menu/MenuViewModel.swift
+++ b/godtools/App/Features/Menu/Presentation/Menu/MenuViewModel.swift
@@ -69,6 +69,7 @@ class MenuViewModel: ObservableObject {
         
         getCurrentAppLanguageUseCase
             .getLanguagePublisher()
+            .receive(on: DispatchQueue.main)
             .assign(to: &$appLanguage)
         
         getMenuInterfaceStringsUseCase

--- a/godtools/App/Features/Onboarding/Domain/UseCases/GetOnboardingTutorialInterfaceStringsUseCase.swift
+++ b/godtools/App/Features/Onboarding/Domain/UseCases/GetOnboardingTutorialInterfaceStringsUseCase.swift
@@ -18,14 +18,10 @@ class GetOnboardingTutorialInterfaceStringsUseCase {
         self.getStringsRepositoryInterface = getStringsRepositoryInterface
     }
     
-    func getStringsPublisher(appLanguagePublisher: AnyPublisher<AppLanguageDomainModel, Never>) -> AnyPublisher<OnboardingTutorialInterfaceStringsDomainModel, Never> {
+    func getStringsPublisher(appLanguage: AppLanguageDomainModel) -> AnyPublisher<OnboardingTutorialInterfaceStringsDomainModel, Never> {
         
-        return appLanguagePublisher
-            .flatMap({ (appLanguage: AppLanguageDomainModel) -> AnyPublisher<OnboardingTutorialInterfaceStringsDomainModel, Never> in
-                
-                return self.getStringsRepositoryInterface.getStringsPublisher(appLanguage: appLanguage)
-                    .eraseToAnyPublisher()
-            })
+        return getStringsRepositoryInterface
+            .getStringsPublisher(appLanguage: appLanguage)
             .eraseToAnyPublisher()
     }
 }

--- a/godtools/App/Features/Onboarding/Presentation/OnboardingTutorial/OnboardingTutorialViewModel.swift
+++ b/godtools/App/Features/Onboarding/Presentation/OnboardingTutorial/OnboardingTutorialViewModel.swift
@@ -29,7 +29,7 @@ class OnboardingTutorialViewModel: ObservableObject {
     
     private weak var flowDelegate: FlowDelegate?
     
-    @Published private var appLanguage: AppLanguageDomainModel = ""
+    @Published private var appLanguage: AppLanguageDomainModel = LanguageCodeDomainModel.english.rawValue
     
     @Published var hidesSkipButton: Bool = true
     @Published var currentPage: Int = 0 {
@@ -66,8 +66,14 @@ class OnboardingTutorialViewModel: ObservableObject {
             .receive(on: DispatchQueue.main)
             .assign(to: &$appLanguage)
         
-        getOnboardingTutorialInterfaceStringsUseCase
-            .getStringsPublisher(appLanguagePublisher: $appLanguage.eraseToAnyPublisher())
+        $appLanguage
+            .dropFirst()
+            .map { (appLanguage: AppLanguageDomainModel) in
+                
+                getOnboardingTutorialInterfaceStringsUseCase
+                    .getStringsPublisher(appLanguage: appLanguage)
+            }
+            .switchToLatest()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] (interfaceStrings: OnboardingTutorialInterfaceStringsDomainModel) in
                 

--- a/godtools/App/Features/Shareables/Presentation/ReviewShareShareable/ReviewShareShareableViewModel.swift
+++ b/godtools/App/Features/Shareables/Presentation/ReviewShareShareable/ReviewShareShareableViewModel.swift
@@ -80,6 +80,7 @@ class ReviewShareShareableViewModel: ObservableObject {
         
         trackShareShareableTapUseCase
             .trackPublisher(toolId: "", shareableId: shareable.dataModelId)
+            .receive(on: DispatchQueue.main)
             .sink { _ in
                 
             }

--- a/godtools/App/Features/Shareables/Presentation/ReviewShareShareable/ReviewShareShareableViewModel.swift
+++ b/godtools/App/Features/Shareables/Presentation/ReviewShareShareable/ReviewShareShareableViewModel.swift
@@ -48,6 +48,7 @@ class ReviewShareShareableViewModel: ObservableObject {
                     .viewPublisher(appLanguage: appLanguage)
                     .eraseToAnyPublisher()
             })
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] (domainModel: ViewReviewShareShareableDomainModel) in
                 self?.shareImageButtonTitle = domainModel.interfaceStrings.shareActionTitle
             }

--- a/godtools/App/Features/Shareables/Presentation/ReviewShareShareable/ReviewShareShareableViewModel.swift
+++ b/godtools/App/Features/Shareables/Presentation/ReviewShareShareable/ReviewShareShareableViewModel.swift
@@ -42,12 +42,14 @@ class ReviewShareShareableViewModel: ObservableObject {
         self.getShareableImageUseCase = getShareableImageUseCase
         self.trackShareShareableTapUseCase = trackShareShareableTapUseCase
         
-        $appLanguage.eraseToAnyPublisher()
-            .flatMap({ (appLanguage: AppLanguageDomainModel) -> AnyPublisher<ViewReviewShareShareableDomainModel, Never> in
-                return viewReviewShareShareableUseCase
+        $appLanguage
+            .dropFirst()
+            .map { (appLanguage: AppLanguageDomainModel) in
+                
+                viewReviewShareShareableUseCase
                     .viewPublisher(appLanguage: appLanguage)
-                    .eraseToAnyPublisher()
-            })
+            }
+            .switchToLatest()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] (domainModel: ViewReviewShareShareableDomainModel) in
                 self?.shareImageButtonTitle = domainModel.interfaceStrings.shareActionTitle

--- a/godtools/App/Features/Shareables/Presentation/ShareShareable/ShareShareableViewModel.swift
+++ b/godtools/App/Features/Shareables/Presentation/ShareShareable/ShareShareableViewModel.swift
@@ -35,6 +35,7 @@ extension ShareShareableViewModel {
     func pageViewed() {
         
         incrementUserCounterUseCase.incrementUserCounter(for: .imageShared)
+            .receive(on: DispatchQueue.main)
             .sink { _ in
                 
             } receiveValue: { _ in

--- a/godtools/App/Features/ToolDetails/Presentation/ToolDetails/ToolDetailsViewModel.swift
+++ b/godtools/App/Features/ToolDetails/Presentation/ToolDetails/ToolDetailsViewModel.swift
@@ -178,23 +178,23 @@ class ToolDetailsViewModel: ObservableObject {
         })
         .store(in: &cancellables)
         
-        $toolId.eraseToAnyPublisher()
-            .flatMap({ (toolId: String) -> AnyPublisher<ToolDetailsMediaDomainModel, Never> in
+        $toolId
+            .map { (toolId: String) in
                 
-                return getToolDetailsMediaUseCase
+                getToolDetailsMediaUseCase
                     .getMediaPublisher(toolId: toolId)
-                    .eraseToAnyPublisher()
-            })
+            }
+            .switchToLatest()
             .receive(on: DispatchQueue.main)
             .assign(to: &$mediaType)
         
-        $toolId.eraseToAnyPublisher()
-            .flatMap({ (toolId: String) -> AnyPublisher<Bool, Never> in
+        $toolId
+            .map { (toolId: String) in
                 
-                return getToolDetailsLearnToShareToolIsAvailableUseCase
+                getToolDetailsLearnToShareToolIsAvailableUseCase
                     .getIsAvailablePublisher(toolId: toolId, language: primaryLanguage)
-                    .eraseToAnyPublisher()
-            })
+            }
+            .switchToLatest()
             .receive(on: DispatchQueue.main)
             .assign(to: &$showsLearnToShareToolButton)
     }

--- a/godtools/App/Features/ToolDetails/Presentation/ToolDetails/ToolDetailsViewModel.swift
+++ b/godtools/App/Features/ToolDetails/Presentation/ToolDetails/ToolDetailsViewModel.swift
@@ -124,13 +124,13 @@ class ToolDetailsViewModel: ObservableObject {
             $toolId.eraseToAnyPublisher(),
             $appLanguage.eraseToAnyPublisher()
         )
-        .receive(on: DispatchQueue.main)
         .flatMap ({ (toolId: String, appLanguage: AppLanguageDomainModel) -> AnyPublisher<ViewToolDetailsDomainModel, Never> in
             
             return viewToolDetailsUseCase
                 .viewPublisher(toolId: toolId, translateInLanguage: appLanguage, toolPrimaryLanguage: primaryLanguage, toolParallelLanguage: parallelLanguage)
                 .eraseToAnyPublisher()
         })
+        .receive(on: DispatchQueue.main)
         .sink(receiveValue: { [weak self] (domainModel: ViewToolDetailsDomainModel) in
             
             self?.analyticsToolAbbreviation = domainModel.toolDetails.analyticsToolAbbreviation

--- a/godtools/App/Features/ToolDetails/Presentation/ToolDetails/ToolDetailsViewModel.swift
+++ b/godtools/App/Features/ToolDetails/Presentation/ToolDetails/ToolDetailsViewModel.swift
@@ -87,6 +87,7 @@ class ToolDetailsViewModel: ObservableObject {
         
         getCurrentAppLanguageUseCase
             .getLanguagePublisher()
+            .receive(on: DispatchQueue.main)
             .assign(to: &$appLanguage)
         
         Publishers.CombineLatest(

--- a/godtools/App/Features/ToolScreenShare/Domain/UseCases/ViewCreatingToolScreenShareSessionUseCase.swift
+++ b/godtools/App/Features/ToolScreenShare/Domain/UseCases/ViewCreatingToolScreenShareSessionUseCase.swift
@@ -18,22 +18,16 @@ class ViewCreatingToolScreenShareSessionUseCase {
         self.getInterfaceStringsRepositoryInterface = getInterfaceStringsRepositoryInterface
     }
     
-    func viewPublisher(appLanguagePublisher: AnyPublisher<AppLanguageDomainModel, Never>) -> AnyPublisher<CreatingToolScreenShareSessionDomainModel, Never> {
+    func viewPublisher(appLanguage: AppLanguageDomainModel) -> AnyPublisher<CreatingToolScreenShareSessionDomainModel, Never> {
         
-        return appLanguagePublisher
-            .flatMap({ (appLanguage: AppLanguageDomainModel) -> AnyPublisher<CreatingToolScreenShareSessionInterfaceStringsDomainModel, Never> in
+        return getInterfaceStringsRepositoryInterface
+            .getStringsPublisher(translateInLanguage: appLanguage)
+            .map { (interfaceStrings: CreatingToolScreenShareSessionInterfaceStringsDomainModel) in
                 
-                return self.getInterfaceStringsRepositoryInterface
-                    .getStringsPublisher(translateInLanguage: appLanguage)
-                    .eraseToAnyPublisher()
-            })
-            .flatMap({ (interfaceStrings: CreatingToolScreenShareSessionInterfaceStringsDomainModel) -> AnyPublisher<CreatingToolScreenShareSessionDomainModel, Never> in
-                
-                let domainModel = CreatingToolScreenShareSessionDomainModel(interfaceStrings: interfaceStrings)
-                
-                return Just(domainModel)
-                    .eraseToAnyPublisher()
-            })
+                CreatingToolScreenShareSessionDomainModel(
+                    interfaceStrings: interfaceStrings
+                )
+            }
             .eraseToAnyPublisher()
     }
 }

--- a/godtools/App/Features/ToolScreenShare/Domain/UseCases/ViewToolScreenShareTutorialUseCase.swift
+++ b/godtools/App/Features/ToolScreenShare/Domain/UseCases/ViewToolScreenShareTutorialUseCase.swift
@@ -20,24 +20,19 @@ class ViewToolScreenShareTutorialUseCase {
         self.getTutorialRepositoryInterface = getTutorialRepositoryInterface
     }
     
-    func viewTutorialPublisher(appLanguagePublisher: AnyPublisher<AppLanguageDomainModel, Never>) -> AnyPublisher<ToolScreenShareTutorialDomainModel, Never> {
+    func viewTutorialPublisher(appLanguage: AppLanguageDomainModel) -> AnyPublisher<ToolScreenShareTutorialDomainModel, Never> {
         
-        return appLanguagePublisher
-            .flatMap({ (appLanguage: AppLanguageDomainModel) -> AnyPublisher<(ToolScreenShareInterfaceStringsDomainModel, [ToolScreenShareTutorialPageDomainModel]), Never> in
-                
-                return Publishers.CombineLatest(
-                    self.getInterfaceStringsRepositoryInterface.getStringsPublisher(translateInLanguage: appLanguage),
-                    self.getTutorialRepositoryInterface.getTutorialPublisher(translateInLanguage: appLanguage)
-                )
-                .eraseToAnyPublisher()
-            })
-            .flatMap({ (interfaceStrings: ToolScreenShareInterfaceStringsDomainModel, pages: [ToolScreenShareTutorialPageDomainModel]) -> AnyPublisher<ToolScreenShareTutorialDomainModel, Never> in
-                
-                let tutorial = ToolScreenShareTutorialDomainModel(interfaceStrings: interfaceStrings, pages: pages)
-                
-                return Just(tutorial)
-                    .eraseToAnyPublisher()
-            })
-            .eraseToAnyPublisher()
+        return Publishers.CombineLatest(
+            getInterfaceStringsRepositoryInterface.getStringsPublisher(translateInLanguage: appLanguage),
+            getTutorialRepositoryInterface.getTutorialPublisher(translateInLanguage: appLanguage)
+        )
+        .map { (interfaceStrings: ToolScreenShareInterfaceStringsDomainModel, pages: [ToolScreenShareTutorialPageDomainModel]) in
+            
+            ToolScreenShareTutorialDomainModel(
+                interfaceStrings: interfaceStrings,
+                pages: pages
+            )
+        }
+        .eraseToAnyPublisher()
     }
 }

--- a/godtools/App/Features/ToolScreenShare/Presentation/CreatingToolScreenShareSession/CreatingToolScreenShareSessionViewModel.swift
+++ b/godtools/App/Features/ToolScreenShare/Presentation/CreatingToolScreenShareSession/CreatingToolScreenShareSessionViewModel.swift
@@ -41,8 +41,14 @@ class CreatingToolScreenShareSessionViewModel: ObservableObject {
             .receive(on: DispatchQueue.main)
             .assign(to: &$appLanguage)
         
-        viewCreatingToolScreenShareSessionUseCase
-            .viewPublisher(appLanguagePublisher: $appLanguage.eraseToAnyPublisher())
+        $appLanguage
+            .dropFirst()
+            .map { (appLanguage: AppLanguageDomainModel) in
+                
+                viewCreatingToolScreenShareSessionUseCase
+                    .viewPublisher(appLanguage: appLanguage)
+            }
+            .switchToLatest()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] (domainModel: CreatingToolScreenShareSessionDomainModel) in
                 

--- a/godtools/App/Features/ToolScreenShare/Presentation/CreatingToolScreenShareSession/CreatingToolScreenShareSessionViewModel.swift
+++ b/godtools/App/Features/ToolScreenShare/Presentation/CreatingToolScreenShareSession/CreatingToolScreenShareSessionViewModel.swift
@@ -38,6 +38,7 @@ class CreatingToolScreenShareSessionViewModel: ObservableObject {
         
         getCurrentAppLanguage
             .getLanguagePublisher()
+            .receive(on: DispatchQueue.main)
             .assign(to: &$appLanguage)
         
         viewCreatingToolScreenShareSessionUseCase

--- a/godtools/App/Features/ToolScreenShare/Presentation/CreatingToolScreenShareSession/CreatingToolScreenShareSessionViewModel.swift
+++ b/godtools/App/Features/ToolScreenShare/Presentation/CreatingToolScreenShareSession/CreatingToolScreenShareSessionViewModel.swift
@@ -80,6 +80,7 @@ extension CreatingToolScreenShareSessionViewModel {
     func pageViewed() {
         
         CreatingToolScreenShareSessionViewModel.incrementScreenShareInBackgroundCancellable = incrementUserCounterUseCase.incrementUserCounter(for: .screenShare(tool: toolId))
+            .receive(on: DispatchQueue.main)
             .sink { _ in
                 
             } receiveValue: { _ in

--- a/godtools/App/Features/ToolScreenShare/Presentation/ToolScreenShareTutorial/ToolScreenShareTutorialViewModel.swift
+++ b/godtools/App/Features/ToolScreenShare/Presentation/ToolScreenShareTutorial/ToolScreenShareTutorialViewModel.swift
@@ -43,8 +43,14 @@ class ToolScreenShareTutorialViewModel: ObservableObject {
             .receive(on: DispatchQueue.main)
             .assign(to: &$appLanguage)
         
-        viewToolScreenShareTutorialUseCase
-            .viewTutorialPublisher(appLanguagePublisher: $appLanguage.eraseToAnyPublisher())
+        $appLanguage
+            .dropFirst()
+            .map { (appLanguage: AppLanguageDomainModel) in
+                
+                viewToolScreenShareTutorialUseCase
+                    .viewTutorialPublisher(appLanguage: appLanguage)
+            }
+            .switchToLatest()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] (toolScreenShareTutorial: ToolScreenShareTutorialDomainModel) in
                 
@@ -54,8 +60,8 @@ class ToolScreenShareTutorialViewModel: ObservableObject {
             .store(in: &cancellables)
         
         Publishers.CombineLatest(
-            $currentPage.eraseToAnyPublisher(),
-            $interfaceStrings.eraseToAnyPublisher()
+            $currentPage,
+            $interfaceStrings
         )
         .receive(on: DispatchQueue.main)
         .sink { [weak self] (currentPage: Int, interfaceStrings: ToolScreenShareInterfaceStringsDomainModel?) in

--- a/godtools/App/Features/ToolScreenShare/Presentation/ToolScreenShareTutorial/ToolScreenShareTutorialViewModel.swift
+++ b/godtools/App/Features/ToolScreenShare/Presentation/ToolScreenShareTutorial/ToolScreenShareTutorialViewModel.swift
@@ -40,6 +40,7 @@ class ToolScreenShareTutorialViewModel: ObservableObject {
         
         getCurrentAppLanguageUseCase
             .getLanguagePublisher()
+            .receive(on: DispatchQueue.main)
             .assign(to: &$appLanguage)
         
         viewToolScreenShareTutorialUseCase

--- a/godtools/App/Features/ToolScreenShare/Presentation/ToolScreenShareTutorial/ToolScreenShareTutorialViewModel.swift
+++ b/godtools/App/Features/ToolScreenShare/Presentation/ToolScreenShareTutorial/ToolScreenShareTutorialViewModel.swift
@@ -126,6 +126,7 @@ extension ToolScreenShareTutorialViewModel {
         
         ToolScreenShareTutorialViewModel.didViewToolScreenShareTutorialCancellable = didViewToolScreenShareTutorialUseCase
             .didViewPublisher(toolId: toolId)
+            .receive(on: DispatchQueue.main)
             .sink { _ in
                 
             }

--- a/godtools/App/Features/ToolSettings/Presentation/ShareTool/ShareToolViewModel.swift
+++ b/godtools/App/Features/ToolSettings/Presentation/ShareTool/ShareToolViewModel.swift
@@ -79,6 +79,7 @@ extension ShareToolViewModel {
         )
         
         incrementUserCounterUseCase.incrementUserCounter(for: .linkShared)
+            .receive(on: DispatchQueue.main)
             .sink { _ in
                 
             } receiveValue: { _ in

--- a/godtools/App/Features/ToolSettings/Presentation/ToolSettings/ToolSettingsViewModel.swift
+++ b/godtools/App/Features/ToolSettings/Presentation/ToolSettings/ToolSettingsViewModel.swift
@@ -49,6 +49,7 @@ class ToolSettingsViewModel: ObservableObject {
         
         getCurrentAppLanguageUseCase
             .getLanguagePublisher()
+            .receive(on: DispatchQueue.main)
             .assign(to: &$appLanguage)
         
         Publishers.CombineLatest(

--- a/godtools/App/Features/ToolSettings/Presentation/ToolSettings/ToolSettingsViewModel.swift
+++ b/godtools/App/Features/ToolSettings/Presentation/ToolSettings/ToolSettingsViewModel.swift
@@ -104,11 +104,12 @@ class ToolSettingsViewModel: ObservableObject {
         .store(in: &cancellables)
         
         toolSettingsObserver.$languages
-            .flatMap({ (languages: ToolSettingsLanguages) -> AnyPublisher<[ShareableDomainModel], Never> in
+            .map { (languages: ToolSettingsLanguages) in
                 
                 getShareablesUseCase
                     .getShareablesPublisher(toolId: toolSettingsObserver.toolId, toolLanguageId: languages.selectedLanguageId)
-            })
+            }
+            .switchToLatest()
             .receive(on: DispatchQueue.main)
             .assign(to: &$shareables)
     }

--- a/godtools/App/Features/ToolSettings/Presentation/ToolSettingsToolLanguagesList/ToolSettingsToolLanguagesListViewModel.swift
+++ b/godtools/App/Features/ToolSettings/Presentation/ToolSettingsToolLanguagesList/ToolSettingsToolLanguagesListViewModel.swift
@@ -45,12 +45,12 @@ class ToolSettingsToolLanguagesListViewModel: ObservableObject {
             .assign(to: &$appLanguage)
         
         Publishers.CombineLatest(
-            $appLanguage.eraseToAnyPublisher(),
-            toolSettingsObserver.$languages.eraseToAnyPublisher()
+            $appLanguage.dropFirst(),
+            toolSettingsObserver.$languages
         )
-        .flatMap({ (appLanguage: AppLanguageDomainModel, languages: ToolSettingsLanguages) -> AnyPublisher<ViewToolSettingsToolLanguagesListDomainModel, Never> in
+        .map { (appLanguage: AppLanguageDomainModel, languages: ToolSettingsLanguages) in
             
-            return viewToolSettingsToolLanguageListUseCase
+            viewToolSettingsToolLanguageListUseCase
                 .viewPublisher(
                     listType: listType,
                     primaryLanguageId: languages.primaryLanguageId,
@@ -58,8 +58,8 @@ class ToolSettingsToolLanguagesListViewModel: ObservableObject {
                     toolId: toolId,
                     appLanguage: appLanguage
                 )
-                .eraseToAnyPublisher()
-        })
+        }
+        .switchToLatest()
         .receive(on: DispatchQueue.main)
         .sink(receiveValue: { [weak self] (domainModel: ViewToolSettingsToolLanguagesListDomainModel) in
             

--- a/godtools/App/Features/ToolSettings/Presentation/ToolSettingsToolLanguagesList/ToolSettingsToolLanguagesListViewModel.swift
+++ b/godtools/App/Features/ToolSettings/Presentation/ToolSettingsToolLanguagesList/ToolSettingsToolLanguagesListViewModel.swift
@@ -41,6 +41,7 @@ class ToolSettingsToolLanguagesListViewModel: ObservableObject {
         
         getCurrentAppLanguageUseCase
             .getLanguagePublisher()
+            .receive(on: DispatchQueue.main)
             .assign(to: &$appLanguage)
         
         Publishers.CombineLatest(

--- a/godtools/App/Features/ToolShortcutLinks/Presentation/ToolShortcutLinks/ToolShortcutLinksView.swift
+++ b/godtools/App/Features/ToolShortcutLinks/Presentation/ToolShortcutLinks/ToolShortcutLinksView.swift
@@ -30,7 +30,8 @@ class ToolShortcutLinksView {
         self.application = application
         self.viewModel = viewModel
         
-        ToolShortcutLinksView.shortcutLinksCancellable = viewModel.$shortcutLinks.eraseToAnyPublisher()
+        ToolShortcutLinksView.shortcutLinksCancellable = viewModel.$shortcutLinks
+            .receive(on: DispatchQueue.main)
             .sink { (toolShortcutLinks: [ToolShortcutLinkDomainModel]) in
                 
                 let toolShortcutItems = toolShortcutLinks.map({ (toolShortcutLink: ToolShortcutLinkDomainModel) in

--- a/godtools/App/Features/ToolShortcutLinks/Presentation/ToolShortcutLinks/ToolShortcutLinksViewModel.swift
+++ b/godtools/App/Features/ToolShortcutLinks/Presentation/ToolShortcutLinks/ToolShortcutLinksViewModel.swift
@@ -28,9 +28,8 @@ class ToolShortcutLinksViewModel: ObservableObject {
             .getLanguagePublisher()
             .flatMap({ (appLanguage: AppLanguageDomainModel) -> AnyPublisher<ViewToolShortcutLinksDomainModel, Never> in
                 
-                return viewToolShortcutLinksUseCase
+                viewToolShortcutLinksUseCase
                     .viewPublisher(appLanguage: appLanguage)
-                    .eraseToAnyPublisher()
             })
             .receive(on: DispatchQueue.main)
             .sink { [weak self] (domainModel: ViewToolShortcutLinksDomainModel) in

--- a/godtools/App/Features/ToolTraining/Presentation/ToolTrainingViewModel.swift
+++ b/godtools/App/Features/ToolTraining/Presentation/ToolTrainingViewModel.swift
@@ -155,6 +155,7 @@ extension ToolTrainingViewModel {
         let trainingTipCompleted = TrainingTipDomainModel(trainingTipId: trainingTipId, resourceId: resource.id, languageId: language.id)
         
         setCompletedTrainingTipUseCase.setTrainingTipAsCompleted(tip: trainingTipCompleted)
+            .receive(on: DispatchQueue.main)
             .sink { _ in
                 
             } receiveValue: { _ in

--- a/godtools/App/Features/ToolsFilter/Presentation/ToolFilterCategorySelectionView/ToolFilterCategorySelectionViewModel.swift
+++ b/godtools/App/Features/ToolsFilter/Presentation/ToolFilterCategorySelectionView/ToolFilterCategorySelectionViewModel.swift
@@ -45,6 +45,7 @@ class ToolFilterCategorySelectionViewModel: ObservableObject {
         
         getCurrentAppLanguageUseCase
             .getLanguagePublisher()
+            .receive(on: DispatchQueue.main)
             .assign(to: &$appLanguage)
         
         $appLanguage.eraseToAnyPublisher()

--- a/godtools/App/Features/ToolsFilter/Presentation/ToolFilterCategorySelectionView/ToolFilterCategorySelectionViewModel.swift
+++ b/godtools/App/Features/ToolsFilter/Presentation/ToolFilterCategorySelectionView/ToolFilterCategorySelectionViewModel.swift
@@ -112,6 +112,7 @@ extension ToolFilterCategorySelectionViewModel {
         selectedCategory = category
         
         storeUserToolFiltersUseCase.storeCategoryFilterPublisher(with: category.id)
+            .receive(on: DispatchQueue.main)
             .sink { _ in
                 
             }

--- a/godtools/App/Features/ToolsFilter/Presentation/ToolFilterLanguageSelectionView/ToolFilterLanguageSelectionViewModel.swift
+++ b/godtools/App/Features/ToolsFilter/Presentation/ToolFilterLanguageSelectionView/ToolFilterLanguageSelectionViewModel.swift
@@ -112,6 +112,7 @@ extension ToolFilterLanguageSelectionViewModel {
         selectedLanguage = language
         
         storeUserToolFilterUseCase.storeLanguageFilterPublisher(with: language.id)
+            .receive(on: DispatchQueue.main)
             .sink { _ in
                 
             }

--- a/godtools/App/Features/ToolsFilter/Presentation/ToolFilterLanguageSelectionView/ToolFilterLanguageSelectionViewModel.swift
+++ b/godtools/App/Features/ToolsFilter/Presentation/ToolFilterLanguageSelectionView/ToolFilterLanguageSelectionViewModel.swift
@@ -44,6 +44,7 @@ class ToolFilterLanguageSelectionViewModel: ObservableObject {
         
         getCurrentAppLanguageUseCase
             .getLanguagePublisher()
+            .receive(on: DispatchQueue.main)
             .assign(to: &$appLanguage)
         
         $appLanguage.eraseToAnyPublisher()

--- a/godtools/App/Features/ToolsFilter/Presentation/ToolFilterLanguageSelectionView/ToolFilterLanguageSelectionViewModel.swift
+++ b/godtools/App/Features/ToolsFilter/Presentation/ToolFilterLanguageSelectionView/ToolFilterLanguageSelectionViewModel.swift
@@ -47,12 +47,14 @@ class ToolFilterLanguageSelectionViewModel: ObservableObject {
             .receive(on: DispatchQueue.main)
             .assign(to: &$appLanguage)
         
-        $appLanguage.eraseToAnyPublisher()
-            .flatMap { appLanguage in
+        $appLanguage
+            .dropFirst()
+            .map { appLanguage in
                 
-                return getUserToolFiltersUseCase.getUserToolFiltersPublisher(translatedInAppLanguage: appLanguage)
-                    .eraseToAnyPublisher()
+                getUserToolFiltersUseCase
+                    .getUserToolFiltersPublisher(translatedInAppLanguage: appLanguage)
             }
+            .switchToLatest()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] userFilters in
             
@@ -62,13 +64,15 @@ class ToolFilterLanguageSelectionViewModel: ObservableObject {
             .store(in: &cancellables)
         
         Publishers.CombineLatest(
-            $appLanguage.eraseToAnyPublisher(),
-            $selectedCategory.eraseToAnyPublisher()
+            $appLanguage.dropFirst(),
+            $selectedCategory
         )
-        .flatMap { appLanguage, selectedCategory in
+        .map { appLanguage, selectedCategory in
             
-            return viewToolFilterLanguagesUseCase.viewPublisher(filteredByCategoryId: selectedCategory.id, translatedInAppLanguage: appLanguage)
+            viewToolFilterLanguagesUseCase
+                .viewPublisher(filteredByCategoryId: selectedCategory.id, translatedInAppLanguage: appLanguage)
         }
+        .switchToLatest()
         .receive(on: DispatchQueue.main)
         .sink { [weak self] viewLanguageFiltersDomainModel in
             guard let self = self else { return }
@@ -82,13 +86,15 @@ class ToolFilterLanguageSelectionViewModel: ObservableObject {
         .store(in: &cancellables)
         
         Publishers.CombineLatest(
-            $searchText.eraseToAnyPublisher(),
-            $allLanguages.eraseToAnyPublisher()
+            $searchText,
+            $allLanguages
         )
-        .flatMap { searchText, allLanguages in
+        .map { searchText, allLanguages in
             
-            return searchToolFilterLanguagesUseCase.getSearchResultsPublisher(for: searchText, in: allLanguages)
+            searchToolFilterLanguagesUseCase
+                .getSearchResultsPublisher(for: searchText, in: allLanguages)
         }
+        .switchToLatest()
         .receive(on: DispatchQueue.main)
         .assign(to: &$languageSearchResults)
     }
@@ -111,7 +117,8 @@ extension ToolFilterLanguageSelectionViewModel {
         
         selectedLanguage = language
         
-        storeUserToolFilterUseCase.storeLanguageFilterPublisher(with: language.id)
+        storeUserToolFilterUseCase
+            .storeLanguageFilterPublisher(with: language.id)
             .receive(on: DispatchQueue.main)
             .sink { _ in
                 

--- a/godtools/App/Features/Tutorial/Presentation/Tutorial/TutorialViewModel.swift
+++ b/godtools/App/Features/Tutorial/Presentation/Tutorial/TutorialViewModel.swift
@@ -44,13 +44,14 @@ class TutorialViewModel: ObservableObject {
             .receive(on: DispatchQueue.main)
             .assign(to: &$appLanguage)
         
-        $appLanguage.eraseToAnyPublisher()
-            .flatMap({ (appLanguage: AppLanguageDomainModel) -> AnyPublisher<TutorialDomainModel, Never> in
+        $appLanguage
+            .dropFirst()
+            .map { (appLanguage: AppLanguageDomainModel) in
                 
-                return getTutorialUseCase
+                getTutorialUseCase
                     .getTutorialPublisher(appLanguage: appLanguage)
-                    .eraseToAnyPublisher()
-            })
+            }
+            .switchToLatest()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] (tutorial: TutorialDomainModel) in
                 
@@ -60,8 +61,8 @@ class TutorialViewModel: ObservableObject {
             .store(in: &cancellables)
         
         Publishers.CombineLatest(
-            $currentPage.eraseToAnyPublisher(),
-            $interfaceStrings.eraseToAnyPublisher()
+            $currentPage,
+            $interfaceStrings
         )
         .receive(on: DispatchQueue.main)
         .sink { [weak self] (currentPage: Int, interfaceStrings: TutorialInterfaceStringsDomainModel?) in
@@ -72,7 +73,6 @@ class TutorialViewModel: ObservableObject {
         .store(in: &cancellables)
         
         $currentPage
-            .eraseToAnyPublisher()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] (page: Int) in
                 self?.pageDidChange(page: page)

--- a/godtools/App/Features/Tutorial/Presentation/Tutorial/TutorialViewModel.swift
+++ b/godtools/App/Features/Tutorial/Presentation/Tutorial/TutorialViewModel.swift
@@ -41,6 +41,7 @@ class TutorialViewModel: ObservableObject {
                 
         getCurrentAppLanguageUseCase
             .getLanguagePublisher()
+            .receive(on: DispatchQueue.main)
             .assign(to: &$appLanguage)
         
         $appLanguage.eraseToAnyPublisher()

--- a/godtools/App/Flows/App/AppFlow.swift
+++ b/godtools/App/Flows/App/AppFlow.swift
@@ -474,13 +474,13 @@ extension AppFlow {
         
         let translatedLanguageNameRepositorySync: TranslatedLanguageNameRepositorySync = appDiContainer.dataLayer.getTranslatedLanguageNameRepositorySync()
         
-        $appLanguage.eraseToAnyPublisher()
-            .flatMap({ (appLanguage: AppLanguageDomainModel) -> AnyPublisher<Void, Never> in
+        $appLanguage
+            .dropFirst()
+            .map { (appLanguage: AppLanguageDomainModel) in
                 
-                return translatedLanguageNameRepositorySync
+                translatedLanguageNameRepositorySync
                     .syncTranslatedLanguageNamesPublisher(translateInLanguage: appLanguage)
-                    .eraseToAnyPublisher()
-            })
+            }
             .receive(on: DispatchQueue.main)
             .sink { _ in
                 

--- a/godtools/App/Flows/App/AppFlow.swift
+++ b/godtools/App/Flows/App/AppFlow.swift
@@ -451,6 +451,7 @@ extension AppFlow {
                     .syncDownloadedLanguagesPublisher()
                     .eraseToAnyPublisher()
             })
+            .receive(on: DispatchQueue.main)
             .sink { _ in
                 
             }
@@ -463,6 +464,7 @@ extension AppFlow {
         let authenticateUser: AuthenticateUserInterface = appDiContainer.feature.accountCreation.dataLayer.getAuthenticateUserInterface()
         
         authenticateUser.renewAuthenticationPublisher()
+            .receive(on: DispatchQueue.main)
             .sink { finished in
 
             } receiveValue: { authUser in
@@ -479,6 +481,7 @@ extension AppFlow {
                     .syncTranslatedLanguageNamesPublisher(translateInLanguage: appLanguage)
                     .eraseToAnyPublisher()
             })
+            .receive(on: DispatchQueue.main)
             .sink { _ in
                 
             }
@@ -490,6 +493,7 @@ extension AppFlow {
         let incrementUserCounterUseCase = appDiContainer.domainLayer.getIncrementUserCounterUseCase()
         
         incrementUserCounterUseCase.incrementUserCounter(for: .sessionLaunch)
+            .receive(on: DispatchQueue.main)
             .sink { _ in
                 
             } receiveValue: { _ in

--- a/godtools/App/Flows/App/AppFlow.swift
+++ b/godtools/App/Flows/App/AppFlow.swift
@@ -85,6 +85,7 @@ class AppFlow: NSObject, ToolNavigationFlow, Flow {
         appDiContainer.feature.appLanguage.domainLayer
             .getCurrentAppLanguageUseCase()
             .getLanguagePublisher()
+            .receive(on: DispatchQueue.main)
             .assign(to: &$appLanguage)
     }
     

--- a/godtools/App/Flows/ChooseAppLanguage/ChooseAppLanguageFlow.swift
+++ b/godtools/App/Flows/ChooseAppLanguage/ChooseAppLanguageFlow.swift
@@ -49,6 +49,7 @@ class ChooseAppLanguageFlow: Flow {
             let setAppLanguageUseCase: SetAppLanguageUseCase = appDiContainer.feature.appLanguage.domainLayer.getSetAppLanguageUseCase()
             
             ChooseAppLanguageFlow.setAppLanguageInBackgroundCancellable = setAppLanguageUseCase.setLanguagePublisher(language: appLanguage.language)
+                .receive(on: DispatchQueue.main)
                 .sink(receiveValue: { _ in
 
                 })

--- a/godtools/App/Flows/ChooseYourOwnAdventure/ChooseYourOwnAdventureFlow.swift
+++ b/godtools/App/Flows/ChooseYourOwnAdventure/ChooseYourOwnAdventureFlow.swift
@@ -126,7 +126,7 @@ extension ChooseYourOwnAdventureFlow {
         
         chooseYourOwnAdventureView = view
         
-        viewModel.$languageNames.eraseToAnyPublisher()
+        viewModel.$languageNames
             .receive(on: DispatchQueue.main)
             .sink { [weak self] (languageNames: [String]) in
                                 
@@ -141,7 +141,7 @@ extension ChooseYourOwnAdventureFlow {
             }
             .store(in: &cancellables)
         
-        viewModel.$selectedLanguageIndex.eraseToAnyPublisher()
+        viewModel.$selectedLanguageIndex
             .receive(on: DispatchQueue.main)
             .sink { (index: Int) in
                 

--- a/godtools/App/Flows/Menu/MenuFlow.swift
+++ b/godtools/App/Flows/Menu/MenuFlow.swift
@@ -48,6 +48,7 @@ class MenuFlow: Flow {
         appDiContainer.feature.appLanguage.domainLayer
             .getCurrentAppLanguageUseCase()
             .getLanguagePublisher()
+            .receive(on: DispatchQueue.main)
             .assign(to: &$appLanguage)
         
         $appLanguage.eraseToAnyPublisher()

--- a/godtools/App/Flows/Menu/MenuFlow.swift
+++ b/godtools/App/Flows/Menu/MenuFlow.swift
@@ -58,6 +58,7 @@ class MenuFlow: Flow {
                     .viewPublisher(appLanguage: appLanguage)
                     .eraseToAnyPublisher()
             })
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] (domainModel: ViewShareGodToolsDomainModel) in
                 self?.viewShareGodToolsDomainModel = domainModel
             }

--- a/godtools/App/Flows/Menu/MenuFlow.swift
+++ b/godtools/App/Flows/Menu/MenuFlow.swift
@@ -51,13 +51,15 @@ class MenuFlow: Flow {
             .receive(on: DispatchQueue.main)
             .assign(to: &$appLanguage)
         
-        $appLanguage.eraseToAnyPublisher()
-            .flatMap({ (appLanguage: AppLanguageDomainModel) -> AnyPublisher<ViewShareGodToolsDomainModel, Never> in
-                return appDiContainer.feature.shareGodTools.domainLayer
+        $appLanguage
+            .dropFirst()
+            .map { (appLanguage: AppLanguageDomainModel) in
+                
+                appDiContainer.feature.shareGodTools.domainLayer
                     .getViewShareGodToolsUseCase()
                     .viewPublisher(appLanguage: appLanguage)
-                    .eraseToAnyPublisher()
-            })
+            }
+            .switchToLatest()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] (domainModel: ViewShareGodToolsDomainModel) in
                 self?.viewShareGodToolsDomainModel = domainModel

--- a/godtools/App/Flows/ToolScreenShare/ToolScreenShareFlow.swift
+++ b/godtools/App/Flows/ToolScreenShare/ToolScreenShareFlow.swift
@@ -48,6 +48,7 @@ class ToolScreenShareFlow: Flow {
         appDiContainer.feature.appLanguage.domainLayer
             .getCurrentAppLanguageUseCase()
             .getLanguagePublisher()
+            .receive(on: DispatchQueue.main)
             .assign(to: &$appLanguage)
         
         let viewCreatingToolScreenShareSessionTimedOutUseCase: ViewCreatingToolScreenShareSessionTimedOutUseCase = appDiContainer.feature.toolScreenShare.domainLayer

--- a/godtools/App/Flows/ToolScreenShare/ToolScreenShareFlow.swift
+++ b/godtools/App/Flows/ToolScreenShare/ToolScreenShareFlow.swift
@@ -61,6 +61,7 @@ class ToolScreenShareFlow: Flow {
                     .viewPublisher(appLanguage: appLanguage)
                     .eraseToAnyPublisher()
             })
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] (domainModel: CreatingToolScreenShareSessionTimedOutDomainModel) in
                 self?.creatingToolScreenShareSessionTimedOutDomainModel = domainModel
             }
@@ -76,6 +77,7 @@ class ToolScreenShareFlow: Flow {
                     .viewPublisher(appLanguage: appLanguage)
                     .eraseToAnyPublisher()
             })
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] (domainModel: ShareToolScreenShareSessionDomainModel) in
                 self?.shareToolScreenShareSessionDomainModel = domainModel
             }

--- a/godtools/App/Flows/ToolScreenShare/ToolScreenShareFlow.swift
+++ b/godtools/App/Flows/ToolScreenShare/ToolScreenShareFlow.swift
@@ -54,13 +54,14 @@ class ToolScreenShareFlow: Flow {
         let viewCreatingToolScreenShareSessionTimedOutUseCase: ViewCreatingToolScreenShareSessionTimedOutUseCase = appDiContainer.feature.toolScreenShare.domainLayer
             .getViewCreatingToolScreenShareSessionTimedOutUseCase()
         
-        $appLanguage.eraseToAnyPublisher()
-            .flatMap({ (appLanguage: AppLanguageDomainModel) -> AnyPublisher<CreatingToolScreenShareSessionTimedOutDomainModel, Never> in
+        $appLanguage
+            .dropFirst()
+            .map { (appLanguage: AppLanguageDomainModel) in
                 
-                return viewCreatingToolScreenShareSessionTimedOutUseCase
+                viewCreatingToolScreenShareSessionTimedOutUseCase
                     .viewPublisher(appLanguage: appLanguage)
-                    .eraseToAnyPublisher()
-            })
+            }
+            .switchToLatest()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] (domainModel: CreatingToolScreenShareSessionTimedOutDomainModel) in
                 self?.creatingToolScreenShareSessionTimedOutDomainModel = domainModel
@@ -70,13 +71,14 @@ class ToolScreenShareFlow: Flow {
         let viewShareToolScreenShareSessionUseCase: ViewShareToolScreenShareSessionUseCase = appDiContainer.feature.toolScreenShare.domainLayer
             .getViewShareToolScreenShareSessionUseCase()
         
-        $appLanguage.eraseToAnyPublisher()
-            .flatMap({ (appLanguage: AppLanguageDomainModel) -> AnyPublisher<ShareToolScreenShareSessionDomainModel, Never> in
+        $appLanguage
+            .dropFirst()
+            .map { (appLanguage: AppLanguageDomainModel) in
                 
-                return viewShareToolScreenShareSessionUseCase
+                viewShareToolScreenShareSessionUseCase
                     .viewPublisher(appLanguage: appLanguage)
-                    .eraseToAnyPublisher()
-            })
+            }
+            .switchToLatest()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] (domainModel: ShareToolScreenShareSessionDomainModel) in
                 self?.shareToolScreenShareSessionDomainModel = domainModel

--- a/godtools/App/Flows/ToolSettings/ToolSettingsFlow.swift
+++ b/godtools/App/Flows/ToolSettings/ToolSettingsFlow.swift
@@ -44,10 +44,11 @@ class ToolSettingsFlow: Flow {
             .receive(on: DispatchQueue.main)
             .assign(to: &$appLanguage)
 
-        $appLanguage.eraseToAnyPublisher()
-            .flatMap({ (appLanguage: AppLanguageDomainModel) -> AnyPublisher<ViewShareToolDomainModel, Never> in
+        $appLanguage
+            .dropFirst()
+            .map { (appLanguage: AppLanguageDomainModel) in
                
-                return appDiContainer.feature.toolSettings.domainLayer
+                appDiContainer.feature.toolSettings.domainLayer
                     .getViewShareToolUseCase()
                     .viewPublisher(
                         toolId: toolSettingsObserver.toolId,
@@ -55,8 +56,8 @@ class ToolSettingsFlow: Flow {
                         pageNumber: toolSettingsObserver.pageNumber,
                         appLanguage: appLanguage
                     )
-                    .eraseToAnyPublisher()
-            })
+            }
+            .switchToLatest()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] (domainModel: ViewShareToolDomainModel) in
                 self?.viewShareToolDomainModel = domainModel

--- a/godtools/App/Flows/ToolSettings/ToolSettingsFlow.swift
+++ b/godtools/App/Flows/ToolSettings/ToolSettingsFlow.swift
@@ -57,6 +57,7 @@ class ToolSettingsFlow: Flow {
                     )
                     .eraseToAnyPublisher()
             })
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] (domainModel: ViewShareToolDomainModel) in
                 self?.viewShareToolDomainModel = domainModel
             }

--- a/godtools/App/Flows/ToolSettings/ToolSettingsFlow.swift
+++ b/godtools/App/Flows/ToolSettings/ToolSettingsFlow.swift
@@ -41,6 +41,7 @@ class ToolSettingsFlow: Flow {
         appDiContainer.feature.appLanguage.domainLayer
             .getCurrentAppLanguageUseCase()
             .getLanguagePublisher()
+            .receive(on: DispatchQueue.main)
             .assign(to: &$appLanguage)
 
         $appLanguage.eraseToAnyPublisher()
@@ -63,6 +64,7 @@ class ToolSettingsFlow: Flow {
         
         getToolScreenShareTutorialHasBeenViewedUseCase
             .getViewedPublisher(toolId: toolSettingsObserver.toolId)
+            .receive(on: DispatchQueue.main)
             .assign(to: &$toolScreenShareTutorialHasBeenViewedDomainModel)
     }
     

--- a/godtools/App/Flows/Tract/TractFlow.swift
+++ b/godtools/App/Flows/Tract/TractFlow.swift
@@ -239,7 +239,7 @@ extension TractFlow {
         
         toolView = view
         
-        viewModel.$languageNames.eraseToAnyPublisher()
+        viewModel.$languageNames
             .receive(on: DispatchQueue.main)
             .sink { [weak self] (languageNames: [String]) in
                 
@@ -258,7 +258,7 @@ extension TractFlow {
             }
             .store(in: &cancellables)
         
-        viewModel.$selectedLanguageIndex.eraseToAnyPublisher()
+        viewModel.$selectedLanguageIndex
             .receive(on: DispatchQueue.main)
             .sink { (index: Int) in
                 

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/Pages/MobileContentPagesViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/Pages/MobileContentPagesViewModel.swift
@@ -67,8 +67,8 @@ class MobileContentPagesViewModel: NSObject, ObservableObject {
             .assign(to: &$appLanguage)
         
         Publishers.CombineLatest(
-            $languages.eraseToAnyPublisher(),
-            $appLanguage.eraseToAnyPublisher()
+            $languages,
+            $appLanguage.dropFirst()
         )
         .receive(on: DispatchQueue.main)
         .sink { [weak self] (languages: [LanguageDomainModel], appLanguage: AppLanguageDomainModel) in

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/Pages/MobileContentPagesViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/Pages/MobileContentPagesViewModel.swift
@@ -748,11 +748,12 @@ extension MobileContentPagesViewModel {
         let locale = Locale(identifier: localeId)
         
         incrementUserCounterUseCase.incrementUserCounter(for: .languageUsed(locale: locale))
-            .sink { completion in
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] completion in
                 
                 switch completion {
                 case .finished:
-                    self.trackLanguageUsageCountedThisSession(localeId: localeId)
+                    self?.trackLanguageUsageCountedThisSession(localeId: localeId)
                     
                 case .failure:
                     break

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/Pages/MobileContentPagesViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/Pages/MobileContentPagesViewModel.swift
@@ -63,6 +63,7 @@ class MobileContentPagesViewModel: NSObject, ObservableObject {
         
         getCurrentAppLanguageUseCase
             .getLanguagePublisher()
+            .receive(on: DispatchQueue.main)
             .assign(to: &$appLanguage)
         
         Publishers.CombineLatest(

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/Pages/MobileContentPagesViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/Pages/MobileContentPagesViewModel.swift
@@ -788,6 +788,7 @@ extension MobileContentPagesViewModel {
         }
         
         incrementUserCounterUseCase.incrementUserCounter(for: toolOpenInteraction)
+            .receive(on: DispatchQueue.main)
             .sink { _ in
                 
             } receiveValue: { _ in

--- a/godtools/App/Share/Application/ApplicationLayout/ApplicationLayout.swift
+++ b/godtools/App/Share/Application/ApplicationLayout/ApplicationLayout.swift
@@ -52,11 +52,16 @@ class ApplicationLayout: ObservableObject {
             .receive(on: DispatchQueue.main)
             .assign(to: &$appLanguage)
         
-        
         let getInterfaceLayoutDirectionUseCase = appLanguageFeatureDiContainer.domainLayer.getInterfaceLayoutDirectionUseCase()
 
-        getInterfaceLayoutDirectionUseCase
-            .getLayoutDirectionPublisher(appLanguagePublisher: $appLanguage.eraseToAnyPublisher())
+        $appLanguage
+            .dropFirst()
+            .map { (appLanguage: AppLanguageDomainModel) in
+                
+                getInterfaceLayoutDirectionUseCase
+                    .getLayoutDirectionPublisher(appLanguage: appLanguage)
+            }
+            .switchToLatest()
             .receive(on: DispatchQueue.main)
             .sink { (interfaceLayoutDirection: AppInterfaceLayoutDirectionDomainModel) in
                 

--- a/godtools/App/Share/Application/ApplicationLayout/ApplicationLayout.swift
+++ b/godtools/App/Share/Application/ApplicationLayout/ApplicationLayout.swift
@@ -49,6 +49,7 @@ class ApplicationLayout: ObservableObject {
         
         getCurrentAppLanguageUseCase
             .getLanguagePublisher()
+            .receive(on: DispatchQueue.main)
             .assign(to: &$appLanguage)
         
         

--- a/godtools/App/Share/SwiftUI Views/SearchBar/SearchBarViewModel.swift
+++ b/godtools/App/Share/SwiftUI Views/SearchBar/SearchBarViewModel.swift
@@ -25,7 +25,8 @@ class SearchBarViewModel: ObservableObject {
         self.getCurrentAppLanguageUseCase = getCurrentAppLanguageUseCase
         self.viewSearchBarUseCase = viewSearchBarUseCase
         
-        getCurrentAppLanguageUseCase.getLanguagePublisher()
+        getCurrentAppLanguageUseCase
+            .getLanguagePublisher()
             .receive(on: DispatchQueue.main)
             .assign(to: &$appLanguage)
         

--- a/godtools/App/Share/SwiftUI Views/SearchBar/SearchBarViewModel.swift
+++ b/godtools/App/Share/SwiftUI Views/SearchBar/SearchBarViewModel.swift
@@ -29,12 +29,14 @@ class SearchBarViewModel: ObservableObject {
             .receive(on: DispatchQueue.main)
             .assign(to: &$appLanguage)
         
-        $appLanguage.eraseToAnyPublisher()
-            .flatMap { appLanguage in
+        $appLanguage
+            .dropFirst()
+            .map { appLanguage in
                 
-                return viewSearchBarUseCase.viewPublisher(appLanguage: appLanguage)
-                    .eraseToAnyPublisher()
+                viewSearchBarUseCase
+                    .viewPublisher(appLanguage: appLanguage)
             }
+            .switchToLatest()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] domainModel in
                 

--- a/godtools/App/Share/SwiftUI Views/SearchBar/SearchBarViewModel.swift
+++ b/godtools/App/Share/SwiftUI Views/SearchBar/SearchBarViewModel.swift
@@ -32,7 +32,7 @@ class SearchBarViewModel: ObservableObject {
         $appLanguage.eraseToAnyPublisher()
             .flatMap { appLanguage in
                 
-                return self.viewSearchBarUseCase.viewPublisher(appLanguage: appLanguage)
+                return viewSearchBarUseCase.viewPublisher(appLanguage: appLanguage)
                     .eraseToAnyPublisher()
             }
             .receive(on: DispatchQueue.main)

--- a/godtools/App/Share/Views/Navigation/NavigationBar/NavBarItems/NavBarItemController/AppInterfaceStringNavBarItemController.swift
+++ b/godtools/App/Share/Views/Navigation/NavigationBar/NavBarItems/NavBarItemController/AppInterfaceStringNavBarItemController.swift
@@ -29,7 +29,8 @@ class AppInterfaceStringNavBarItemController: NavBarItemController {
             itemIndex: itemIndex
         )
         
-        getInterfaceStringInAppLanguageUseCase.getStringPublisher(id: interfaceStringBarItem.localizedStringKey)
+        getInterfaceStringInAppLanguageUseCase
+            .getStringPublisher(id: interfaceStringBarItem.localizedStringKey)
         .receive(on: DispatchQueue.main)
         .sink{ [weak self] (interfaceString: String) in
             


### PR DESCRIPTION
In this PR I will be running through all of our Combine ```.sink``` and making updates to the following:
- In ViewModels and Flows ensure we're dispatching to the main thread.
- Where assign is used in ViewModels and Flows ensure we're receiving those on the main thread.
- Check for any strong reference cycles in the ViewModel that can lead to a reference cycle.
- See where sink is used in our Flows and ViewModels and see if we should use switchToLatest() and also dropFirst() if we don't care to display the initial value on a Published property.
- Ensure we aren't accessing the value of an observed Published property in the sink closure as it wouldn't be set to the new value at this point.
- Look into any subscriptions that might have Data types or Image types which could lead to excess memory being used.