### PR TITLE
GT-2429 fix start image logic

### DIFF
--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentTabs/MobileContentTabsViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentTabs/MobileContentTabsViewModel.swift
@@ -19,8 +19,4 @@ class MobileContentTabsViewModel: MobileContentViewModel {
         
         super.init(baseModel: tabsModel, renderedPageContext: renderedPageContext, mobileContentAnalytics: mobileContentAnalytics)
     }
-    
-    var languageDirectionSemanticContentAttribute: UISemanticContentAttribute {
-        return UISemanticContentAttribute.from(languageDirection: LanguageDirectionDomainModel(languageModel: renderedPageContext.language))
-    }
 }

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentText/MobileContentTextView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentText/MobileContentTextView.swift
@@ -69,6 +69,8 @@ class MobileContentTextView: MobileContentView, NibBased {
             loadNib()
         }
         
+        rootNibView?.semanticContentAttribute = viewModel.languageDirectionSemanticContentAttribute
+        
         setupBinding()
     }
     

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/MobileContentViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/MobileContentViewModel.swift
@@ -53,6 +53,10 @@ class MobileContentViewModel: NSObject {
         return renderedPageContext.language.direction == .leftToRight ? .left : .right
     }
     
+    var languageDirectionSemanticContentAttribute: UISemanticContentAttribute {
+        return UISemanticContentAttribute.from(languageDirection: LanguageDirectionDomainModel(languageModel: renderedPageContext.language))
+    }
+    
     func viewDidAppear(visibleAnalyticsEvents: [MobileContentRendererAnalyticsEvent]) {
         
         for event in visibleAnalyticsEvents {

--- a/godtools/App/Services/Renderer/Views/Tract/Views/CallToAction/TractPageCallToActionViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/Tract/Views/CallToAction/TractPageCallToActionViewModel.swift
@@ -20,7 +20,7 @@ class TractPageCallToActionViewModel: MobileContentViewModel {
         super.init(baseModel: callToActionModel, renderedPageContext: renderedPageContext, mobileContentAnalytics: mobileContentAnalytics)
     }
     
-    var languageDirectionSemanticContentAttribute: UISemanticContentAttribute {
+    override var languageDirectionSemanticContentAttribute: UISemanticContentAttribute {
         return UISemanticContentAttribute.from(languageDirection: LanguageDirectionDomainModel(languageModel: renderedPageContext.primaryRendererLanguage))
     }
     

--- a/godtools/App/Services/Renderer/Views/Tract/Views/Card/TractPageCardViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/Tract/Views/Card/TractPageCardViewModel.swift
@@ -144,10 +144,6 @@ class TractPageCardViewModel: MobileContentViewModel {
         return FontLibrary.systemUIFont(size: 18, weight: .regular)
     }
     
-    var languageDirectionSemanticContentAttribute: UISemanticContentAttribute {
-        return UISemanticContentAttribute.from(languageDirection: LanguageDirectionDomainModel(languageModel: renderedPageContext.language))
-    }
-    
     func containsDismissListener(eventId: EventId) -> Bool {
         return cardModel.dismissListeners.contains(eventId)
     }

--- a/godtools/App/Services/Renderer/Views/Tract/Views/Header/TractPageHeaderViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/Tract/Views/Header/TractPageHeaderViewModel.swift
@@ -28,10 +28,6 @@ class TractPageHeaderViewModel: MobileContentViewModel {
         }
     }
     
-    var languageDirectionSemanticContentAttribute: UISemanticContentAttribute {
-        return UISemanticContentAttribute.from(languageDirection: LanguageDirectionDomainModel(languageModel: renderedPageContext.language))
-    }
-    
     var backgroundColor: UIColor {
         return headerModel.backgroundColor
     }

--- a/godtools/App/Share/Protocols/NibBased.swift
+++ b/godtools/App/Share/Protocols/NibBased.swift
@@ -44,4 +44,8 @@ extension NibBased where Self: UIView {
                 
         return rootNibView
     }
+    
+    var rootNibView: UIView? {
+        return subviews.first
+    }
 }


### PR DESCRIPTION
Fixed the context-text start image to respect language direction:

Example in English:

![english](https://github.com/user-attachments/assets/f950f6e1-51ec-4ea2-9a89-73c51914ae07)


Example in Arabic:

![arabic-1](https://github.com/user-attachments/assets/b32de653-90a7-4933-ab33-dacd8db7ed27)
