### PR TITLE
GT-2405 lesson navigation fix

### DIFF
--- a/godtools/App/Features/Lessons/Presentation/Lessons/LessonsViewModel.swift
+++ b/godtools/App/Features/Lessons/Presentation/Lessons/LessonsViewModel.swift
@@ -183,7 +183,7 @@ extension LessonsViewModel {
     
     func lessonCardTapped(lessonListItem: LessonListItemDomainModel) {
         
-        flowDelegate?.navigate(step: .lessonTappedFromLessonsList(lessonListItem: lessonListItem))
+        flowDelegate?.navigate(step: .lessonTappedFromLessonsList(lessonListItem: lessonListItem, languageFilter: lessonFilterLanguageSelection))
         
         trackLessonTappedAnalytics(lessonListItem: lessonListItem)
     }

--- a/godtools/App/Flows/App/AppFlow.swift
+++ b/godtools/App/Flows/App/AppFlow.swift
@@ -202,8 +202,13 @@ class AppFlow: NSObject, ToolNavigationFlow, Flow {
                 navigateToTool(toolDataModelId: toolId, primaryLanguage: primaryLanguage, parallelLanguage: parallelLanguage, selectedLanguageIndex: selectedLanguageIndex, trainingTipsEnabled: false)
             }
             
-        case .lessonTappedFromLessonsList(let lessonListItem):
-            navigateToToolInAppLanguage(toolDataModelId: lessonListItem.dataModelId, trainingTipsEnabled: false)
+        case .lessonTappedFromLessonsList(let lessonListItem, let languageFilter):
+            
+            if let languageFilter = languageFilter {
+                navigateToTool(toolDataModelId: lessonListItem.dataModelId, languageIds: [languageFilter.languageId], selectedLanguageIndex: 0, trainingTipsEnabled: false)
+            } else {
+                navigateToToolInAppLanguage(toolDataModelId: lessonListItem.dataModelId, trainingTipsEnabled: false)
+            }
             
         case .lessonLanguageFilterTappedFromLessons:
             navigationController.pushViewController(getLessonLanguageFilterSelection(), animated: true)

--- a/godtools/App/Flows/Flow/FlowStep.swift
+++ b/godtools/App/Flows/Flow/FlowStep.swift
@@ -32,7 +32,7 @@ enum FlowStep {
     
     // lessons list
     case lessonLanguageFilterTappedFromLessons
-    case lessonTappedFromLessonsList(lessonListItem: LessonListItemDomainModel)
+    case lessonTappedFromLessonsList(lessonListItem: LessonListItemDomainModel, languageFilter: LessonFilterLanguageDomainModel?)
     case languageTappedFromLessonLanguageFilter
     case backTappedFromLessonLanguageFilter
 


### PR DESCRIPTION
Fixes:
1. When clicked, lessons should open up in the chosen filter language.
2. The lesson title should be written in the filtered language rather than the app language.