### PR TITLE
GT-2456 fix tract tools expanding into navbar

### DIFF
--- a/godtools/App/Flows/DownloadToolTranslations/DownloadToolTranslationsFlow.swift
+++ b/godtools/App/Flows/DownloadToolTranslations/DownloadToolTranslationsFlow.swift
@@ -53,10 +53,10 @@ class DownloadToolTranslationsFlow: Flow {
         }, receiveValue: { [weak self] (toolTranslations: ToolTranslationsDomainModel) in
             
             if let downloadToolProgressView = self?.downloadToolProgressView {
-                
-                downloadToolProgressView.completeDownloadProgress {
-                    self?.dismissDownloadTool(completion: nil)
-                    self?.didDownloadToolTranslations(.success(toolTranslations))
+                downloadToolProgressView.completeDownloadProgress { [weak self] in
+                    self?.dismissDownloadTool(completion: { [weak self] in
+                        self?.didDownloadToolTranslations(.success(toolTranslations))
+                    })
                 }
             }
             else {

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/Pages/MobileContentPagesView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/Pages/MobileContentPagesView.swift
@@ -55,17 +55,9 @@ class MobileContentPagesView: AppViewController {
             return
         }
         didLayoutSubviews = true
-                
-        var safeAreaTopInset: CGFloat
-        let safeAreaBottomInset: CGFloat
-        
-        if #available(iOS 11.0, *) {
-            safeAreaTopInset = view.safeAreaInsets.top
-            safeAreaBottomInset = view.safeAreaInsets.bottom
-        } else {
-            safeAreaTopInset = topLayoutGuide.length
-            safeAreaBottomInset = bottomLayoutGuide.length
-        }
+                        
+        var safeAreaTopInset: CGFloat = view.safeAreaInsets.top
+        let safeAreaBottomInset: CGFloat = view.safeAreaInsets.bottom
         
         if safeAreaTopInset == 0 {
             safeAreaTopInset = safeAreaView.convert(.zero, to: nil).y


### PR DESCRIPTION
This fixes a bug where opening tools in iOS 18 the tool content would be rendered behind the navigation bar and wasn't respecting the safe area.  To trigger the bug you would have to open a tool that wasn't downloaded. For example, honor restored and power over fear tools.

The fix is to ensure the download tool modal is completely dismissed before navigating to a tool.  Not sure if this is just something buggy in iOS 18 since this wasn't an issue in iOS 16 and iOS 17. 