### PR TITLE
GT-2488 decrease tool tile button padding

### DIFF
--- a/godtools/App/Features/Dashboard/Presentation/Tools/Subviews/ToolCard/ToolCardView.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Tools/Subviews/ToolCard/ToolCardView.swift
@@ -21,6 +21,7 @@ struct ToolCardView: View {
     private let navButtonWidth: CGFloat = 92
     private let navButtonHeight: CGFloat = 30
     private let navButtonSpacing: CGFloat = 8
+    private let navButtonTitleHorizontalPadding: CGFloat?
     private let contentHorizontalInsets: CGFloat = 15
     private let showsCategory: Bool
     private let accessibility: AccessibilityStrings.Button?
@@ -31,7 +32,7 @@ struct ToolCardView: View {
     
     @ObservedObject private var viewModel: ToolCardViewModel
     
-    init(viewModel: ToolCardViewModel, geometry: GeometryProxy, layout: ToolCardLayout, showsCategory: Bool, accessibility: AccessibilityStrings.Button?, favoriteTappedClosure: (() -> Void)?, toolDetailsTappedClosure: (() -> Void)?, openToolTappedClosure: (() -> Void)?, toolTappedClosure: (() -> Void)?) {
+    init(viewModel: ToolCardViewModel, geometry: GeometryProxy, layout: ToolCardLayout, showsCategory: Bool, navButtonTitleHorizontalPadding: CGFloat?, accessibility: AccessibilityStrings.Button?, favoriteTappedClosure: (() -> Void)?, toolDetailsTappedClosure: (() -> Void)?, openToolTappedClosure: (() -> Void)?, toolTappedClosure: (() -> Void)?) {
         
         var navButtons: [ToolCardNavButtonType] = Array()
         
@@ -50,6 +51,7 @@ struct ToolCardView: View {
         self.layout = layout
         self.navButtons = navButtons
         self.showsCategory = showsCategory
+        self.navButtonTitleHorizontalPadding = navButtonTitleHorizontalPadding
         self.accessibility = accessibility
         self.favoriteTappedClosure = favoriteTappedClosure
         self.toolDetailsTappedClosure = toolDetailsTappedClosure
@@ -147,12 +149,12 @@ struct ToolCardView: View {
                                 Spacer()
                             }
                             
-                            GTWhiteButton(title: viewModel.detailsButtonTitle, font: navButtonFont, width: navButtonWidth, height: navButtonHeight, accessibility: .toolDetails) {
+                            GTWhiteButton(title: viewModel.detailsButtonTitle, font: navButtonFont, width: navButtonWidth, height: navButtonHeight, titleHorizontalPadding: navButtonTitleHorizontalPadding, accessibility: .toolDetails) {
                                 
                                 toolDetailsTappedClosure?()
                             }
                             
-                            GTBlueButton(title: viewModel.openButtonTitle, font: navButtonFont, width: navButtonWidth, height: navButtonHeight, accessibility: .openTool) {
+                            GTBlueButton(title: viewModel.openButtonTitle, font: navButtonFont, width: navButtonWidth, height: navButtonHeight, titleHorizontalPadding: navButtonTitleHorizontalPadding, accessibility: .openTool) {
 
                                 openToolTappedClosure?()
                             }
@@ -224,6 +226,7 @@ struct ToolCardView_Previews: PreviewProvider {
                 geometry: geometry,
                 layout: .landscape,
                 showsCategory: true,
+                navButtonTitleHorizontalPadding: nil,
                 accessibility: nil,
                 favoriteTappedClosure: nil,
                 toolDetailsTappedClosure: nil,

--- a/godtools/App/Features/Dashboard/Presentation/Tools/Subviews/ToolSpotlight/ToolSpotlightView.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Tools/Subviews/ToolSpotlight/ToolSpotlightView.swift
@@ -51,6 +51,7 @@ struct ToolSpotlightView: View {
                             geometry: geometry,
                             layout: .thumbnail,
                             showsCategory: false,
+                            navButtonTitleHorizontalPadding: nil,
                             accessibility: .spotlightTool,
                             favoriteTappedClosure: {
                                 

--- a/godtools/App/Features/Dashboard/Presentation/Tools/ToolsView.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Tools/ToolsView.swift
@@ -71,6 +71,7 @@ struct ToolsView: View {
                                     geometry: geometry,
                                     layout: .landscape,
                                     showsCategory: true,
+                                    navButtonTitleHorizontalPadding: nil,
                                     accessibility: .tool,
                                     favoriteTappedClosure: {
                                         

--- a/godtools/App/Features/Favorites/Presentation/AllYourFavoriteTools/AllYourFavoriteToolsView.swift
+++ b/godtools/App/Features/Favorites/Presentation/AllYourFavoriteTools/AllYourFavoriteToolsView.swift
@@ -45,6 +45,7 @@ struct AllYourFavoriteToolsView: View {
                                 geometry: geometry,
                                 layout: .landscape,
                                 showsCategory: true,
+                                navButtonTitleHorizontalPadding: YourFavoriteToolsView.toolCardNavButtonTitleHorizontalPadding,
                                 accessibility: .favoriteTool,
                                 favoriteTappedClosure: {
                                     

--- a/godtools/App/Features/Favorites/Presentation/Favorites/Subviews/YourFavoriteTools/YourFavoriteToolsView.swift
+++ b/godtools/App/Features/Favorites/Presentation/Favorites/Subviews/YourFavoriteTools/YourFavoriteToolsView.swift
@@ -9,7 +9,9 @@
 import SwiftUI
 
 struct YourFavoriteToolsView: View {
-        
+       
+    static let toolCardNavButtonTitleHorizontalPadding: CGFloat = 5
+    
     private let geometry: GeometryProxy
     private let contentHorizontalInsets: CGFloat
     private let toolCardSpacing: CGFloat
@@ -47,6 +49,7 @@ struct YourFavoriteToolsView: View {
                                 geometry: geometry,
                                 layout: .thumbnail,
                                 showsCategory: true,
+                                navButtonTitleHorizontalPadding: Self.toolCardNavButtonTitleHorizontalPadding,
                                 accessibility: .favoriteTool,
                                 favoriteTappedClosure: {
                                     

--- a/godtools/App/Share/SwiftUI Views/GTBlueButton/GTBlueButton.swift
+++ b/godtools/App/Share/SwiftUI Views/GTBlueButton/GTBlueButton.swift
@@ -15,16 +15,20 @@ struct GTBlueButton: View {
     let width: CGFloat
     let height: CGFloat
     let cornerRadius: CGFloat
+    let titleHorizontalPadding: CGFloat?
+    let titleVerticalPadding: CGFloat?
     let highlightsTitleOnTap: Bool
     let accessibility: AccessibilityStrings.Button?
     let action: () -> Void
     
-    init(title: String, font: Font? = nil, fontSize: CGFloat? = nil, width: CGFloat, height: CGFloat, cornerRadius: CGFloat = 6, highlightsTitleOnTap: Bool = true, accessibility: AccessibilityStrings.Button? = nil, action: @escaping () -> Void) {
+    init(title: String, font: Font? = nil, fontSize: CGFloat? = nil, width: CGFloat, height: CGFloat, cornerRadius: CGFloat = 6, titleHorizontalPadding: CGFloat? = nil, titleVerticalPadding: CGFloat? = nil, highlightsTitleOnTap: Bool = true, accessibility: AccessibilityStrings.Button? = nil, action: @escaping () -> Void) {
         
         self.title = title
         self.width = width
         self.height = height
         self.cornerRadius = cornerRadius
+        self.titleHorizontalPadding = titleHorizontalPadding
+        self.titleVerticalPadding = titleVerticalPadding
         self.highlightsTitleOnTap = highlightsTitleOnTap
         self.accessibility = accessibility
         self.action = action
@@ -80,7 +84,8 @@ struct GTBlueButton: View {
         Text(title)
             .font(font)
             .foregroundColor(Color.white)
-            .padding()
+            .padding([.leading, .trailing], titleHorizontalPadding)
+            .padding([.top, .bottom], titleVerticalPadding)
     }
 }
 

--- a/godtools/App/Share/SwiftUI Views/GTWhiteButton/GTWhiteButton.swift
+++ b/godtools/App/Share/SwiftUI Views/GTWhiteButton/GTWhiteButton.swift
@@ -17,13 +17,17 @@ struct GTWhiteButton: View {
     let width: CGFloat
     let height: CGFloat
     let cornerRadius: CGFloat
+    let titleHorizontalPadding: CGFloat?
+    let titleVerticalPadding: CGFloat?
     let action: () -> Void
     
-    init(title: String, font: Font? = nil, fontSize: CGFloat? = nil, width: CGFloat, height: CGFloat, cornerRadius: CGFloat = 6, accessibility: AccessibilityStrings.Button? = nil, action: @escaping () -> Void) {
+    init(title: String, font: Font? = nil, fontSize: CGFloat? = nil, width: CGFloat, height: CGFloat, cornerRadius: CGFloat = 6, titleHorizontalPadding: CGFloat? = nil, titleVerticalPadding: CGFloat? = nil, accessibility: AccessibilityStrings.Button? = nil, action: @escaping () -> Void) {
         self.title = title
         self.width = width
         self.height = height
         self.cornerRadius = cornerRadius
+        self.titleHorizontalPadding = titleHorizontalPadding
+        self.titleVerticalPadding = titleVerticalPadding
         self.accessibility = accessibility
         self.action = action
         
@@ -58,7 +62,8 @@ struct GTWhiteButton: View {
                 Text(title)
                     .font(font)
                     .foregroundColor(ColorPalette.gtBlue.color)
-                    .padding()
+                    .padding([.leading, .trailing], titleHorizontalPadding)
+                    .padding([.top, .bottom], titleVerticalPadding)
             }
         }
         .frame(width: width, height: height, alignment: .center)


### PR DESCRIPTION
Decreased the tool card details and open button title padding to 5 points for the favorites tool cards.

By default SwiftUI uses a system defined value when applying padding, so ended up going with 5 points (https://developer.apple.com/documentation/swiftui/view/padding(_:_:)).