### PR TITLE
GT-2323 Add interfaces for GetTranslatedLanguageName in order to mock tests

### DIFF
--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -184,6 +184,11 @@
 		452504462C32DC4500FF2B36 /* LocaleLanguageNameInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 452504452C32DC4500FF2B36 /* LocaleLanguageNameInterface.swift */; };
 		452504482C32DC4E00FF2B36 /* LocaleLanguageRegionNameInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 452504472C32DC4E00FF2B36 /* LocaleLanguageRegionNameInterface.swift */; };
 		4525044A2C32DC5700FF2B36 /* LocaleLanguageScriptNameInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 452504492C32DC5700FF2B36 /* LocaleLanguageScriptNameInterface.swift */; };
+		4525044F2C32DD4800FF2B36 /* GetTranslatedLanguageNameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4525044E2C32DD4800FF2B36 /* GetTranslatedLanguageNameTests.swift */; };
+		452504562C32E05600FF2B36 /* MockLocaleLanguageScriptName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 452504502C32E05600FF2B36 /* MockLocaleLanguageScriptName.swift */; };
+		452504572C32E05600FF2B36 /* MockLocaleLanguageRegionName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 452504522C32E05600FF2B36 /* MockLocaleLanguageRegionName.swift */; };
+		452504582C32E05600FF2B36 /* MockLocaleLanguageName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 452504542C32E05600FF2B36 /* MockLocaleLanguageName.swift */; };
+		4525045A2C32E96500FF2B36 /* MockTranslatableLanguage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 452504592C32E96500FF2B36 /* MockTranslatableLanguage.swift */; };
 		4526EDD42AEB274800D1A3D4 /* EvaluationOptionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4526EDD32AEB274800D1A3D4 /* EvaluationOptionButton.swift */; };
 		4526EDD62AEB330100D1A3D4 /* OverlayNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4526EDD52AEB330100D1A3D4 /* OverlayNavigationController.swift */; };
 		4529B96628933A610011F16B /* ParseTranslationManifestForRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4529B96528933A610011F16B /* ParseTranslationManifestForRenderer.swift */; };
