### PR TITLE
GT Update realm dependency version to 20.0.0

### DIFF
--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -15107,7 +15107,7 @@
 			repositoryURL = "https://github.com/realm/realm-swift.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 10.50.0;
+				minimumVersion = 20.0.0;
 			};
 		};
 		45B4FDBB2BE1787000E5E35B /* XCRemoteSwiftPackageReference "AppsFlyerFramework-Strict" */ = {

--- a/godtools.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/godtools.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -222,8 +222,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/realm/realm-core.git",
       "state" : {
-        "revision" : "9cf7ef4ad8e2f4c7a519c9a395ca3d253bb87aa8",
-        "version" : "14.6.2"
+        "revision" : "f98720a07e6150c41c953e1937108225550ba155",
+        "version" : "20.0.0"
       }
     },
     {
@@ -231,8 +231,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/realm/realm-swift.git",
       "state" : {
-        "revision" : "6e0772315809ff0a11cd265126350039a6aac59d",
-        "version" : "10.50.1"
+        "revision" : "7ea8be1f74034bae860120d58d3491c4fcedff5b",
+        "version" : "20.0.0"
       }
     },
     {


### PR DESCRIPTION
Started seeing a strange error in GitHub Actions when running tests.  Hoping updating Realm will resolve it.

StackOverflow popped up with this (https://stackoverflow.com/questions/31029255/no-space-left-on-device-error-when-compiling). 

Wondering if GitHub Actions macos is running out of space?

<img width="1328" alt="Screenshot 2024-09-12 at 3 38 03 PM" src="https://github.com/user-attachments/assets/f807b266-f4b5-4245-af61-de32b8129758">

