### PR TITLE
GT-2478 When sync is called on ToolLanguageDownloader, mark all downloadable languages as downloaded

### DIFF
--- a/godtools/App/Features/AppLanguage/Data/DownloadedLanguagesRepository/Cache/RealmDownloadedLanguagesCache.swift
+++ b/godtools/App/Features/AppLanguage/Data/DownloadedLanguagesRepository/Cache/RealmDownloadedLanguagesCache.swift
@@ -122,4 +122,27 @@ class RealmDownloadedLanguagesCache {
         )
         .eraseToAnyPublisher()
     }
+    
+    func markAllDownloadsAsCompleted() {
+            
+        let realm: Realm = realmDatabase.openRealm()
+        
+        let nonCompletedDownloads = realm
+            .objects(RealmDownloadedLanguage.self)
+            .where { $0.downloadComplete == false }
+        
+        let languagesIds: [String] = nonCompletedDownloads.map {
+            $0.languageId
+        }
+        print(languagesIds)
+        
+        _ = realmDatabase.writeObjects(realm: realm, updatePolicy: .modified) { realm in
+            
+            for language in nonCompletedDownloads {
+                language.downloadComplete = true
+            }
+            
+            return Array(nonCompletedDownloads)
+        }
+    }
 }

--- a/godtools/App/Features/AppLanguage/Data/DownloadedLanguagesRepository/DownloadedLanguagesRepository.swift
+++ b/godtools/App/Features/AppLanguage/Data/DownloadedLanguagesRepository/DownloadedLanguagesRepository.swift
@@ -52,4 +52,8 @@ class DownloadedLanguagesRepository {
         
         return cache.deleteDownloadedLanguagePublisher(languageId: languageId)
     }
+    
+    func markAllDownloadsAsCompleted() {
+        cache.markAllDownloadsAsCompleted()
+    }
 }

--- a/godtools/App/Features/AppLanguage/Data/ToolLanguageDownloader/ToolLanguageDownloader.swift
+++ b/godtools/App/Features/AppLanguage/Data/ToolLanguageDownloader/ToolLanguageDownloader.swift
@@ -50,9 +50,11 @@ class ToolLanguageDownloader {
     
     func syncDownloadedLanguagesPublisher() -> AnyPublisher<Void, Error> {
         
-        return downloadedLanguagesRepository.getDownloadedLanguagesPublisher(completedDownloadsOnly: false)
+        downloadedLanguagesRepository.markAllDownloadsAsCompleted()
+        
+        return downloadedLanguagesRepository.getDownloadedLanguagesPublisher(completedDownloadsOnly: true)
             .flatMap({ (downloadedLanguages: [DownloadedLanguageDataModel]) -> AnyPublisher<Void, Error> in
-                                
+                                         
                 let downloadToolLanguageRequests: [AnyPublisher<ToolDownloaderDataModel, Error>] = downloadedLanguages.map({
                     self.downloadToolLanguagePublisher(languageId: $0.languageId)
                 })


### PR DESCRIPTION
The ToolLanguageDownloader sync will run anytime the app is launched from a terminated state or launched from the background past 2 hours or more.

It will fetch downloadable languages from the DownloadedLanguagesRepository and download new data (translations, attachments, articles, etc.).

When this is run I think it's a good idea to mark any downloadable language in DownloadedLanguagesRepository as downloaded completed = true.  This way if a user was downloading some languages and they either closed the app or were on a slow network connection and closed the app, the next time they launch the app the sync would mark those as completed and begin downloading data again in the background.

If they were to open up the list of downloadable languages they would see those languages they tapped on as completed.