### PR TITLE
GT-2478 Fix Fuzi crash in Xcode 16.2

### DIFF
--- a/godtools/App/Share/Data/WebArchiveQueue/WebArchiveOperation.swift
+++ b/godtools/App/Share/Data/WebArchiveQueue/WebArchiveOperation.swift
@@ -225,9 +225,12 @@ class WebArchiveOperation: Operation, @unchecked Sendable {
                 do {
                     let webArchiveResource: WebArchiveResource = WebArchiveResource(url: url, data: data, mimeType: mimeType)
                     let mainResource: WebArchiveMainResource = WebArchiveMainResource(baseResource: webArchiveResource)
-                    //let htmlDocument: HTMLDocument = try HTMLDocument(string: htmlString, encoding: .utf8) // NOTE: Was getting a bad access starting in Xcode 16.2 (https://github.com/cezheng/Fuzi/issues/130). ~Levi
-                    let htmlDocumentWrapper = try HTMLDocumentWrapper(string: htmlString, encoding: .utf8)
-                    let resourceUrls: [String] = htmlDocumentWrapper.htmlDocument.getHTMLReferences(host: host, includeJavascript: includeJavascript)
+                    
+                    // NOTE: Using HTMLDocumentWrapper for now with open PR fix until merged and Fuzi is updated. ~Levi
+                    // TODO: GT-2492 Remove HTMLDocumentWrapper once PR is merged. ~Levi
+                    //let htmlDocument: HTMLDocument = try HTMLDocument(string: htmlString, encoding: .utf8)
+                    let htmlDocument: HTMLDocument = try HTMLDocumentWrapper(string: htmlString, encoding: .utf8).htmlDocument
+                    let resourceUrls: [String] = htmlDocument.getHTMLReferences(host: host, includeJavascript: includeJavascript)
                     complete(.success(HTMLDocumentData(mainResource: mainResource, resourceUrls: resourceUrls)))
                 }
                 catch let parseHtmlDocumentError {


### PR DESCRIPTION
Temp fix for HTMLDocument currently crashing in Xcode 16.2.

Basically copied this open PR fix (https://github.com/cezheng/Fuzi/pull/131/files) into a wrapper class that can be used for now. 

Created ticket to remove wrapper once Fuzi is updated. (https://jira.cru.org/browse/GT-2492)