### PR TITLE
GT-1628 change tool language in screen share from tool settings

### DIFF
--- a/godtools/App/Features/Dashboard/Presentation/Tract/TractView.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Tract/TractView.swift
@@ -62,7 +62,7 @@ class TractView: MobileContentRendererView {
                     return
                 }
                 
-                self?.viewModel.sendRemoteShareNavigationEvent(
+                weakSelf.viewModel.sendRemoteShareNavigationEvent(
                     page:  weakSelf.pageNavigationView.getCurrentPage(),
                     pagePositions: tractPagePositions
                 )

--- a/godtools/App/Features/Dashboard/Presentation/Tract/TractView.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Tract/TractView.swift
@@ -7,10 +7,13 @@
 //
 
 import UIKit
+import Combine
 
 class TractView: MobileContentRendererView {
     
     private let viewModel: TractViewModel
+    
+    private var cancellables: Set<AnyCancellable> = Set()
                     
     init(viewModel: TractViewModel, navigationBar: AppNavigationBar?) {
         self.viewModel = viewModel
@@ -46,6 +49,25 @@ class TractView: MobileContentRendererView {
                 toolView.viewModel.subscribedForRemoteSharePublishing(page: page, pagePositions: tractPagePositions)
             }
         }
+        
+        viewModel.$toolSettingsDidClose
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] (didClose: Void?) in
+                
+                guard let weakSelf = self, didClose != nil else {
+                    return
+                }
+                
+                guard let tractPagePositions = weakSelf.getCurrentPagePositions() as? TractPagePositions else {
+                    return
+                }
+                
+                self?.viewModel.sendRemoteShareNavigationEvent(
+                    page:  weakSelf.pageNavigationView.getCurrentPage(),
+                    pagePositions: tractPagePositions
+                )
+            }
+            .store(in: &cancellables)
     }
     
     override func didConfigurePageView(pageView: MobileContentPageView) {

--- a/godtools/App/Flows/ChooseYourOwnAdventure/ChooseYourOwnAdventureFlow.swift
+++ b/godtools/App/Flows/ChooseYourOwnAdventure/ChooseYourOwnAdventureFlow.swift
@@ -55,7 +55,7 @@ class ChooseYourOwnAdventureFlow: ToolNavigationFlow, ToolSettingsNavigationFlow
         switch step {
         case .toolSettingsTappedFromChooseYourOwnAdventure(let toolSettingsObserver):
             
-            openToolSettings(with: toolSettingsObserver)
+            openToolSettings(toolSettingsObserver: toolSettingsObserver, toolSettingsDidCloseClosure: nil)
             
         case .toolSettingsFlowCompleted( _):
             

--- a/godtools/App/Flows/Flow/FlowStep.swift
+++ b/godtools/App/Flows/Flow/FlowStep.swift
@@ -86,7 +86,7 @@ enum FlowStep {
     // tool
     case homeTappedFromTool(isScreenSharing: Bool)
     case backTappedFromTool
-    case toolSettingsTappedFromTool(toolSettingsObserver: ToolSettingsObserver)
+    case toolSettingsTappedFromTool(toolSettingsObserver: ToolSettingsObserver, toolSettingsDidCloseClosure: (() -> Void)?)
     case tractFlowCompleted(state: TractFlowCompletedState)
     case acceptTappedFromExitToolRemoteShare
         

--- a/godtools/App/Flows/ToolSettings/ToolSettingsFlow.swift
+++ b/godtools/App/Flows/ToolSettings/ToolSettingsFlow.swift
@@ -13,6 +13,7 @@ import Combine
 class ToolSettingsFlow: Flow {
     
     private let toolSettingsObserver: ToolSettingsObserver
+    private let toolSettingsDidCloseClosure: (() -> Void)?
     
     private var toolScreenShareFlow: ToolScreenShareFlow?
     private var languagesListModal: UIViewController?
@@ -29,12 +30,13 @@ class ToolSettingsFlow: Flow {
     let appDiContainer: AppDiContainer
     let navigationController: AppNavigationController
     
-    init(flowDelegate: FlowDelegate, appDiContainer: AppDiContainer, sharedNavigationController: AppNavigationController, toolSettingsObserver: ToolSettingsObserver) {
+    init(flowDelegate: FlowDelegate, appDiContainer: AppDiContainer, sharedNavigationController: AppNavigationController, toolSettingsObserver: ToolSettingsObserver, toolSettingsDidCloseClosure: (() -> Void)? = nil) {
             
         self.flowDelegate = flowDelegate
         self.appDiContainer = appDiContainer
         self.navigationController = sharedNavigationController
         self.toolSettingsObserver = toolSettingsObserver
+        self.toolSettingsDidCloseClosure = toolSettingsDidCloseClosure
         
         let getToolScreenShareTutorialHasBeenViewedUseCase: GetToolScreenShareTutorialHasBeenViewedUseCase = appDiContainer.feature.toolScreenShare.domainLayer.getToolScreenShareTutorialHasBeenViewedUseCase()
                 
@@ -83,6 +85,10 @@ class ToolSettingsFlow: Flow {
         )
         
         return transparentModal
+    }
+    
+    func didClose() {
+        toolSettingsDidCloseClosure?()
     }
     
     func navigate(step: FlowStep) {

--- a/godtools/App/Flows/ToolSettingsNavigationFlow/ToolSettingsNavigationFlow.swift
+++ b/godtools/App/Flows/ToolSettingsNavigationFlow/ToolSettingsNavigationFlow.swift
@@ -15,12 +15,13 @@ protocol ToolSettingsNavigationFlow: Flow {
 
 extension ToolSettingsNavigationFlow {
     
-    func openToolSettings(with toolSettingsObserver: ToolSettingsObserver) {
+    func openToolSettings(toolSettingsObserver: ToolSettingsObserver, toolSettingsDidCloseClosure: (() -> Void)?) {
         let toolSettingsFlow = ToolSettingsFlow(
             flowDelegate: self,
             appDiContainer: appDiContainer,
             sharedNavigationController: navigationController,
-            toolSettingsObserver: toolSettingsObserver
+            toolSettingsObserver: toolSettingsObserver,
+            toolSettingsDidCloseClosure: toolSettingsDidCloseClosure
         )
         
         navigationController.present(toolSettingsFlow.getInitialView(), animated: true)
@@ -33,9 +34,11 @@ extension ToolSettingsNavigationFlow {
         guard toolSettingsFlow != nil else {
             return
         }
-    
-        navigationController.dismiss(animated: true)
         
-        toolSettingsFlow = nil
+        navigationController.dismissPresented(animated: true) { [weak self] in
+            
+            self?.toolSettingsFlow?.didClose()
+            self?.toolSettingsFlow = nil
+        }
     }
 }

--- a/godtools/App/Flows/Tract/TractFlow.swift
+++ b/godtools/App/Flows/Tract/TractFlow.swift
@@ -96,9 +96,9 @@ class TractFlow: ToolNavigationFlow, ToolSettingsNavigationFlow {
         case .backTappedFromTool:
             closeTool()
             
-        case .toolSettingsTappedFromTool(let toolSettingsObserver):
+        case .toolSettingsTappedFromTool(let toolSettingsObserver, let toolSettingsDidCloseClosure):
                     
-            openToolSettings(with: toolSettingsObserver)
+            openToolSettings(toolSettingsObserver: toolSettingsObserver, toolSettingsDidCloseClosure: toolSettingsDidCloseClosure)
             
         case .toolSettingsFlowCompleted( _):
             
@@ -163,6 +163,7 @@ extension TractFlow {
             renderer: renderer,
             tractRemoteSharePublisher: appDiContainer.feature.toolScreenShare.dataLayer.getTractRemoteSharePublisher(),
             tractRemoteShareSubscriber: appDiContainer.feature.toolScreenShare.dataLayer.getTractRemoteShareSubscriber(),
+            languagesRepository: appDiContainer.dataLayer.getLanguagesRepository(),
             resourceViewsService: appDiContainer.dataLayer.getResourceViewsService(),
             trackActionAnalyticsUseCase: appDiContainer.domainLayer.getTrackActionAnalyticsUseCase(),
             resourcesRepository: appDiContainer.dataLayer.getResourcesRepository(),


### PR DESCRIPTION
Allows for the language to be changed from tool settings during a screen share.
- When closing tool settings the publisher will send a screen share navigation event.
- The subscriber can now handle any locale given to it from the publisher as long as it exists in the LanguagesRepository. 