### PR TITLE
GT-2458 Open URL using SwiftUI

### DIFF
--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -773,6 +773,7 @@
 		45965D4D2B4488BD001C9AA5 /* GetDashboardInterfaceStringsRepositoryInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45965D4C2B4488BD001C9AA5 /* GetDashboardInterfaceStringsRepositoryInterface.swift */; };
 		45965D4F2B44890F001C9AA5 /* GetDashboardInterfaceStringsRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45965D4E2B44890F001C9AA5 /* GetDashboardInterfaceStringsRepository.swift */; };
 		4597101629CDE02400C47040 /* View+CornerRadius.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4597101529CDE02400C47040 /* View+CornerRadius.swift */; };
+		45977F2C2CC8245700F4E558 /* ExitAppToUrl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45977F2A2CC8245700F4E558 /* ExitAppToUrl.swift */; };
 		4598BD0D2BF7DF6800196463 /* AppleAuthentication+AuthenticationProviderInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4598BCDC2BF7DF6800196463 /* AppleAuthentication+AuthenticationProviderInterface.swift */; };
 		4598BD0E2BF7DF6800196463 /* FacebookAuthentication+AuthenticationProviderInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4598BCDD2BF7DF6800196463 /* FacebookAuthentication+AuthenticationProviderInterface.swift */; };
 		4598BD0F2BF7DF6800196463 /* GoogleAuthentication+AuthenticationProviderInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4598BCDE2BF7DF6800196463 /* GoogleAuthentication+AuthenticationProviderInterface.swift */; };
@@ -2437,6 +2438,7 @@
 		45965D4C2B4488BD001C9AA5 /* GetDashboardInterfaceStringsRepositoryInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetDashboardInterfaceStringsRepositoryInterface.swift; sourceTree = "<group>"; };
 		45965D4E2B44890F001C9AA5 /* GetDashboardInterfaceStringsRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetDashboardInterfaceStringsRepository.swift; sourceTree = "<group>"; };
 		4597101529CDE02400C47040 /* View+CornerRadius.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "View+CornerRadius.swift"; sourceTree = "<group>"; };
+		45977F2A2CC8245700F4E558 /* ExitAppToUrl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExitAppToUrl.swift; sourceTree = "<group>"; };
 		4598BCDC2BF7DF6800196463 /* AppleAuthentication+AuthenticationProviderInterface.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AppleAuthentication+AuthenticationProviderInterface.swift"; sourceTree = "<group>"; };
 		4598BCDD2BF7DF6800196463 /* FacebookAuthentication+AuthenticationProviderInterface.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "FacebookAuthentication+AuthenticationProviderInterface.swift"; sourceTree = "<group>"; };
 		4598BCDE2BF7DF6800196463 /* GoogleAuthentication+AuthenticationProviderInterface.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "GoogleAuthentication+AuthenticationProviderInterface.swift"; sourceTree = "<group>"; };
@@ -7406,6 +7408,14 @@
 			path = DownloadToolTranslations;
 			sourceTree = "<group>";
 		};
+		45977F2B2CC8245700F4E558 /* ExitAppToUrl */ = {
+			isa = PBXGroup;
+			children = (
+				45977F2A2CC8245700F4E558 /* ExitAppToUrl.swift */,
+			);
+			path = ExitAppToUrl;
+			sourceTree = "<group>";
+		};
 		4598BCDF2BF7DF6800196463 /* Providers */ = {
 			isa = PBXGroup;
 			children = (
@@ -8616,6 +8626,7 @@
 				45E347972A49C0EC0014CCD1 /* AnimatableValue */,
 				4585E4B32B05738600223A9B /* BCP47LanguageIdentifier */,
 				45AD20C625938F3900A096A0 /* CallbackHandler */,
+				45977F2B2CC8245700F4E558 /* ExitAppToUrl */,
 				45AD20AC25938EE500A096A0 /* FileCache */,
 				45AD20E8259391B000A096A0 /* Json */,
 				4581D97D297AD16300D056D6 /* JsonApi */,
@@ -13707,6 +13718,7 @@
 				45880D892BD2BBE7008F021C /* GetShareGodToolsInterfaceStringsRepositoryInterface.swift in Sources */,
 				45308EB92BDC249000A49D96 /* DidChangeScaleForSpiritualConversationReadinessUseCase.swift in Sources */,
 				458D01832B1E4ED30029523C /* LessonsInterfaceStringsDomainModel.swift in Sources */,
+				45977F2C2CC8245700F4E558 /* ExitAppToUrl.swift in Sources */,
 				453D1F022861CFEE00CEA3AC /* CircleSelectorView.swift in Sources */,
 				45AE974D27C97A9500C2CB33 /* Multiselect+MobileContentRenderableModel.swift in Sources */,
 				45BD7A7026A235780007426B /* MobileContentRendererPageViewFactories.swift in Sources */,

--- a/godtools/App/Flows/App/AppFlow.swift
+++ b/godtools/App/Flows/App/AppFlow.swift
@@ -407,7 +407,7 @@ class AppFlow: NSObject, ToolNavigationFlow, Flow {
             let didParseDeepLinkFromUrl: Bool = deepLinkingService.parseDeepLinkAndNotify(incomingDeepLink: .url(incomingUrl: IncomingDeepLinkUrl(url: url)))
             
             if !didParseDeepLinkFromUrl {
-                UIApplication.shared.open(url)
+                ExitAppToUrl.open(url: url)
             }
             
         case .learnToShareToolTappedFromToolDetails(let toolId, let primaryLanguage, let parallelLanguage, let selectedLanguageIndex):

--- a/godtools/App/Flows/Flow+NavigateToUrl/Flow+NavigateToUrl.swift
+++ b/godtools/App/Flows/Flow+NavigateToUrl/Flow+NavigateToUrl.swift
@@ -21,6 +21,6 @@ extension Flow {
             url: url
         )
                 
-        UIApplication.shared.open(url)
+        ExitAppToUrl.open(url: url)
     }
 }

--- a/godtools/App/Share/Common/ExitAppToUrl/ExitAppToUrl.swift
+++ b/godtools/App/Share/Common/ExitAppToUrl/ExitAppToUrl.swift
@@ -1,0 +1,25 @@
+//
+//  ExitAppToUrl.swift
+//  godtools
+//
+//  Created by Levi Eggert on 10/22/24.
+//  Copyright © 2024 Cru. All rights reserved.
+//
+
+import Foundation
+import UIKit
+import SwiftUI // TODO: Remove SwiftUI once udpating to FacebookSDK 17.3+ ~Levi
+
+class ExitAppToUrl {
+    
+    static func open(url: URL) {
+                
+        // TODO: Remove Environment once udpating to FacebookSDK 17.3+ ~Levi
+        // FBSDK uses method swizzling and is overriding UIApplication.shared.open(url) and within sdk version 16 is calling deprecated UIApplication.shared.openUrl. ~Levi
+        @Environment(\.openURL) var environmentOpenUrl
+        environmentOpenUrl(url)
+        
+        // TODO: Uncomment once udpating to FacebookSDK 17.3+ ~Levi
+        //UIApplication.shared.open(url)
+    }
+}


### PR DESCRIPTION
The Facebook SDK uses method swizzling on UIApplication open url and currently FBSDK 16 is using deprecated (https://developer.apple.com/documentation/uikit/uiapplication/1622961-openurl) which has caused open url to no longer work in iOS 18.  This is a temp fix to use SwiftUI until we upgrade to FBSDK 17.3+