### PR TITLE
GT-2420 enable wrapping multi line text for buttons

### DIFF
--- a/godtools/App/Features/ToolSettings/Presentation/ToolSettings/ToolSettingsHostingView.swift
+++ b/godtools/App/Features/ToolSettings/Presentation/ToolSettings/ToolSettingsHostingView.swift
@@ -79,8 +79,8 @@ extension ToolSettingsHostingView: TransparentModalCustomView {
         
         view.translatesAutoresizingMaskIntoConstraints = false
         
-        view.constrainLeadingToView(view: parent, constant: modalHorizontalPadding)
-        view.constrainTrailingToView(view: parent, constant: modalHorizontalPadding)
+        _ = view.constrainLeadingToView(view: parent, constant: modalHorizontalPadding)
+        _ = view.constrainTrailingToView(view: parent, constant: modalHorizontalPadding)
         modalBottomToParent = view.constrainBottomToView(view: parent, constant: 0)
         _ = view.addHeightConstraint(constant: getModalHeight())
         

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentButton/MobileContentButtonView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentButton/MobileContentButtonView.swift
@@ -131,7 +131,7 @@ class MobileContentButtonView: MobileContentView {
                     toItem: buttonTitle,
                     attribute: .leading,
                     multiplier: 1,
-                    constant: buttonImagePaddingToButtonTitle * -1
+                    constant: 0
                 )
                 
                 buttonView.addConstraint(trailing)
@@ -145,7 +145,7 @@ class MobileContentButtonView: MobileContentView {
                     toItem: buttonTitle,
                     attribute: .trailing,
                     multiplier: 1,
-                    constant: buttonImagePaddingToButtonTitle
+                    constant: 0
                 )
                 
                 buttonView.addConstraint(leading)
@@ -159,7 +159,7 @@ class MobileContentButtonView: MobileContentView {
                     toItem: buttonTitle,
                     attribute: .leading,
                     multiplier: 1,
-                    constant: buttonImagePaddingToButtonTitle * -1
+                    constant: 0
                 )
                 
                 buttonView.addConstraint(trailing)
@@ -197,7 +197,7 @@ class MobileContentButtonView: MobileContentView {
         let buttonViewWidth: CGFloat = getButtonViewWidth()
         
         let minSuggestedButtonTitleWidth: CGFloat = buttonViewWidth / 4
-        var suggestedButtonTitleWidth: CGFloat = buttonViewWidth - (buttonIconSize.width * 2) - (buttonImagePaddingToButtonTitle * 2) - (buttonImagePaddingToButtonTitle * 2)
+        var suggestedButtonTitleWidth: CGFloat = buttonViewWidth - (buttonIconSize.width * 2) - (buttonImagePaddingToButtonTitle * 4)
         
         if suggestedButtonTitleWidth < minSuggestedButtonTitleWidth {
             suggestedButtonTitleWidth = minSuggestedButtonTitleWidth
@@ -207,7 +207,7 @@ class MobileContentButtonView: MobileContentView {
             return suggestedButtonTitleWidth
         }
         
-        return buttonTitleSizeToFitSize.width
+        return buttonTitleSizeToFitSize.width + (buttonImagePaddingToButtonTitle * 2)
     }
     
     private func getButtonIconSize() -> CGSize? {

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentButton/MobileContentButtonView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentButton/MobileContentButtonView.swift
@@ -10,13 +10,13 @@ import Foundation
 import UIKit
 
 class MobileContentButtonView: MobileContentView {
-    
-    private static let buttonHeight: CGFloat = 50
-    
+        
     private let viewModel: MobileContentButtonViewModel
     private let buttonView: UIView = UIView()
     private let buttonTitle: UILabel = UILabel()
     private let buttonImagePaddingToButtonTitle: CGFloat = 12
+    private let minimumButtonHeight: CGFloat = 21
+    private let buttonTopAndBottomPaddingToTitle: CGFloat = 8
     
     private var buttonTitleSizeToFitSize: CGSize?
     private var buttonImageView: UIImageView?
@@ -92,7 +92,7 @@ class MobileContentButtonView: MobileContentView {
         _ = buttonView.constrainBottomToView(view: self)
         
         _ = buttonView.addHeightConstraint(
-            constant: Self.buttonHeight,
+            constant: minimumButtonHeight,
             relatedBy: .greaterThanOrEqual,
             priority: 1000
         )
@@ -106,9 +106,9 @@ class MobileContentButtonView: MobileContentView {
         // buttonTitle
         buttonView.addSubview(buttonTitle)
         buttonTitle.translatesAutoresizingMaskIntoConstraints = false
-        _ = buttonTitle.constrainTopToView(view: buttonView)
-        _ = buttonTitle.constrainBottomToView(view: buttonView)
-        
+        _ = buttonTitle.constrainTopToView(view: buttonView, constant: buttonTopAndBottomPaddingToTitle)
+        _ = buttonTitle.constrainBottomToView(view: buttonView, constant: buttonTopAndBottomPaddingToTitle)
+                
         if let buttonImageView = buttonImageView, let buttonIcon = viewModel.icon, let buttonIconSize = getButtonIconSize(), let buttonTitleWidth = getButtonTitleWidth() {
             
             buttonTitle.constrainCenterHorizontallyInView(view: buttonView)

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentFlowRow/MobileContentFlowRow.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentFlowRow/MobileContentFlowRow.swift
@@ -112,7 +112,7 @@ class MobileContentFlowRow: MobileContentView {
                 
         flowItem.translatesAutoresizingMaskIntoConstraints = false
         
-        flowItem.constrainTopToView(view: self)
+        _ = flowItem.constrainTopToView(view: self)
         _ = flowItem.constrainBottomToView(view: self)
         flowItem.setWidthConstraint(constant: flowItemWidth)
                         

--- a/godtools/App/Share/Common/SharedAppleExtensions/UIKit/UIView/UIView+Constraints.swift
+++ b/godtools/App/Share/Common/SharedAppleExtensions/UIKit/UIView/UIView+Constraints.swift
@@ -12,20 +12,20 @@ extension UIView {
     
     func constrainEdgesToView(view: UIView, edgeInsets: UIEdgeInsets = .zero, horizontalConstraintType: UIViewHorizontalContraintType = .leadingAndTrailing) {
         
-        constrainTopToView(view: view, constant: edgeInsets.top)
+        _ = constrainTopToView(view: view, constant: edgeInsets.top)
         _ = constrainBottomToView(view: view, constant: edgeInsets.bottom)
         
         switch horizontalConstraintType {
         case .leadingAndTrailing:
-            constrainLeadingToView(view: view, constant: edgeInsets.left)
-            constrainTrailingToView(view: view, constant: edgeInsets.right)
+            _ = constrainLeadingToView(view: view, constant: edgeInsets.left)
+            _ = constrainTrailingToView(view: view, constant: edgeInsets.right)
         case .leftAndRight:
             constrainLeftToView(view: view, constant: edgeInsets.left)
             constrainRightToView(view: view, constant: edgeInsets.right)
         }
     }
     
-    func constrainTopToView(view: UIView, constant: CGFloat = 0) {
+    func constrainTopToView(view: UIView, constant: CGFloat = 0) -> NSLayoutConstraint {
         
         let top: NSLayoutConstraint = NSLayoutConstraint(
             item: self,
@@ -38,6 +38,8 @@ extension UIView {
         )
         
         view.addConstraint(top)
+        
+        return top
     }
     
     func constrainBottomToView(view: UIView, constant: CGFloat = 0) -> NSLayoutConstraint {
@@ -87,7 +89,7 @@ extension UIView {
         view.addConstraint(right)
     }
     
-    func constrainLeadingToView(view: UIView, constant: CGFloat = 0) {
+    func constrainLeadingToView(view: UIView, constant: CGFloat = 0) -> NSLayoutConstraint {
         
         let leading: NSLayoutConstraint = NSLayoutConstraint(
             item: self,
@@ -100,9 +102,11 @@ extension UIView {
         )
         
         view.addConstraint(leading)
+        
+        return leading
     }
     
-    func constrainTrailingToView(view: UIView, constant: CGFloat = 0) {
+    func constrainTrailingToView(view: UIView, constant: CGFloat = 0) -> NSLayoutConstraint {
         
         let trailing: NSLayoutConstraint = NSLayoutConstraint(
             item: self,
@@ -115,6 +119,8 @@ extension UIView {
         )
         
         view.addConstraint(trailing)
+        
+        return trailing
     }
     
     func constrainCenterHorizontallyInView(view: UIView) {

--- a/godtools/App/Share/Views/PageNavigationCollectionView/PageNavigationCollectionView.swift
+++ b/godtools/App/Share/Views/PageNavigationCollectionView/PageNavigationCollectionView.swift
@@ -32,7 +32,7 @@ class PageNavigationCollectionView: UIView, NibBased {
     }
     
     private let layoutType: PageNavigationCollectionViewLayoutType
-    private let loggingEnabled: Bool = true
+    private let loggingEnabled: Bool = false
     
     private var layout: UICollectionViewFlowLayout = PageNavigationCollectionView.getDefaultFlowLayout()
     private var currentPageNavigation: PageNavigationCollectionView.CurrentNavigation?


### PR DESCRIPTION
This PR makes a fix to buttons (```MobileContentButtonView.swift```) in the mobile content renderer to support multiple lines of text.  I noticed multiple lines of text was working correctly when buttons rendered a title only.  However, when rendering a title + icon then multiline text would fail to work and a single line of text was rendered.

The reason being, in title only mode a width constraint was being defined by applying a leading and trailing constraint to the title's parent view which allowed for multiple lines of text to render.  In title + icon mode there wasn't a width constraint being defined and the title was instead horizontally constrained to the center of the parent.  Without a defined width, the title width would stretch as far and wide as it could to account for all the text.

The fix was to ensure a width constraint was defined when in title + icon mode.  This involved calculating the single line width of the title (```sizeToFit```) and using that if the sizeToFit size was less than the suggested size which accounts for the icon width and padding.

Fix to production Agape KGP in Polish button to support multiple line of text with icon.

![fix-multiline-buttons](https://github.com/user-attachments/assets/94e40b01-f6c3-4a4c-adc0-ec2516a6ab77)

Staging build with the applied fix.  Really no change.  But, it is using the title width for the ```sizeToFit```.

![staging-button-styles](https://github.com/user-attachments/assets/95fa9039-d188-4479-b2f3-c2b2e51ec67c)

Staging build with hardcoded long button title.  You can see the title's with icons are a single line due to no width constraint.

![staging-hardcode-button-title](https://github.com/user-attachments/assets/acf87337-2bee-4ad9-b21b-d80abbcb1c1e)