@@ -1795,6 +1800,11 @@
 		452504452C32DC4500FF2B36 /* LocaleLanguageNameInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocaleLanguageNameInterface.swift; sourceTree = "<group>"; };
 		452504472C32DC4E00FF2B36 /* LocaleLanguageRegionNameInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocaleLanguageRegionNameInterface.swift; sourceTree = "<group>"; };
 		452504492C32DC5700FF2B36 /* LocaleLanguageScriptNameInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocaleLanguageScriptNameInterface.swift; sourceTree = "<group>"; };
+		4525044E2C32DD4800FF2B36 /* GetTranslatedLanguageNameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetTranslatedLanguageNameTests.swift; sourceTree = "<group>"; };
+		452504502C32E05600FF2B36 /* MockLocaleLanguageScriptName.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockLocaleLanguageScriptName.swift; sourceTree = "<group>"; };
+		452504522C32E05600FF2B36 /* MockLocaleLanguageRegionName.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockLocaleLanguageRegionName.swift; sourceTree = "<group>"; };
+		452504542C32E05600FF2B36 /* MockLocaleLanguageName.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockLocaleLanguageName.swift; sourceTree = "<group>"; };
+		452504592C32E96500FF2B36 /* MockTranslatableLanguage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTranslatableLanguage.swift; sourceTree = "<group>"; };
 		4526EDD32AEB274800D1A3D4 /* EvaluationOptionButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvaluationOptionButton.swift; sourceTree = "<group>"; };
 		4526EDD52AEB330100D1A3D4 /* OverlayNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverlayNavigationController.swift; sourceTree = "<group>"; };
 		4529B96528933A610011F16B /* ParseTranslationManifestForRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseTranslationManifestForRenderer.swift; sourceTree = "<group>"; };
@@ -4360,6 +4370,55 @@
 			path = Cache;
 			sourceTree = "<group>";
 		};
+		4525044B2C32DD3400FF2B36 /* GetTranslatedLanguageName */ = {
+			isa = PBXGroup;
+			children = (
+				4525044E2C32DD4800FF2B36 /* GetTranslatedLanguageNameTests.swift */,
+				452504592C32E96500FF2B36 /* MockTranslatableLanguage.swift */,
+			);
+			path = GetTranslatedLanguageName;
+			sourceTree = "<group>";
+		};
+		4525044C2C32DD3400FF2B36 /* Supporting */ = {
+			isa = PBXGroup;
+			children = (
+				4525044B2C32DD3400FF2B36 /* GetTranslatedLanguageName */,
+			);
+			path = Supporting;
+			sourceTree = "<group>";
+		};
+		4525044D2C32DD3400FF2B36 /* Data-DomainInterface */ = {
+			isa = PBXGroup;
+			children = (
+				4525044C2C32DD3400FF2B36 /* Supporting */,
+			);
+			path = "Data-DomainInterface";
+			sourceTree = "<group>";
+		};
+		452504512C32E05600FF2B36 /* LocaleLanguageScriptName */ = {
+			isa = PBXGroup;
+			children = (
+				452504502C32E05600FF2B36 /* MockLocaleLanguageScriptName.swift */,
+			);
+			path = LocaleLanguageScriptName;
+			sourceTree = "<group>";
+		};
+		452504532C32E05600FF2B36 /* LocaleLanguageRegionName */ = {
+			isa = PBXGroup;
+			children = (
+				452504522C32E05600FF2B36 /* MockLocaleLanguageRegionName.swift */,
+			);
+			path = LocaleLanguageRegionName;
+			sourceTree = "<group>";
+		};
+		452504552C32E05600FF2B36 /* LocaleLanguageName */ = {
+			isa = PBXGroup;
+			children = (
+				452504542C32E05600FF2B36 /* MockLocaleLanguageName.swift */,
+			);
+			path = LocaleLanguageName;
+			sourceTree = "<group>";
+		};
 		4526EDD22AEB273C00D1A3D4 /* EvaluationOptionButton */ = {
 			isa = PBXGroup;
 			children = (
@@ -4635,6 +4694,7 @@
 				457719AC2BE00F9900E7E4D8 /* Application */,
 				453689FE2ABB2D840028A570 /* Common */,
 				45368A052ABB2D840028A570 /* Data */,
+				4525044D2C32DD3400FF2B36 /* Data-DomainInterface */,
 				45368A102ABB2D840028A570 /* Services */,
 			);
 			path = Share;
@@ -4643,6 +4703,9 @@
 		453689FE2ABB2D840028A570 /* Common */ = {
 			isa = PBXGroup;
 			children = (
+				452504552C32E05600FF2B36 /* LocaleLanguageName */,
+				452504532C32E05600FF2B36 /* LocaleLanguageRegionName */,
+				452504512C32E05600FF2B36 /* LocaleLanguageScriptName */,
 				453689FF2ABB2D840028A570 /* SharedAppleExtensions */,
 			);
 			path = Common;
@@ -13350,7 +13413,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				452504572C32E05600FF2B36 /* MockLocaleLanguageRegionName.swift in Sources */,
 				459ABF612B0BB29D0034499D /* RealmResourcesCacheTests.swift in Sources */,
+				4525044F2C32DD4800FF2B36 /* GetTranslatedLanguageNameTests.swift in Sources */,
 				45D7783029A572CC00F23D99 /* PassthroughValue.swift in Sources */,
 				45E198692BA4822A00BF14F3 /* TestsDiContainer.swift in Sources */,
 				450FB88A2BFBA0F80015D945 /* StoreInitialAppLanguageTests.swift in Sources */,
@@ -13368,6 +13433,7 @@
 				450FB8922BFBA1060015D945 /* RealmDatabaseWriteTests.swift in Sources */,
 				45368A1B2ABB2D850028A570 /* LocalizableStringsRepositoryTests.swift in Sources */,
 				45CBDA092BA3930B0007DEC8 /* MockLaunchCountRepository.swift in Sources */,
+				4525045A2C32E96500FF2B36 /* MockTranslatableLanguage.swift in Sources */,
 				45368A182ABB2D850028A570 /* TestRealmObject.swift in Sources */,
 				453E2A122BC8C8810047D4C6 /* GetToolsRepositoryTests.swift in Sources */,
 				45368A192ABB2D850028A570 /* DeepLinkingServiceTests.swift in Sources */,
@@ -13377,11 +13443,13 @@
 				45368A1C2ABB2D850028A570 /* LocalizationServicesTests.swift in Sources */,
 				457719AF2BE00FA600E7E4D8 /* MockDeviceSystemLanguage.swift in Sources */,
 				45CBDA0E2BA394FD0007DEC8 /* MockOnboardingTutorialViewedRepository.swift in Sources */,
+				452504582C32E05600FF2B36 /* MockLocaleLanguageName.swift in Sources */,
 				45308EC52BDC317300A49D96 /* GetSpiritualConversationReadinessScaleTests.swift in Sources */,
 				45CBDA142BA399750007DEC8 /* MockLocalizationServices.swift in Sources */,
 				45368A162ABB2D850028A570 /* LocaleTests.swift in Sources */,
 				45E198662BA47F4400BF14F3 /* GetDownloadToolProgressInterfaceStringsRepositoryTests.swift in Sources */,
 				450FB8872BFBA0E80015D945 /* GetOnboardingTutorialInterfaceStringsRepositoryTests.swift in Sources */,
+				452504562C32E05600FF2B36 /* MockLocaleLanguageScriptName.swift in Sources */,
 				450FB88F2BFBA0FD0015D945 /* Collection+SafeLookupTests.swift in Sources */,
 				450FB8882BFBA0E80015D945 /* GetOnboardingTutorialIsAvailableTests.swift in Sources */,
 				45AA12DB2BE55D1D00C85BFF /* TestRealmObjectMapping.swift in Sources */,

--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -181,6 +181,9 @@
 		452486E02B07C9A5007AD932 /* GetUserToolFiltersRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 452486DE2B07C9A5007AD932 /* GetUserToolFiltersRepository.swift */; };
 		452486E12B07C9A5007AD932 /* StoreUserFiltersRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 452486DF2B07C9A5007AD932 /* StoreUserFiltersRepository.swift */; };
 		452486E82B07C9AA007AD932 /* UserToolFiltersRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 452486E62B07C9AA007AD932 /* UserToolFiltersRepository.swift */; };
