### PR TITLE
GT-2508 cyoa support inserting parent page on back navigation

### DIFF
--- a/godtools/App/Features/Dashboard/Presentation/ChooseYourOwnAdventure/ChooseYourOwnAdventureViewModel.swift
+++ b/godtools/App/Features/Dashboard/Presentation/ChooseYourOwnAdventure/ChooseYourOwnAdventureViewModel.swift
@@ -91,7 +91,7 @@ class ChooseYourOwnAdventureViewModel: MobileContentRendererViewModel {
             
             setPages = nil
         }
-        else if isBackNavigation, let backToPageIndex = pages.firstIndex(of: page) {
+        else if let backToPageIndex = pages.firstIndex(of: page) {
             
             // Backward Navigation - Page is in navigation stack
             

--- a/godtools/App/Features/Dashboard/Presentation/ChooseYourOwnAdventure/ChooseYourOwnAdventureViewModel.swift
+++ b/godtools/App/Features/Dashboard/Presentation/ChooseYourOwnAdventure/ChooseYourOwnAdventureViewModel.swift
@@ -122,7 +122,7 @@ class ChooseYourOwnAdventureViewModel: MobileContentRendererViewModel {
         }
         else if isBackNavigation, let nearestAncestorPageIndex = super.getNearestAncestorPageIndex(page: page) {
             
-            // Backward Navigation - Page is NOT in navigation stack, but an ancestor page is...
+            // Backward Navigation - Page is NOT in navigation stack, but an ancestor page is in stack.  Add to top of ancestor page.
             
             let insertPageAtIndex: Int = nearestAncestorPageIndex + 1
             

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/Pages/MobileContentPagesViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/Pages/MobileContentPagesViewModel.swift
@@ -66,6 +66,35 @@ class MobileContentPagesViewModel: NSObject, ObservableObject {
         return pageModels.count
     }
     
+    func getNearestAncestorPage(page: Page) -> Page? {
+        
+        guard let index = getNearestAncestorPageIndex(page: page) else {
+            return nil
+        }
+        
+        return getPage(index: index)
+    }
+    
+    func getNearestAncestorPageIndex(page: Page) -> Int? {
+        
+        let pages: [Page] = getPages()
+        
+        var ancestor: Page? = page.parentPage
+        
+        while ancestor != nil {
+            
+            if let ancestorPageId = ancestor?.id,
+               let ancestorPageIndex = pages.firstIndex(where: { $0.id == ancestorPageId }) {
+                
+                return ancestorPageIndex
+            }
+            
+            ancestor = ancestor?.parentPage
+        }
+        
+        return nil
+    }
+    
     // MARK: - Events
     
     func pageDidReceiveEvent(eventId: EventId) -> ProcessedEventResult? {
@@ -178,14 +207,18 @@ class MobileContentPagesViewModel: NSObject, ObservableObject {
         navigateToPage(page: page, animated: animated)
     }
         
-    func navigateToPage(page: Page, animated: Bool) {
+    func navigateToPage(page: Page, animated: Bool, isBackNavigation: Bool = false) {
         
-        let navigationEvent: MobileContentPagesNavigationEvent = getPageNavigationEvent(page: page, animated: animated)
+        let navigationEvent: MobileContentPagesNavigationEvent = getPageNavigationEvent(
+            page: page,
+            animated: animated,
+            isBackNavigation: isBackNavigation
+        )
         
         sendPageNavigationEvent(navigationEvent: navigationEvent)
     }
     
-    func getPageNavigationEvent(page: Page, animated: Bool, reloadCollectionViewDataNeeded: Bool = false) -> MobileContentPagesNavigationEvent {
+    func getPageNavigationEvent(page: Page, animated: Bool, reloadCollectionViewDataNeeded: Bool = false, isBackNavigation: Bool = false) -> MobileContentPagesNavigationEvent {
                 
         let currentPages: [Page] = pageModels
                 


### PR DESCRIPTION
Adds support for CYOA back navigation to navigate back to a parent page when the parent page does NOT exist in the current navigation stack.

If the parent page has an ancestor that exists in the navigation stack, CYOA will attach the parent page on top of the nearest ancestor that exists in the navigation stack and then navigate back to the parent page.