### PR TITLE
GT-2438 Fix initial page navigation in renderer

### DIFF
--- a/godtools/App/Features/Dashboard/Presentation/ChooseYourOwnAdventure/ChooseYourOwnAdventureViewModel.swift
+++ b/godtools/App/Features/Dashboard/Presentation/ChooseYourOwnAdventure/ChooseYourOwnAdventureViewModel.swift
@@ -71,7 +71,7 @@ class ChooseYourOwnAdventureViewModel: MobileContentPagesViewModel {
         return []
     }
     
-    override func getPageNavigationEvent(page: Page, animated: Bool) -> MobileContentPagesNavigationEvent {
+    override func getPageNavigationEvent(page: Page, animated: Bool, reloadCollectionViewDataNeeded: Bool) -> MobileContentPagesNavigationEvent {
         
         let pages: [Page] = super.getPages()
         

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/Pages/MobileContentPagesViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/Pages/MobileContentPagesViewModel.swift
@@ -376,7 +376,7 @@ class MobileContentPagesViewModel: NSObject, ObservableObject {
                 
         switch initialPage {
         
-        case .pageId(let value):
+        case .pageId(let value):            
             var page = allPages.first(where: {$0.id == value})
             
             while(page?.isHidden == true) {
@@ -431,7 +431,7 @@ class MobileContentPagesViewModel: NSObject, ObservableObject {
             return nil
         }
         
-        return getPageNavigationEvent(page: initialPage, animated: false)
+        return getPageNavigationEvent(page: initialPage, animated: false, reloadCollectionViewDataNeeded: true)
     }
     
     private func checkIfEventIsPageListenerAndNavigate(eventId: EventId) -> Bool {
@@ -472,7 +472,7 @@ class MobileContentPagesViewModel: NSObject, ObservableObject {
         sendPageNavigationEvent(navigationEvent: navigationEvent)
     }
         
-    func getPageNavigationEvent(page: Page, animated: Bool) -> MobileContentPagesNavigationEvent {
+    func getPageNavigationEvent(page: Page, animated: Bool, reloadCollectionViewDataNeeded: Bool = false) -> MobileContentPagesNavigationEvent {
                 
         let currentRenderedPages: [Page] = pageModels
                 
@@ -519,7 +519,7 @@ class MobileContentPagesViewModel: NSObject, ObservableObject {
                 navigationDirection: nil,
                 page: pageIndexToNavigateTo,
                 animated: animated,
-                reloadCollectionViewDataNeeded: false,
+                reloadCollectionViewDataNeeded: reloadCollectionViewDataNeeded,
                 insertPages: insertPages,
                 deletePages: nil
             ),

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/Pages/MobileContentPagesViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/Pages/MobileContentPagesViewModel.swift
@@ -376,7 +376,7 @@ class MobileContentPagesViewModel: NSObject, ObservableObject {
                 
         switch initialPage {
         
-        case .pageId(let value):            
+        case .pageId(let value):
             var page = allPages.first(where: {$0.id == value})
             
             while(page?.isHidden == true) {

--- a/godtools/App/Share/Views/PageNavigationCollectionView/PageNavigationCollectionView.swift
+++ b/godtools/App/Share/Views/PageNavigationCollectionView/PageNavigationCollectionView.swift
@@ -534,14 +534,11 @@ extension PageNavigationCollectionView {
             return false
         }
         
-        DispatchQueue.main.async {
-            
-            self.collectionView.scrollToItem(
-                at: IndexPath(item: item, section: 0),
-                at: .centeredHorizontally,
-                animated: animated
-            )
-        }
+        collectionView.scrollToItem(
+            at: IndexPath(item: item, section: 0),
+            at: .centeredHorizontally,
+            animated: animated
+        )
         
         return true
     }


### PR DESCRIPTION
Hey @rachaelblue looks like initial page navigation was broken across the board.  The collection view needed to be reloaded when performing an initial page navigation.  Once reloaded and the data model (pageModels) aren't mutated, page navigation can be performed without the need to reload the collection view. 