+		452504462C32DC4500FF2B36 /* LocaleLanguageNameInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 452504452C32DC4500FF2B36 /* LocaleLanguageNameInterface.swift */; };
+		452504482C32DC4E00FF2B36 /* LocaleLanguageRegionNameInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 452504472C32DC4E00FF2B36 /* LocaleLanguageRegionNameInterface.swift */; };
+		4525044A2C32DC5700FF2B36 /* LocaleLanguageScriptNameInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 452504492C32DC5700FF2B36 /* LocaleLanguageScriptNameInterface.swift */; };
 		4526EDD42AEB274800D1A3D4 /* EvaluationOptionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4526EDD32AEB274800D1A3D4 /* EvaluationOptionButton.swift */; };
 		4526EDD62AEB330100D1A3D4 /* OverlayNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4526EDD52AEB330100D1A3D4 /* OverlayNavigationController.swift */; };
 		4529B96628933A610011F16B /* ParseTranslationManifestForRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4529B96528933A610011F16B /* ParseTranslationManifestForRenderer.swift */; };
@@ -1789,6 +1792,9 @@
 		452486DE2B07C9A5007AD932 /* GetUserToolFiltersRepository.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GetUserToolFiltersRepository.swift; sourceTree = "<group>"; };
 		452486DF2B07C9A5007AD932 /* StoreUserFiltersRepository.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreUserFiltersRepository.swift; sourceTree = "<group>"; };
 		452486E62B07C9AA007AD932 /* UserToolFiltersRepository.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserToolFiltersRepository.swift; sourceTree = "<group>"; };
+		452504452C32DC4500FF2B36 /* LocaleLanguageNameInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocaleLanguageNameInterface.swift; sourceTree = "<group>"; };
+		452504472C32DC4E00FF2B36 /* LocaleLanguageRegionNameInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocaleLanguageRegionNameInterface.swift; sourceTree = "<group>"; };
+		452504492C32DC5700FF2B36 /* LocaleLanguageScriptNameInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocaleLanguageScriptNameInterface.swift; sourceTree = "<group>"; };
 		4526EDD32AEB274800D1A3D4 /* EvaluationOptionButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvaluationOptionButton.swift; sourceTree = "<group>"; };
 		4526EDD52AEB330100D1A3D4 /* OverlayNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverlayNavigationController.swift; sourceTree = "<group>"; };
 		4529B96528933A610011F16B /* ParseTranslationManifestForRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseTranslationManifestForRenderer.swift; sourceTree = "<group>"; };
@@ -5007,6 +5013,7 @@
 			isa = PBXGroup;
 			children = (
 				453E00062B29FB7D00029402 /* LocaleLanguageRegionName.swift */,
+				452504472C32DC4E00FF2B36 /* LocaleLanguageRegionNameInterface.swift */,
 			);
 			path = LocaleLanguageRegionName;
 			sourceTree = "<group>";
