### PR TITLE
GT fix swiftui preview

### DIFF
--- a/godtools/App/Features/Dashboard/Presentation/Dashboard/DashboardView.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Dashboard/DashboardView.swift
@@ -100,14 +100,18 @@ import Combine
 
 struct DashboardView_Previews: PreviewProvider {
     
+    private static let diContainer: AppDiContainer = SwiftUIPreviewDiContainer().getAppDiContainer()
+    private static let flowDelegate: FlowDelegate = MockFlowDelegate()
+    private static let dashboardDependencies: DashboardPresentationLayerDependencies = DashboardPresentationLayerDependencies(appDiContainer: DashboardView_Previews.diContainer, flowDelegate: DashboardView_Previews.flowDelegate)
+        
     static func getDashboardViewModel() -> DashboardViewModel {
         
-        let appDiContainer: AppDiContainer = SwiftUIPreviewDiContainer().getAppDiContainer()
+        let appDiContainer: AppDiContainer = DashboardView_Previews.diContainer
         
         let viewModel = DashboardViewModel(
             startingTab: .favorites,
-            flowDelegate: MockFlowDelegate(),
-            dashboardPresentationLayerDependencies: DashboardPresentationLayerDependencies(appDiContainer: appDiContainer, flowDelegate: MockFlowDelegate()),
+            flowDelegate: DashboardView_Previews.flowDelegate,
+            dashboardPresentationLayerDependencies: DashboardView_Previews.dashboardDependencies,
             getCurrentAppLanguageUseCase: appDiContainer.feature.appLanguage.domainLayer.getCurrentAppLanguageUseCase(),
             viewDashboardUseCase: appDiContainer.feature.dashboard.domainLayer.getViewDashboardUseCase(), 
             dashboardTabObserver: CurrentValueSubject(.favorites)

--- a/godtools/App/Features/Dashboard/Presentation/Dashboard/DashboardView.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Dashboard/DashboardView.swift
@@ -102,16 +102,16 @@ struct DashboardView_Previews: PreviewProvider {
     
     private static let diContainer: AppDiContainer = SwiftUIPreviewDiContainer().getAppDiContainer()
     private static let flowDelegate: FlowDelegate = MockFlowDelegate()
-    private static let dashboardDependencies: DashboardPresentationLayerDependencies = DashboardPresentationLayerDependencies(appDiContainer: DashboardView_Previews.diContainer, flowDelegate: DashboardView_Previews.flowDelegate)
+    private static let dashboardDependencies: DashboardPresentationLayerDependencies = DashboardPresentationLayerDependencies(appDiContainer: Self.diContainer, flowDelegate: Self.flowDelegate)
         
     static func getDashboardViewModel() -> DashboardViewModel {
         
-        let appDiContainer: AppDiContainer = DashboardView_Previews.diContainer
+        let appDiContainer: AppDiContainer = Self.diContainer
         
         let viewModel = DashboardViewModel(
             startingTab: .favorites,
-            flowDelegate: DashboardView_Previews.flowDelegate,
-            dashboardPresentationLayerDependencies: DashboardView_Previews.dashboardDependencies,
+            flowDelegate: Self.flowDelegate,
+            dashboardPresentationLayerDependencies: Self.dashboardDependencies,
             getCurrentAppLanguageUseCase: appDiContainer.feature.appLanguage.domainLayer.getCurrentAppLanguageUseCase(),
             viewDashboardUseCase: appDiContainer.feature.dashboard.domainLayer.getViewDashboardUseCase(), 
             dashboardTabObserver: CurrentValueSubject(.favorites)
@@ -122,6 +122,6 @@ struct DashboardView_Previews: PreviewProvider {
     
     static var previews: some View {
     
-        DashboardView(viewModel: DashboardView_Previews.getDashboardViewModel())
+        DashboardView(viewModel: Self.getDashboardViewModel())
     }
 }

--- a/godtools/App/Services/Analytics/AppsFlyer/AppsFlyerAnalytics.swift
+++ b/godtools/App/Services/Analytics/AppsFlyer/AppsFlyerAnalytics.swift
@@ -48,9 +48,7 @@ class AppsFlyerAnalytics: NSObject {
     func trackAppLaunch() {
                     
         serialQueue.async { [weak self] in
-            
-            self?.assertFailureIfNotConfigured()
-        
+                    
             self?.appsFlyer.appsFlyerLib.start()
                         
             self?.log(method: "trackAppLaunch()", label: nil, labelValue: nil, data: nil)
@@ -60,17 +58,9 @@ class AppsFlyerAnalytics: NSObject {
     func trackAction(actionName: String, data: [String: Any]?) {
                 
         serialQueue.async { [weak self] in
-            
-            self?.assertFailureIfNotConfigured()
-            
+                        
             self?.appsFlyer.appsFlyerLib.logEvent(actionName, withValues: data)
             self?.log(method: "trackEvent()", label: "eventName", labelValue: actionName, data: data)
-        }
-    }
-    
-    private func assertFailureIfNotConfigured() {
-        if !isConfigured {
-            assertionFailure("AppsFlyer has not been configured.  Call configure() on application didFinishLaunching.")
         }
     }
     

--- a/godtools/App/Services/Analytics/Firebase/FirebaseAnalytics.swift
+++ b/godtools/App/Services/Analytics/Firebase/FirebaseAnalytics.swift
@@ -45,7 +45,6 @@ class FirebaseAnalytics {
     }
     
     func setLoggedInStateUserProperties(isLoggedIn: Bool, loggedInUserProperties: FirebaseAnalyticsLoggedInUserProperties?) {
-        assertFailureIfNotConfigured()
         
         let userId: String? = loggedInUserProperties?.grMasterPersonId ?? loggedInUserProperties?.ssoguid
         
@@ -104,16 +103,8 @@ class FirebaseAnalytics {
         )
     }
         
-    private func assertFailureIfNotConfigured() {
-        if !isConfigured {
-            assertionFailure("FirebaseAnalytics has not been configured.  Call configure() on application didFinishLaunching.")
-        }
-    }
-    
     private func internalTrackEvent(screenName: String?, siteSection: String?, siteSubSection: String?, appLanguage: String?, contentLanguage: String?, secondaryContentLanguage: String?, previousScreenName: String, eventName: String, data: [String: Any]?) {
-        
-        assertFailureIfNotConfigured()
-        
+                
         DispatchQueue.global().async { [weak self] in
             
             guard let firebaseAnalytics = self else {
@@ -176,7 +167,6 @@ class FirebaseAnalytics {
     }
     
     private func createBaseProperties(screenName: String?, siteSection: String?, siteSubSection: String?, appLanguage: String?, contentLanguage: String?, secondaryContentLanguage: String?, previousScreenName: String?) -> [String: String] {
-        assertFailureIfNotConfigured()
         
         var properties: [String: String] = [:]
                 

--- a/godtools/App/Share/Data/AppsFlyer/AppsFlyer.swift
+++ b/godtools/App/Share/Data/AppsFlyer/AppsFlyer.swift
@@ -22,14 +22,7 @@ class AppsFlyer {
     }
     
     var appsFlyerLib: AppsFlyerLib {
-        assertFailureIfNotConfigured()
         return sharedAppsFlyerLib
-    }
-    
-    private func assertFailureIfNotConfigured() {
-        if !isConfigured {
-            assertionFailure("AppsFlyer has not been configured.  Be sure to call configure on application didFinishLaunching.")
-        }
     }
     
     func configure(configuration: AppsFlyerConfiguration, deepLinkDelegate: DeepLinkDelegate) {


### PR DESCRIPTION
Fixed crashes in SwiftUI Preview. Mainly were caused by assertions. 

Actually it appears AppDelegate does run.  It's just that SwiftUI uses a different AppDiContainer so those analytics were never configured which caused the assertions. 
