### PR TITLE
GT-2478 add timer publisher

### DIFF
--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -612,6 +612,7 @@
 		457766F92AD72DF70093B19A /* GetToolDetailsLearnToShareToolIsAvailableUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 457766F82AD72DF70093B19A /* GetToolDetailsLearnToShareToolIsAvailableUseCase.swift */; };
 		457766FB2AD72F3C0093B19A /* GetToolDetailsLearnToShareToolIsAvailableRepositoryInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 457766FA2AD72F3C0093B19A /* GetToolDetailsLearnToShareToolIsAvailableRepositoryInterface.swift */; };
 		457766FD2AD72F590093B19A /* GetToolDetailsLearnToShareToolIsAvailableRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 457766FC2AD72F590093B19A /* GetToolDetailsLearnToShareToolIsAvailableRepository.swift */; };
+		457772562D661FC800AC02CB /* SwiftUITimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 457772542D661FC800AC02CB /* SwiftUITimer.swift */; };
 		4578783027C41C08004552D5 /* MobileContentBackgroundImageAlignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4578782F27C41C08004552D5 /* MobileContentBackgroundImageAlignment.swift */; };
 		4578783527C41C50004552D5 /* BackgroundImageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4578783327C41C50004552D5 /* BackgroundImageModel.swift */; };
 		4578ED2A2D4C2A190032EFD5 /* MobileContentRendererView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4578ED292D4C2A130032EFD5 /* MobileContentRendererView.swift */; };
