### PR TITLE
GT-1603 Fix to content image sizing in renderer stack

### DIFF
--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentStack/MobileContentStackView.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/ContentStack/MobileContentStackView.swift
@@ -812,8 +812,21 @@ extension MobileContentStackView {
     
     private func addWidthAndHeightConstraintsToChildViewWithMaxWidthSize(childView: MobileContentView, maxWidthSize: CGFloat, maintainsAspectRatioSize: CGSize?) {
         
-        let size: CGSize = calculateSizeFromWidth(width: maxWidthSize, maintainsAspectRatioSize: maintainsAspectRatioSize)
-        let clampedSize: CGSize = clampSizeToChildrenParentSizeAndInsets(size: size)
+        let parentWidth: CGFloat = childrenParentView.frame.size.width
+        let parentWidthMinusContentHorizontalInsets: CGFloat = parentWidth - (contentInsets.left + contentInsets.right)
+        let clampedMaxWidthSizeForHorizontalInsets: CGFloat
+        
+        if maxWidthSize > parentWidthMinusContentHorizontalInsets {
+            clampedMaxWidthSizeForHorizontalInsets = parentWidthMinusContentHorizontalInsets
+        }
+        else {
+            clampedMaxWidthSizeForHorizontalInsets = maxWidthSize
+        }
+        
+        let size: CGSize = calculateSizeFromWidth(
+            width: clampedMaxWidthSizeForHorizontalInsets,
+            maintainsAspectRatioSize: maintainsAspectRatioSize
+        )
         
         var widthConstraint: NSLayoutConstraint?
         var heightConstraint: NSLayoutConstraint?
@@ -833,17 +846,17 @@ extension MobileContentStackView {
         }
         
         if let widthConstraint = widthConstraint {
-            widthConstraint.constant = clampedSize.width
+            widthConstraint.constant = size.width
         }
         else {
-            _ = childView.addWidthConstraint(constant: clampedSize.width, priority: 1000)
+            _ = childView.addWidthConstraint(constant: size.width, priority: 1000)
         }
         
         if let heightConstraint = heightConstraint {
-            heightConstraint.constant = clampedSize.height
+            heightConstraint.constant = size.height
         }
         else {
-            _ = childView.addHeightConstraint(constant: clampedSize.height, priority: 1000)
+            _ = childView.addHeightConstraint(constant: size.height, priority: 1000)
         }
     }
     
@@ -865,31 +878,6 @@ extension MobileContentStackView {
         }
         
         return CGSize(width: width, height: height)
-    }
-    
-    private func clampSizeToChildrenParentSizeAndInsets(size: CGSize) -> CGSize {
-        
-        let parentWidth: CGFloat = childrenParentView.frame.size.width
-        let parentWidthMinusContentInsets: CGFloat = parentWidth - (contentInsets.left + contentInsets.right)
-        
-        let pointsToTrim: CGFloat
-        
-        if size.width > parentWidthMinusContentInsets && parentWidthMinusContentInsets > 0 {
-            pointsToTrim = size.width - parentWidthMinusContentInsets
-        }
-        else if size.width > parentWidth && parentWidth > 0 {
-            pointsToTrim = size.width - parentWidth
-        }
-        else {
-            pointsToTrim = 0
-        }
-        
-        let clampedSize: CGSize = CGSize(
-            width: floor(size.width - pointsToTrim),
-            height: floor(size.height - pointsToTrim)
-        )
-                
-        return clampedSize
     }
 }
 


### PR DESCRIPTION
When attaching images to a vertical stack in the renderer, the max image width is clamped to the width of the stack minus content insets.

The issue was when clamping the max image width the difference in the content insets was also getting applied to the clamped height and this was getting done after resizing the image to the max width of the stack.

Needed to clamp the image width first and only the width and then resize the image to scale based on the clamped width.

Invalid clamping and resizing of image.
![lesson-check-clamping-height](https://github.com/user-attachments/assets/6e5c4c9e-ea0f-48c2-9162-775be9dd75bc)

Fix which clamps max width first and then resizes the image.
![lesson-check-mark](https://github.com/user-attachments/assets/c3e000d3-a548-4247-a978-778a9db5b895)
