### PR TITLE
GT-2354 Sort spotlight tools by tool order

### DIFF
--- a/godtools/App/Features/SpotlightTools/Data-DomainInterface/GetSpotlightToolsRepository.swift
+++ b/godtools/App/Features/SpotlightTools/Data-DomainInterface/GetSpotlightToolsRepository.swift
@@ -46,7 +46,7 @@ class GetSpotlightToolsRepository: GetSpotlightToolsRepositoryInterface {
         )
         .flatMap({ (resourcesChanged: Void, interfaceStrings: ToolListItemInterfaceStringsDomainModel) -> AnyPublisher<[SpotlightToolListItemDomainModel], Never> in
         
-            let spotlightToolResources: [ResourceModel] = self.resourcesRepository.getSpotlightTools()
+            let spotlightToolResources: [ResourceModel] = self.resourcesRepository.getSpotlightTools(sortByDefaultOrder: true)
 
             let spotlightTools: [SpotlightToolListItemDomainModel] = spotlightToolResources
                 .map({

--- a/godtools/App/Share/Data/ResourcesRepository/Cache/RealmResourcesCache.swift
+++ b/godtools/App/Share/Data/ResourcesRepository/Cache/RealmResourcesCache.swift
@@ -157,7 +157,7 @@ extension RealmResourcesCache {
 
 extension RealmResourcesCache {
     
-    func getSpotlightTools() -> [ResourceModel] {
+    func getSpotlightTools(sortByDefaultOrder: Bool) -> [ResourceModel] {
         
         let realm: Realm = realmDatabase.openRealm()
         
@@ -171,9 +171,20 @@ extension RealmResourcesCache {
         
         let filterPredicate = NSCompoundPredicate(andPredicateWithSubpredicates: filterByAttributes)
                 
-        let filteredResources = realm.objects(RealmResource.self).filter(filterPredicate)
+        let filteredResources: Results<RealmResource> = realm.objects(RealmResource.self).filter(filterPredicate)
+                
+        let spotlightToolsResults: Results<RealmResource>
         
-        return filteredResources
+        if sortByDefaultOrder {
+            
+            spotlightToolsResults = filteredResources.sorted(byKeyPath: #keyPath(RealmResource.attrDefaultOrder), ascending: true)
+        }
+        else {
+            
+            spotlightToolsResults = filteredResources
+        }
+        
+        return spotlightToolsResults
             .map {
                 ResourceModel(model: $0)
             }

--- a/godtools/App/Share/Data/ResourcesRepository/ResourcesRepository.swift
+++ b/godtools/App/Share/Data/ResourcesRepository/ResourcesRepository.swift
@@ -157,8 +157,8 @@ class ResourcesRepository {
 
 extension ResourcesRepository {
     
-    func getSpotlightTools() -> [ResourceModel] {
-        return cache.getSpotlightTools()
+    func getSpotlightTools(sortByDefaultOrder: Bool = false) -> [ResourceModel] {
+        return cache.getSpotlightTools(sortByDefaultOrder: sortByDefaultOrder)
     }
 }
 


### PR DESCRIPTION
- Adds flag to ResourcesRepository to fetch spotlight tools by default order.
- Updates business logic in GetSpotlightToolsRepository to sort spotlight tools by default order when fetching.