### PR TITLE
GT-2323 update tests to include force language name

### DIFF
--- a/godtoolsTests/App/Share/Data-DomainInterface/Supporting/GetTranslatedLanguageName/GetTranslatedLanguageNameTests.swift
+++ b/godtoolsTests/App/Share/Data-DomainInterface/Supporting/GetTranslatedLanguageName/GetTranslatedLanguageNameTests.swift
@@ -43,6 +43,12 @@ class GetTranslatedLanguageNameTests: QuickSpec {
                 LanguageCodeDomainModel.portuguese.rawValue: "Espanhol",
                 LanguageCodeDomainModel.spanish.rawValue: "Español",
                 LanguageCodeDomainModel.russian.rawValue: "испанский"
+            ],
+            LanguageCodeDomainModel.russian.rawValue: [
+                LanguageCodeDomainModel.english.rawValue: "Russian",
+                LanguageCodeDomainModel.portuguese.rawValue: "Russo",
+                LanguageCodeDomainModel.spanish.rawValue: "Ruso",
+                LanguageCodeDomainModel.russian.rawValue: "Русский"
             ]
         ]
                 
@@ -53,58 +59,147 @@ class GetTranslatedLanguageNameTests: QuickSpec {
             localeScriptName: MockLocaleLanguageScriptName(scriptNames: [:])
         )
         
