### PR TITLE
GT-2435 Fixes banner animation not showing when opening tool for first time 

### DIFF
--- a/godtools/App/Share/Data/ToolDownloader/ToolDownloader.swift
+++ b/godtools/App/Share/Data/ToolDownloader/ToolDownloader.swift
@@ -43,6 +43,10 @@ class ToolDownloader {
                 if let resourceBannerAbout = attachmentsRepository.getAttachmentModel(id: resource.attrBannerAbout) {
                     attachments.append(resourceBannerAbout)
                 }
+                
+                if let resourceAboutBannerAnimation = attachmentsRepository.getAttachmentModel(id: resource.attrAboutBannerAnimation) {
+                    attachments.append(resourceAboutBannerAnimation)
+                }
             }
             
             for language in tool.languages {


### PR DESCRIPTION
This PR adds about banner animation downloading to the tool downloader process.  This will include banner animation downloads when choosing a language to download from the download languages list.

This change fixes an issue where opening a tool offline to tool details wouldn't display the banner animation.

Now when a language is chosen to download, such as English, it will include about banner animations and when an english tool is opened for the first time offline, it will display the about banner animation in tool details.