@@ -2308,6 +2309,7 @@
 		457766F82AD72DF70093B19A /* GetToolDetailsLearnToShareToolIsAvailableUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetToolDetailsLearnToShareToolIsAvailableUseCase.swift; sourceTree = "<group>"; };
 		457766FA2AD72F3C0093B19A /* GetToolDetailsLearnToShareToolIsAvailableRepositoryInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetToolDetailsLearnToShareToolIsAvailableRepositoryInterface.swift; sourceTree = "<group>"; };
 		457766FC2AD72F590093B19A /* GetToolDetailsLearnToShareToolIsAvailableRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetToolDetailsLearnToShareToolIsAvailableRepository.swift; sourceTree = "<group>"; };
+		457772542D661FC800AC02CB /* SwiftUITimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUITimer.swift; sourceTree = "<group>"; };
 		4578782F27C41C08004552D5 /* MobileContentBackgroundImageAlignment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MobileContentBackgroundImageAlignment.swift; sourceTree = "<group>"; };
 		4578783327C41C50004552D5 /* BackgroundImageModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackgroundImageModel.swift; sourceTree = "<group>"; };
 		4578ED292D4C2A130032EFD5 /* MobileContentRendererView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileContentRendererView.swift; sourceTree = "<group>"; };
@@ -6688,6 +6690,14 @@
 			path = ContentFlowRow;
 			sourceTree = "<group>";
 		};
+		457772552D661FC800AC02CB /* SwiftUITimer */ = {
+			isa = PBXGroup;
+			children = (
+				457772542D661FC800AC02CB /* SwiftUITimer.swift */,
+			);
+			path = SwiftUITimer;
+			sourceTree = "<group>";
+		};
 		4578782E27C41C08004552D5 /* Models */ = {
 			isa = PBXGroup;
 			children = (
@@ -8608,6 +8618,7 @@
 				45EB9B4429F16CF200CA74A8 /* SharedAppleExtensions */,
 				D4670B0A2AFAA17C00FAD896 /* StringSearcher */,
 				458539372C57DEF200748BAF /* StringWithLocaleCount */,
+				457772552D661FC800AC02CB /* SwiftUITimer */,
 				45E4DBB52BECFB09006ED2F3 /* SyncInvalidator */,
 				456DA4EF2CC96ADE004BFB1E /* UrlOpener */,
 				45D63E54288F67F8009B4610 /* URLSession */,
@@ -13431,6 +13442,7 @@
 				45F7167B290A13530019B715 /* EmailSignUpModelType.swift in Sources */,
 				45B6FF322BAA39720037B240 /* GetToolFilterLanguagesRepositoryInterface.swift in Sources */,
 				45C2AF412A81730B004958AB /* LearnToShareToolItemAssetContent.swift in Sources */,
+				457772562D661FC800AC02CB /* SwiftUITimer.swift in Sources */,
 				4534F93C2AE9B11600A7A071 /* LessonEvaluationRealmCache.swift in Sources */,
 				45EA5AA72B22473700D9E330 /* GetToolSettingsInterfaceStringsRepositoryInterface.swift in Sources */,
 				455582E3269F2C1000C3FF14 /* TrainingTipViewType.swift in Sources */,

--- a/godtools/App/Features/AppLanguage/Presentation/DownloadableLanguages/DownloadableLanguagesView.swift
+++ b/godtools/App/Features/AppLanguage/Presentation/DownloadableLanguages/DownloadableLanguagesView.swift
@@ -28,10 +28,11 @@ struct DownloadableLanguagesView: View {
             List {
                 ForEach(viewModel.displayedDownloadableLanguages) { downloadableLanguage in
                     
-                    DownloadableLanguageItemView(downloadableLanguage: downloadableLanguage) {
-                        
-                        downloadableLanguageTapped(downloadableLanguage: downloadableLanguage)
-                    }
+                    DownloadableLanguageItemView(downloadableLanguage: downloadableLanguage, tappedClosure: {
+                        self.downloadableLanguageTapped(downloadableLanguage: downloadableLanguage)
+                    }, removeTapped: {
+                        self.viewModel.removeDownloadedLanguage(downloadableLanguage)
+                    })
                     .listRowBackground(Color.clear)
                 }
             }
@@ -54,7 +55,7 @@ struct DownloadableLanguagesView: View {
             break
             
         case .downloaded:
-            viewModel.removeDownloadedLanguage(downloadableLanguage)
+            break
         }
     }
 }

--- a/godtools/App/Share/Common/SwiftUITimer/SwiftUITimer.swift
+++ b/godtools/App/Share/Common/SwiftUITimer/SwiftUITimer.swift
@@ -1,0 +1,111 @@
+//
+//  SwiftUITimer.swift
+//  SwiftUIViewTimer
+//
+//  Created by Levi Eggert on 2/13/25.
+//
+
+import Foundation
+import Combine
+
+class SwiftUITimer: ObservableObject {
+    
+    private static let defaultRunLoop: RunLoop = .main
+    private static let defaultRunLoopMode: RunLoop.Mode = .common
+    
+    private let intervalSeconds: TimeInterval
+    private let repeats: Bool
+    
+    private var timerPublisher: Timer.TimerPublisher
+    private var timerPublisherCancellable: Cancellable?
+    private var cancellables: Set<AnyCancellable> = Set()
+    private var timerHandledOnce: Bool = false
+    
+    @Published private(set) var isRunning: Bool = false
+    
+    init(intervalSeconds: TimeInterval, repeats: Bool = true) {
+        
+        self.timerPublisher = Self.createNewTimerPublisher(
+            intervalSeconds: intervalSeconds
+        )
+        
+        self.intervalSeconds = intervalSeconds
+        self.repeats = repeats
+    }
+    
+    deinit {
+        invalidate()
+    }
+    
+    static private func createNewTimerPublisher(intervalSeconds: TimeInterval, runLoop: RunLoop? = nil, runLoopMode: RunLoop.Mode? = nil) -> Timer.TimerPublisher {
+        
+        return Timer.publish(
+            every: intervalSeconds,
+            on: runLoop ?? Self.defaultRunLoop,
+            in: runLoopMode ?? Self.defaultRunLoopMode
+        )
+    }
+    
+    private func newTimerPublisher() -> Timer.TimerPublisher {
+        
+        return Self.createNewTimerPublisher(
+            intervalSeconds: intervalSeconds
+        )
+    }
+    
+    private func handleInternalTimerInterval() {
+        
+        timerHandledOnce = true
+                
+        if timerHandledOnce && repeats == false {
+            stop()
+        }
+    }
+    
+    var publisher: Timer.TimerPublisher {
+        return timerPublisher
+    }
+    
+    func toggle() {
+        
+        isRunning ? stop() : start()
+    }
+    
+    func start() {
+        
+        stop()
+        
+        isRunning = true
+        
+        timerPublisher = newTimerPublisher()
+        
+        timerPublisher
+        .sink { [weak self] _ in
+            self?.handleInternalTimerInterval()
+        }
+        .store(in: &cancellables)
+        
+        timerPublisherCancellable = timerPublisher.connect()
+    }
+    
+    func startPublisher() -> AnyPublisher<Date, Never> {
+        
+        start()
+        
+        return timerPublisher
+            .eraseToAnyPublisher()
+    }
+    
+    func stop() {
+        
+        isRunning = false
+        
+        timerPublisherCancellable?.cancel()
+        
+        timerHandledOnce = false
+    }
+    
+    func invalidate() {
+        stop()
+    }
+}


### PR DESCRIPTION
Changes in this PR:
- Replacing download removal timer with Timer.TimerPublisher. In SwiftUI use the ```onReceive``` modifier to listen for the Timer publisher.
- Changed  attribute name shouldConfirmDownloadRemoval to isMarkedForRemoval.
- Added a method to set the isMarkedForRemoval state which handles starting and stopping the timer.
- Added a removeTapped closure that the parent View can listen for.  I feel this gives a little better direction and readability for the parent view.  I noticed prior to this change the parent view would call remove on the downloaded state (https://github.com/CruGlobal/godtools-swift/blob/develop/godtools/App/Features/AppLanguage/Presentation/DownloadableLanguages/DownloadableLanguagesView.swift#L57) which is less inaccurate.  Although this worked, it was dependent on the Subview invoking the tappedClosure at the right time. 
- Removed the call to cancel the remove timer on the View onDisappear.  I noticed if you scroll away and then back the removal will no longer be available.  I'm not sure if that's intended.  It seems it should be available as long as the timer is running.

Differences and benefits to using Timer.TimerPublisher vs Timer in SwiftUI.
- I noticed that scrolling a ScrollView causes Timers to pause.  By creating the Timer.TimerPublisher with run loop mode ```common``` it doesn't block the Timer when scrolling the ScrollView.