@@ -8548,6 +8555,7 @@
 			isa = PBXGroup;
 			children = (
 				45AF070E2B066266000EACF2 /* LocaleLanguageName.swift */,
+				452504452C32DC4500FF2B36 /* LocaleLanguageNameInterface.swift */,
 			);
 			path = LocaleLanguageName;
 			sourceTree = "<group>";
@@ -8556,6 +8564,7 @@
 			isa = PBXGroup;
 			children = (
 				45AF07132B0663FD000EACF2 /* LocaleLanguageScriptName.swift */,
+				452504492C32DC5700FF2B36 /* LocaleLanguageScriptNameInterface.swift */,
 			);
 			path = LocaleLanguageScriptName;
 			sourceTree = "<group>";
@@ -12002,6 +12011,7 @@
 				45D63E9D288F77D4009B4610 /* RealmResourcesCache.swift in Sources */,
 				45AD1F6525938A9800A096A0 /* ToolTrainingTipsOnboardingViewsService.swift in Sources */,
 				453F84C32A029FC00005101E /* ArticleAemCache.swift in Sources */,
+				4525044A2C32DC5700FF2B36 /* LocaleLanguageScriptNameInterface.swift in Sources */,
 				D4F0457F2BBB479D00B115C9 /* RealmUserToolLanguageFilter.swift in Sources */,
 				450B7FC22B2B53A2000B9035 /* ToolSettingsToolLanguagesListTypeDomainModel.swift in Sources */,
 				D4F0457B2BBB464D00B115C9 /* RealmUserToolFiltersCache.swift in Sources */,
@@ -12413,6 +12423,7 @@
 				45D5433628B4001400C4E70F /* GetResourcesAttachments.swift in Sources */,
 				4555849A269F2F9E00C3FF14 /* TrainingTipEvent.swift in Sources */,
 				455583F1269F2DA500C3FF14 /* MobileContentTabView.swift in Sources */,
+				452504462C32DC4500FF2B36 /* LocaleLanguageNameInterface.swift in Sources */,
 				450D63B22AC8A87200B90319 /* TrackScreenViewAnalyticsInterface.swift in Sources */,
 				459E86EB28EDA86C00E197A5 /* DeepLinkingParserManifestType.swift in Sources */,
 				453F84BC2A029FC00005101E /* ArticleAemWebArchiveFileCacheLocation.swift in Sources */,
@@ -12594,6 +12605,7 @@
 				4578783027C41C08004552D5 /* MobileContentBackgroundImageAlignment.swift in Sources */,
 				D4BE3F722C0909BA00887BFD /* UserToolSettingsDataModel.swift in Sources */,
 				454ADAD72ABDD9D400037C27 /* LanguageSettingsAppInterfaceLanguageView.swift in Sources */,
+				452504482C32DC4E00FF2B36 /* LocaleLanguageRegionNameInterface.swift in Sources */,
 				45D63E70288F698C009B4610 /* LanguagesRepository.swift in Sources */,
 				4556CEB029F2E09500643BBC /* ArticleDebugViewModel.swift in Sources */,
 				45325F27285CF8B40078D932 /* VideoViewCoordinator.swift in Sources */,

--- a/godtools/App/Share/Common/LocaleLanguageName/LocaleLanguageName.swift
+++ b/godtools/App/Share/Common/LocaleLanguageName/LocaleLanguageName.swift
@@ -27,4 +27,18 @@ class LocaleLanguageName: LocaleLanguageNameInterface {
         
         return translateInLocale.localizedString(forLanguageCode: forLanguageCode)
     }
+    
+    func getLanguageName(forLocaleId: String, translatedInLanguageId: BCP47LanguageIdentifier?) -> String? {
+        
+        let translateInLocale: Locale
+        
+        if let translatedInLanguageId = translatedInLanguageId, !translatedInLanguageId.isEmpty {
+            translateInLocale = Locale(identifier: translatedInLanguageId)
+        }
+        else {
+            translateInLocale = Locale(identifier: forLocaleId)
+        }
+        
+        return translateInLocale.localizedString(forLanguageCode: forLocaleId)
+    }
 }

