### PR TITLE
GT-2541 fix download modal getting stuck

### DIFF
--- a/godtools/App/Flows/DownloadToolTranslations/DownloadToolTranslationsFlow.swift
+++ b/godtools/App/Flows/DownloadToolTranslations/DownloadToolTranslationsFlow.swift
@@ -10,7 +10,7 @@ import UIKit
 import Combine
 
 class DownloadToolTranslationsFlow: Flow {
-    
+        
     private let determineToolTranslationsToDownload: DetermineToolTranslationsToDownloadType
     private let getToolTranslationsFilesUseCase: GetToolTranslationsFilesUseCase
     private let didDownloadToolTranslations: ((_ result: Result<ToolTranslationsDomainModel, Error>) -> Void)
@@ -47,7 +47,7 @@ class DownloadToolTranslationsFlow: Flow {
             case .failure(let error):
                 self?.dismissDownloadTool(completion: {
                     self?.didDownloadToolTranslations(.failure(error))
-                })
+                }, delaySeconds: 2)
             }
             
         }, receiveValue: { [weak self] (toolTranslations: ToolTranslationsDomainModel) in
@@ -121,15 +121,32 @@ class DownloadToolTranslationsFlow: Flow {
         downloadToolProgressModal = modal
     }
     
-    private func dismissDownloadTool(completion: (() -> Void)?) {
+    private func dismissDownloadTool(completion: (() -> Void)?, delaySeconds: TimeInterval? = nil) {
         
         guard let modal = downloadToolProgressModal else {
             return
         }
         
-        modal.dismiss(animated: true, completion: completion)
+        delayCallbackSeconds(delaySeconds: delaySeconds) { [weak self] in
+           
+            modal.dismiss(animated: true, completion: completion)
+            
+            self?.downloadToolProgressView = nil
+            self?.downloadToolProgressModal = nil
+        }
+    }
+    
+    private func delayCallbackSeconds(delaySeconds: TimeInterval?, closure: (() -> Void)?) {
+        
+        if let delaySeconds = delaySeconds {
+            
+            DispatchQueue.main.asyncAfter(deadline: .now() + delaySeconds) {
                 
-        downloadToolProgressView = nil
-        downloadToolProgressModal = nil
+                closure?()
+            }
+        }
+        else {
+            closure?()
+        }
     }
 }

--- a/godtools/App/Services/Renderer/Navigation/MobileContentRendererNavigation.swift
+++ b/godtools/App/Services/Renderer/Navigation/MobileContentRendererNavigation.swift
@@ -78,6 +78,11 @@ class MobileContentRendererNavigation {
         delegate?.mobileContentRendererNavigationDismissRenderer(navigation: self, event: event)
     }
     
+    func presentError(error: Error, appLanguage: AppLanguageDomainModel) {
+        
+        parentFlow?.presentError(appLanguage: appLanguage, error: error)
+    }
+    
     func errorOccurred(error: MobileContentErrorViewModel) {
         
         let view = MobileContentErrorView(viewModel: error)

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/Renderer/MobileContentRendererViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/Renderer/MobileContentRendererViewModel.swift
@@ -212,6 +212,7 @@ class MobileContentRendererViewModel: MobileContentPagesViewModel {
     
     func setRendererPrimaryLanguage(primaryLanguageId: String, parallelLanguageId: String?, selectedLanguageId: String?) {
         
+        let appLanguage: AppLanguageDomainModel = self.appLanguage
         let currentRenderer: MobileContentRenderer = renderer.value
         
         var newLanguageIds: [String] = [primaryLanguageId]
@@ -232,8 +233,9 @@ class MobileContentRendererViewModel: MobileContentPagesViewModel {
                 
                 self?.setRenderer(renderer: newRenderer, pageRendererIndex: newSelectedLanguageIndex, navigationEvent: nil)
                 
-            case .failure( _):
-                break
+            case .failure(let error):
+                
+                currentRenderer.navigation.presentError(error: error, appLanguage: appLanguage)
             }
         }
         


### PR DESCRIPTION
Fix to download tool modal from tool > tool settings > primary language tapped needs to download translation.

The issue was the error was produced so quickly that dismiss was called before the modal fully presented.  So a delay was added to dismiss the modal when coming from an error.

Also, sending the error from the renderer.