### PR TITLE
GT-2266 always translate tool category in app language

### DIFF
--- a/godtools/App/DependencyContainer/AppDataLayerDependencies.swift
+++ b/godtools/App/DependencyContainer/AppDataLayerDependencies.swift
@@ -314,7 +314,6 @@ class AppDataLayerDependencies {
     
     func getTranslatedToolCategory() -> GetTranslatedToolCategory {
         return GetTranslatedToolCategory(
-            languagesRepository: getLanguagesRepository(), 
             localizationServices: getLocalizationServices(),
             resourcesRepository: getResourcesRepository()
         )

--- a/godtools/App/Share/Data-DomainInterface/Supporting/GetTranslatedToolCategory/GetTranslatedToolCategory.swift
+++ b/godtools/App/Share/Data-DomainInterface/Supporting/GetTranslatedToolCategory/GetTranslatedToolCategory.swift
@@ -33,16 +33,7 @@ class GetTranslatedToolCategory {
     
     func getTranslatedCategory(resource: ResourceModel, translateInLanguage: BCP47LanguageIdentifier) -> String {
         
-        let localeId: String
-        
-        if 
-            let translateInLanguageModel = languagesRepository.getLanguage(code: translateInLanguage),
-            resource.supportsLanguage(languageId: translateInLanguageModel.id)
-        {
-            localeId = translateInLanguageModel.code
-        } else {
-            localeId = resource.attrDefaultLocale
-        }
+        let localeId = translateInLanguage.localeId
 
         let category: String = localizationServices.stringForLocaleElseEnglish(
             localeIdentifier: localeId,

--- a/godtools/App/Share/Data-DomainInterface/Supporting/GetTranslatedToolCategory/GetTranslatedToolCategory.swift
+++ b/godtools/App/Share/Data-DomainInterface/Supporting/GetTranslatedToolCategory/GetTranslatedToolCategory.swift
@@ -11,13 +11,11 @@ import LocalizationServices
 
 class GetTranslatedToolCategory {
     
-    private let languagesRepository: LanguagesRepository
     private let localizationServices: LocalizationServices
     private let resourcesRepository: ResourcesRepository
     
-    init(languagesRepository: LanguagesRepository, localizationServices: LocalizationServices, resourcesRepository: ResourcesRepository) {
+    init(localizationServices: LocalizationServices, resourcesRepository: ResourcesRepository) {
         
-        self.languagesRepository = languagesRepository
         self.localizationServices = localizationServices
         self.resourcesRepository = resourcesRepository
     }


### PR DESCRIPTION
Updated comment from Jill on https://jira.cru.org/browse/GT-2266-- tool category should always be translated in app language.