--- a/godtools/App/Share/Common/LocaleLanguageName/LocaleLanguageName.swift
+++ b/godtools/App/Share/Common/LocaleLanguageName/LocaleLanguageName.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-class LocaleLanguageName {
+class LocaleLanguageName: LocaleLanguageNameInterface {
     
     init() {
         

--- a/godtools/App/Share/Common/LocaleLanguageName/LocaleLanguageNameInterface.swift
+++ b/godtools/App/Share/Common/LocaleLanguageName/LocaleLanguageNameInterface.swift
@@ -11,4 +11,5 @@ import Foundation
 protocol LocaleLanguageNameInterface {
     
     func getLanguageName(forLanguageCode: String, translatedInLanguageId: BCP47LanguageIdentifier?) -> String?
+    func getLanguageName(forLocaleId: String, translatedInLanguageId: BCP47LanguageIdentifier?) -> String?
 }

--- a/godtools/App/Share/Common/LocaleLanguageName/LocaleLanguageNameInterface.swift
+++ b/godtools/App/Share/Common/LocaleLanguageName/LocaleLanguageNameInterface.swift
@@ -1,0 +1,14 @@
+//
+//  LocaleLanguageNameInterface.swift
+//  godtools
+//
+//  Created by Levi Eggert on 7/1/24.
+//  Copyright © 2024 Cru. All rights reserved.
+//
+
+import Foundation
+
+protocol LocaleLanguageNameInterface {
+    
+    func getLanguageName(forLanguageCode: String, translatedInLanguageId: BCP47LanguageIdentifier?) -> String?
+}

--- a/godtools/App/Share/Common/LocaleLanguageRegionName/LocaleLanguageRegionName.swift
+++ b/godtools/App/Share/Common/LocaleLanguageRegionName/LocaleLanguageRegionName.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-class LocaleLanguageRegionName {
+class LocaleLanguageRegionName: LocaleLanguageRegionNameInterface {
     
     init() {
         

--- a/godtools/App/Share/Common/LocaleLanguageRegionName/LocaleLanguageRegionNameInterface.swift
+++ b/godtools/App/Share/Common/LocaleLanguageRegionName/LocaleLanguageRegionNameInterface.swift
@@ -1,0 +1,14 @@
+//
+//  LocaleLanguageRegionNameInterface.swift
+//  godtools
+//
+//  Created by Levi Eggert on 7/1/24.
+//  Copyright © 2024 Cru. All rights reserved.
+//
+
+import Foundation
+
+protocol LocaleLanguageRegionNameInterface {
+    
+    func getRegionName(forRegionCode: String, translatedInLanguageId: BCP47LanguageIdentifier?) -> String?
+}

--- a/godtools/App/Share/Common/LocaleLanguageScriptName/LocaleLanguageScriptName.swift
+++ b/godtools/App/Share/Common/LocaleLanguageScriptName/LocaleLanguageScriptName.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-class LocaleLanguageScriptName {
+class LocaleLanguageScriptName: LocaleLanguageScriptNameInterface {
     
     init() {
         

--- a/godtools/App/Share/Common/LocaleLanguageScriptName/LocaleLanguageScriptNameInterface.swift
+++ b/godtools/App/Share/Common/LocaleLanguageScriptName/LocaleLanguageScriptNameInterface.swift
@@ -1,0 +1,14 @@
+//
+//  LocaleLanguageScriptNameInterface.swift
+//  godtools
+//
+//  Created by Levi Eggert on 7/1/24.
+//  Copyright © 2024 Cru. All rights reserved.
+//
+
+import Foundation
+
+protocol LocaleLanguageScriptNameInterface {
+    
+    func getScriptName(forScriptCode: String, translatedInLanguageId: BCP47LanguageIdentifier?) -> String?
+}

--- a/godtools/App/Share/Data-DomainInterface/Supporting/GetTranslatedLanguageName/GetTranslatedLanguageName.swift
+++ b/godtools/App/Share/Data-DomainInterface/Supporting/GetTranslatedLanguageName/GetTranslatedLanguageName.swift
@@ -63,7 +63,7 @@ class GetTranslatedLanguageName {
             languageName = localeLanguageName
         }
         else {
-            languageName = Locale(identifier: translatedInLanguage).localizedString(forIdentifier: language.localeId)
+            languageName = localeLanguageName.getLanguageName(forLocaleId: language.localeId, translatedInLanguageId: translatedInLanguage)
         }
         
         guard let languageName = languageName else {

--- a/godtools/App/Share/Data-DomainInterface/Supporting/GetTranslatedLanguageName/GetTranslatedLanguageName.swift
+++ b/godtools/App/Share/Data-DomainInterface/Supporting/GetTranslatedLanguageName/GetTranslatedLanguageName.swift
@@ -10,12 +10,12 @@ import Foundation
 
 class GetTranslatedLanguageName {
     
-    private let localizationServices: LocalizationServices
+    private let localizationServices: LocalizationServicesInterface
     private let localeLanguageName: LocaleLanguageName
     private let localeRegionName: LocaleLanguageRegionName
     private let localeScriptName: LocaleLanguageScriptName
     
-    init(localizationServices: LocalizationServices, localeLanguageName: LocaleLanguageName, localeRegionName: LocaleLanguageRegionName, localeScriptName: LocaleLanguageScriptName) {
+    init(localizationServices: LocalizationServicesInterface, localeLanguageName: LocaleLanguageName, localeRegionName: LocaleLanguageRegionName, localeScriptName: LocaleLanguageScriptName) {
         
         self.localizationServices = localizationServices
         self.localeLanguageName = localeLanguageName
@@ -44,7 +44,7 @@ class GetTranslatedLanguageName {
     private func getLanguageNameFromLocalization(language: TranslatableLanguage, translatedInLanguage: BCP47LanguageIdentifier) -> String? {
         
         let localizedKey: String = "language_name_" + language.localeId
-        let localizedName: String = localizationServices.stringForLocaleElseEnglish(localeIdentifier: translatedInLanguage, key: localizedKey)
+        let localizedName: String = localizationServices.stringForLocaleElseEnglish(localeIdentifier: translatedInLanguage, key: localizedKey, fileType: .strings)
         
         guard !localizedName.isEmpty && localizedName != localizedKey else {
             return nil

--- a/godtools/App/Share/Data-DomainInterface/Supporting/GetTranslatedLanguageName/GetTranslatedLanguageName.swift
+++ b/godtools/App/Share/Data-DomainInterface/Supporting/GetTranslatedLanguageName/GetTranslatedLanguageName.swift
@@ -11,11 +11,11 @@ import Foundation
 class GetTranslatedLanguageName {
     
     private let localizationServices: LocalizationServicesInterface
-    private let localeLanguageName: LocaleLanguageName
-    private let localeRegionName: LocaleLanguageRegionName
-    private let localeScriptName: LocaleLanguageScriptName
+    private let localeLanguageName: LocaleLanguageNameInterface
+    private let localeRegionName: LocaleLanguageRegionNameInterface
+    private let localeScriptName: LocaleLanguageScriptNameInterface
     
-    init(localizationServices: LocalizationServicesInterface, localeLanguageName: LocaleLanguageName, localeRegionName: LocaleLanguageRegionName, localeScriptName: LocaleLanguageScriptName) {
+    init(localizationServices: LocalizationServicesInterface, localeLanguageName: LocaleLanguageNameInterface, localeRegionName: LocaleLanguageRegionNameInterface, localeScriptName: LocaleLanguageScriptNameInterface) {
         
         self.localizationServices = localizationServices
         self.localeLanguageName = localeLanguageName

--- a/godtoolsTests/App/Share/Common/LocaleLanguageName/MockLocaleLanguageName.swift
+++ b/godtoolsTests/App/Share/Common/LocaleLanguageName/MockLocaleLanguageName.swift
@@ -1,0 +1,39 @@
+//
+//  MockLocaleLanguageName.swift
+//  godtools
+//
+//  Created by Levi Eggert on 7/1/24.
+//  Copyright © 2024 Cru. All rights reserved.
+//
+
+import Foundation
+@testable import godtools
+
+class MockLocaleLanguageName: LocaleLanguageNameInterface {
+    
+    typealias LanguageCode = String
+    typealias TranslateInLocaleId = String
+    typealias LanguageName = String
+    
+    private let languageNames: [LanguageCode: [TranslateInLocaleId: LanguageName]]
+    
+    init(languageNames: [LanguageCode: [TranslateInLocaleId: LanguageName]]) {
+        
+        self.languageNames = languageNames
+    }
+
+    func getLanguageName(forLanguageCode: String, translatedInLanguageId: BCP47LanguageIdentifier?) -> String? {
+        
+        if let translatedInLanguageId = translatedInLanguageId {
+            
+            return languageNames[forLanguageCode]?[translatedInLanguageId]
+        }
+        
+        return languageNames[forLanguageCode]?[forLanguageCode]
+    }
+    
+    func getLanguageName(forLocaleId: String, translatedInLanguageId: BCP47LanguageIdentifier?) -> String? {
+        
+        return getLanguageName(forLanguageCode: forLocaleId, translatedInLanguageId: translatedInLanguageId)
+    }
+}

--- a/godtoolsTests/App/Share/Common/LocaleLanguageRegionName/MockLocaleLanguageRegionName.swift
+++ b/godtoolsTests/App/Share/Common/LocaleLanguageRegionName/MockLocaleLanguageRegionName.swift
@@ -1,0 +1,34 @@
+//
+//  MockLocaleLanguageRegionName.swift
+//  godtools
+//
+//  Created by Levi Eggert on 7/1/24.
+//  Copyright © 2024 Cru. All rights reserved.
+//
+
+import Foundation
+@testable import godtools
+
+class MockLocaleLanguageRegionName: LocaleLanguageRegionNameInterface {
+    
+    typealias RegionCode = String
+    typealias TranslateInLocaleId = String
+    typealias RegionName = String
+    
+    private let regionNames: [RegionCode: [TranslateInLocaleId: RegionName]]
+    
+    init(regionNames: [RegionCode: [TranslateInLocaleId: RegionName]]) {
+        
+        self.regionNames = regionNames
+    }
+
+    func getRegionName(forRegionCode: String, translatedInLanguageId: BCP47LanguageIdentifier?) -> String? {
+        
+        if let translatedInLanguageId = translatedInLanguageId {
+            
+            return regionNames[forRegionCode]?[translatedInLanguageId]
+        }
+        
+        return regionNames[forRegionCode]?[forRegionCode]
+    }
+}

--- a/godtoolsTests/App/Share/Common/LocaleLanguageScriptName/MockLocaleLanguageScriptName.swift
+++ b/godtoolsTests/App/Share/Common/LocaleLanguageScriptName/MockLocaleLanguageScriptName.swift
@@ -1,0 +1,34 @@
+//
+//  MockLocaleLanguageScriptName.swift
+//  godtools
+//
+//  Created by Levi Eggert on 7/1/24.
+//  Copyright © 2024 Cru. All rights reserved.
+//
+
+import Foundation
+@testable import godtools
+
+class MockLocaleLanguageScriptName: LocaleLanguageScriptNameInterface {
+    
+    typealias ScriptCode = String
+    typealias TranslateInLocaleId = String
+    typealias ScriptName = String
+    
+    private let scriptNames: [ScriptCode: [TranslateInLocaleId: ScriptName]]
+    
+    init(scriptNames: [ScriptCode: [TranslateInLocaleId: ScriptName]]) {
+        
+        self.scriptNames = scriptNames
+    }
+    
+    func getScriptName(forScriptCode: String, translatedInLanguageId: BCP47LanguageIdentifier?) -> String? {
+        
+        if let translatedInLanguageId = translatedInLanguageId {
+            
+            return scriptNames[forScriptCode]?[translatedInLanguageId]
+        }
+        
+        return scriptNames[forScriptCode]?[forScriptCode]
+    }
+}

--- a/godtoolsTests/App/Share/Data-DomainInterface/Supporting/GetTranslatedLanguageName/GetTranslatedLanguageNameTests.swift
+++ b/godtoolsTests/App/Share/Data-DomainInterface/Supporting/GetTranslatedLanguageName/GetTranslatedLanguageNameTests.swift
@@ -1,0 +1,113 @@
+//
+//  GetTranslatedLanguageNameTests.swift
+//  godtoolsTests
+//
+//  Created by Levi Eggert on 7/1/24.
+//  Copyright © 2024 Cru. All rights reserved.
+//
+
+import Foundation
+@testable import godtools
+import Quick
+import Nimble
+
+class GetTranslatedLanguageNameTests: QuickSpec {
+    
+    override class func spec() {
+                
+        let localizableStrings: [MockLocalizationServices.LocaleId: [MockLocalizationServices.StringKey: String]] = [
+            LanguageCodeDomainModel.spanish.value: [
+                LanguageCodeDomainModel.english.rawValue: "Inglés",
+                LanguageCodeDomainModel.french.rawValue: "Francés",
+                LanguageCodeDomainModel.spanish.rawValue: "Español",
+                LanguageCodeDomainModel.russian.rawValue: "Ruso"
+            ]
+        ]
+        
+        let languageNames: [MockLocaleLanguageName.LanguageCode: [MockLocaleLanguageName.TranslateInLocaleId: MockLocaleLanguageName.LanguageName]] = [
+            LanguageCodeDomainModel.english.rawValue: [
+                LanguageCodeDomainModel.english.rawValue: "English",
+                LanguageCodeDomainModel.portuguese.rawValue: "Inglês",
+                LanguageCodeDomainModel.spanish.rawValue: "Inglés",
+                LanguageCodeDomainModel.russian.rawValue: "Английский"
+            ],
+            LanguageCodeDomainModel.french.rawValue: [
+                LanguageCodeDomainModel.czech.rawValue: "francouzština",
+                LanguageCodeDomainModel.english.rawValue: "French",
+                LanguageCodeDomainModel.portuguese.rawValue: "Francês",
+                LanguageCodeDomainModel.spanish.rawValue: "Francés",
+                LanguageCodeDomainModel.russian.rawValue: "Французский"
+            ],
+            LanguageCodeDomainModel.spanish.rawValue: [
+                LanguageCodeDomainModel.english.rawValue: "Spanish",
+                LanguageCodeDomainModel.portuguese.rawValue: "Espanhol",
+                LanguageCodeDomainModel.spanish.rawValue: "Español",
+                LanguageCodeDomainModel.russian.rawValue: "испанский"
+            ]
+        ]
+                
+        let getTranslatedLanguageName = GetTranslatedLanguageName(
+            localizationServices: MockLocalizationServices(localizableStrings: localizableStrings),
+            localeLanguageName: MockLocaleLanguageName(languageNames: languageNames),
+            localeRegionName: MockLocaleLanguageRegionName(regionNames: [:]),
+            localeScriptName: MockLocaleLanguageScriptName(scriptNames: [:])
+        )
+        
+        let frenchLanguage = MockTranslatableLanguage(
+            languageCode: LanguageCodeDomainModel.french.rawValue,
+            localeId: LanguageCodeDomainModel.french.rawValue,
+            fallbackName: "French",
+            regionCode: nil,
+            scriptCode: nil
+        )
+        
+        describe("User is viewing the french language name translated in spanish.") {
+         
+            context("If the spanish translation is available in the app bundle's string phrases.") {
+                
+                it("Display the language name from the app bundle's string phrases.") {
+                    
+                    let translation: String? = getTranslatedLanguageName.getLanguageName(
+                        language: frenchLanguage,
+                        translatedInLanguage: LanguageCodeDomainModel.spanish.rawValue
+                    )
+                    
+                    expect(translation).to(equal("Francés"))
+                }
+            }
+        }
+        
+        describe("User is viewing the french language name translated in czech.") {
+         
+            context("If the czech translation is not available in the app bundle's string phrases, but available in Locale.") {
+                
+                it("Display the language name from Locale.") {
+                    
+                    let translation: String? = getTranslatedLanguageName.getLanguageName(
+                        language: frenchLanguage,
+                        translatedInLanguage: LanguageCodeDomainModel.czech.rawValue
+                    )
+                    
+                    expect(translation).to(equal("francouzština"))
+                }
+            }
+        }
+        
+        describe("User is viewing the french language name translated in arabic.") {
+         
+            context("If the arabic translation is not available in the app bundle's string phrases and is not available in Locale.") {
+                
+                it("Display the fallback name.") {
+                    
+                    let translation: String? = getTranslatedLanguageName.getLanguageName(
+                        language: frenchLanguage,
+                        translatedInLanguage: LanguageCodeDomainModel.arabic.rawValue
+                    )
+                    
+                    expect(translation).to(equal("French"))
+                }
+            }
+        }
+    }
+}
+

--- a/godtoolsTests/App/Share/Data-DomainInterface/Supporting/GetTranslatedLanguageName/MockTranslatableLanguage.swift
+++ b/godtoolsTests/App/Share/Data-DomainInterface/Supporting/GetTranslatedLanguageName/MockTranslatableLanguage.swift
@@ -1,0 +1,19 @@
+//
+//  MockTranslatableLanguage.swift
+//  godtoolsTests
+//
+//  Created by Levi Eggert on 7/1/24.
+//  Copyright © 2024 Cru. All rights reserved.
+//
+
+import Foundation
+@testable import godtools
+
+struct MockTranslatableLanguage: TranslatableLanguage {
+    
+    let languageCode: String
+    let localeId: BCP47LanguageIdentifier
+    let fallbackName: String
+    let regionCode: String?
+    let scriptCode: String?
+}


### PR DESCRIPTION
This PR adds tests for GetTranslatedLanguageName.  I needed to add interfaces for the GetTranslatedLanguageName dependencies in order to mock the data for testing the behavior.

These tests will allow @gyasistory to add additional tests for changes in GT-2323.