-        let frenchLanguage = MockTranslatableLanguage(
-            languageCode: LanguageCodeDomainModel.french.rawValue,
-            localeId: LanguageCodeDomainModel.french.rawValue,
-            fallbackName: "French",
-            regionCode: nil,
-            scriptCode: nil
-        )
-        
-        describe("User is viewing the french language name translated in spanish.") {
-         
-            context("If the spanish translation is available in the app bundle's string phrases.") {
+        describe("User is viewing the russian language name.") {
+            
+            context("When translating the russian language name using an empty translation string and fallbackName is false.") {
                 
-                it("Display the language name from the app bundle's string phrases.") {
+                it("Then translate the russian language name using the fallbackName.") {
+                    
+                    let russianFallbackName: String = "Russian Fallback Name"
+                    
+                    let russianLanguage = MockTranslatableLanguage(
+                        languageCode: LanguageCodeDomainModel.russian.rawValue,
+                        localeId: LanguageCodeDomainModel.russian.rawValue,
+                        fallbackName: russianFallbackName,
+                        forceLanguageName: false,
+                        regionCode: nil,
+                        scriptCode: nil
+                    )
+                    
+                    let translation: String? = getTranslatedLanguageName.getLanguageName(
+                        language: russianLanguage,
+                        translatedInLanguage: ""
+                    )
+                                        
+                    expect(translation).to(equal(russianFallbackName))
+                }
+            }
+        }
+        
+        describe("User is viewing the russian language name.") {
+            
+            context("When translating the russian language name in spanish and forceLanguageName is true and a translation is available in the app bundle's string phrases and in Locale.") {
+                
+                it("Then translate the russian language name using the fallbackName.") {
+                    
+                    let russianFallbackName: String = "Russian Fallback Name"
+                    
+                    let russianLanguage = MockTranslatableLanguage(
+                        languageCode: LanguageCodeDomainModel.russian.rawValue,
+                        localeId: LanguageCodeDomainModel.russian.rawValue,
+                        fallbackName: russianFallbackName,
+                        forceLanguageName: true,
+                        regionCode: nil,
+                        scriptCode: nil
+                    )
+                    
+                    let translation: String? = getTranslatedLanguageName.getLanguageName(
+                        language: russianLanguage,
+                        translatedInLanguage: LanguageCodeDomainModel.spanish.rawValue
+                    )
+                    
+                    let translationFromAppBundle: String? = localizableStrings[LanguageCodeDomainModel.spanish.value]?[LanguageCodeDomainModel.russian.value]
+                    let translationFromLocale: String? = languageNames[LanguageCodeDomainModel.russian.value]?[LanguageCodeDomainModel.spanish.value]
+                    
+                    expect(translation).to(equal(russianFallbackName))
+                    expect(translationFromAppBundle).to(equal("Ruso"))
+                    expect(translationFromLocale).to(equal("Ruso"))
+                }
+            }
+        }
+        
+        describe("User is viewing the french language name.") {
+            
+            context("When translating the french language name in spanish and forceLanguageName is false and a translation is available in the app bundle's string phrases.") {
+                
+                it("Then translate the french language name using the app bundle's string phrases.") {
+                    
+                    let fallbackName: String = "French Fallback Name"
+                    
+                    let frenchLanguage = MockTranslatableLanguage(
+                        languageCode: LanguageCodeDomainModel.french.rawValue,
+                        localeId: LanguageCodeDomainModel.french.rawValue,
+                        fallbackName: fallbackName,
+                        forceLanguageName: false,
+                        regionCode: nil,
+                        scriptCode: nil
+                    )
                     
                     let translation: String? = getTranslatedLanguageName.getLanguageName(
                         language: frenchLanguage,
                         translatedInLanguage: LanguageCodeDomainModel.spanish.rawValue
                     )
                     
-                    expect(translation).to(equal("Francés"))
+                    let translationFromLocale: String? = languageNames[LanguageCodeDomainModel.french.value]?[LanguageCodeDomainModel.spanish.value]
+                    
+                    expect(translation).to(equal(localizableStrings[LanguageCodeDomainModel.spanish.value]?[LanguageCodeDomainModel.french.value]))
+                    expect(translationFromLocale).to(equal("Francés"))
                 }
             }
-        }
-        
-        describe("User is viewing the french language name translated in czech.") {
-         
-            context("If the czech translation is not available in the app bundle's string phrases, but available in Locale.") {
+            
+            context("When translating the french language name in czech and forceLanguageName is false and a translation is not available in the app bundle's string phrases, but available in Locale.") {
                 
-                it("Display the language name from Locale.") {
+                it("Then translate the french language name using Locale.") {
+                    
+                    let fallbackName: String = "French Fallback Name"
+                    
+                    let frenchLanguage = MockTranslatableLanguage(
+                        languageCode: LanguageCodeDomainModel.french.rawValue,
+                        localeId: LanguageCodeDomainModel.french.rawValue,
+                        fallbackName: fallbackName,
+                        forceLanguageName: false,
+                        regionCode: nil,
+                        scriptCode: nil
+                    )
                     
                     let translation: String? = getTranslatedLanguageName.getLanguageName(
                         language: frenchLanguage,
                         translatedInLanguage: LanguageCodeDomainModel.czech.rawValue
                     )
                     
+                    let translationFromAppBundle: String? = localizableStrings[LanguageCodeDomainModel.czech.value]?[LanguageCodeDomainModel.french.value]
+                    
                     expect(translation).to(equal("francouzština"))
+                    expect(translationFromAppBundle).to(beNil())
                 }
             }
-        }
-        
-        describe("User is viewing the french language name translated in arabic.") {
-         
-            context("If the arabic translation is not available in the app bundle's string phrases and is not available in Locale.") {
+            
+            context("When translating the french language name in arabic and forceLanguageName is false and a translation is not available in the app bundle's string phrases or in Locale.") {
                 
-                it("Display the fallback name.") {
+                it("Then translate the french language using the fallbackName.") {
+                             
+                    let fallbackName: String = "French Fallback Name"
+                    
+                    let frenchLanguage = MockTranslatableLanguage(
+                        languageCode: LanguageCodeDomainModel.french.rawValue,
+                        localeId: LanguageCodeDomainModel.french.rawValue,
+                        fallbackName: fallbackName,
+                        forceLanguageName: false,
+                        regionCode: nil,
+                        scriptCode: nil
+                    )
+                    
+                    let translationFromAppBundle: String? = localizableStrings[LanguageCodeDomainModel.arabic.value]?[LanguageCodeDomainModel.french.value]
+                    let translationFromLocale: String? = languageNames[LanguageCodeDomainModel.french.value]?[LanguageCodeDomainModel.arabic.value]
                     
                     let translation: String? = getTranslatedLanguageName.getLanguageName(
                         language: frenchLanguage,
                         translatedInLanguage: LanguageCodeDomainModel.arabic.rawValue
                     )
                     
-                    expect(translation).to(equal("French"))
+                    expect(translation).to(equal(fallbackName))
+                    expect(translationFromAppBundle).to(beNil())
+                    expect(translationFromLocale).to(beNil())
                 }
             }
         }

--- a/godtoolsTests/App/Share/Data-DomainInterface/Supporting/GetTranslatedLanguageName/MockTranslatableLanguage.swift
+++ b/godtoolsTests/App/Share/Data-DomainInterface/Supporting/GetTranslatedLanguageName/MockTranslatableLanguage.swift
@@ -14,6 +14,7 @@ struct MockTranslatableLanguage: TranslatableLanguage {
     let languageCode: String
     let localeId: BCP47LanguageIdentifier
     let fallbackName: String
+    let forceLanguageName: Bool
     let regionCode: String?
     let scriptCode: String?
 }


### PR DESCRIPTION
- Adding ```forceLanguageName``` to ```MockTranslatableLanguage.swift.```
- Added test to ensure languageName is returned when forceLanguageName is true and a translation is available in both localizable strings and Locale.
- Added test to ensure fallbackName is returned when the translate in language string is empty.
- Added some additional checks in tests against localizable strings and locale.