### PR TITLE
convert to language ID to check if language is supported

### DIFF
--- a/godtools/App/DependencyContainer/AppDataLayerDependencies.swift
+++ b/godtools/App/DependencyContainer/AppDataLayerDependencies.swift
@@ -314,6 +314,7 @@ class AppDataLayerDependencies {
     
     func getTranslatedToolCategory() -> GetTranslatedToolCategory {
         return GetTranslatedToolCategory(
+            languagesRepository: getLanguagesRepository(), 
             localizationServices: getLocalizationServices(),
             resourcesRepository: getResourcesRepository()
         )

--- a/godtools/App/Share/Data-DomainInterface/Supporting/GetTranslatedToolCategory/GetTranslatedToolCategory.swift
+++ b/godtools/App/Share/Data-DomainInterface/Supporting/GetTranslatedToolCategory/GetTranslatedToolCategory.swift
@@ -11,11 +11,13 @@ import LocalizationServices
 
 class GetTranslatedToolCategory {
     
+    private let languagesRepository: LanguagesRepository
     private let localizationServices: LocalizationServices
     private let resourcesRepository: ResourcesRepository
     
-    init(localizationServices: LocalizationServices, resourcesRepository: ResourcesRepository) {
+    init(languagesRepository: LanguagesRepository, localizationServices: LocalizationServices, resourcesRepository: ResourcesRepository) {
         
+        self.languagesRepository = languagesRepository
         self.localizationServices = localizationServices
         self.resourcesRepository = resourcesRepository
     }
@@ -33,8 +35,11 @@ class GetTranslatedToolCategory {
         
         let localeId: String
         
-        if resource.supportsLanguage(languageId: translateInLanguage) {
-            localeId = translateInLanguage
+        if 
+            let translateInLanguageModel = languagesRepository.getLanguage(code: translateInLanguage),
+            resource.supportsLanguage(languageId: translateInLanguageModel.id)
+        {
+            localeId = translateInLanguageModel.code
         } else {
             localeId = resource.attrDefaultLocale
         }

--- a/godtools/App/Share/Data/LanguagesRepository/LanguagesRepository.swift
+++ b/godtools/App/Share/Data/LanguagesRepository/LanguagesRepository.swift
@@ -33,7 +33,7 @@ class LanguagesRepository {
         return cache.getLanguage(id: id)
     }
     
-    func getLanguage(code: String) -> LanguageModel? {
+    func getLanguage(code: BCP47LanguageIdentifier) -> LanguageModel? {
         return cache.getLanguage(code: code)
     }
     
@@ -41,7 +41,7 @@ class LanguagesRepository {
         return cache.getLanguages(ids: ids)
     }
     
-    func getLanguages(languageCodes: [String]) -> [LanguageModel] {
+    func getLanguages(languageCodes: [BCP47LanguageIdentifier]) -> [LanguageModel] {
         return cache.getLanguages(languageCodes: languageCodes)
     }
     


### PR DESCRIPTION
See Jill's comment on https://jira.cru.org/browse/GT-2266 about the category not translating correctly.

The existing logic was failing because a `BCP47LanguageIdentifier` was being passed into `resource.supportsLanguage(languageId:)`.  But `languageId` isn't equivalent to `BCP47LanguageIdentifier`.  But  `BCP47LanguageIdentifier` is equivalent to `languageCode` and `localeId`, right?  I feel like we need a better way to convert/standardize this.