### PR TITLE
GT-1628 Fixes issue where navigation event wasn't getting sent when receiving a screen share event with change to Locale

### DIFF
--- a/godtools/App/Features/Dashboard/Presentation/Tract/TractViewModel.swift
+++ b/godtools/App/Features/Dashboard/Presentation/Tract/TractViewModel.swift
@@ -394,6 +394,25 @@ extension TractViewModel {
         else {
             remoteLocaleNavBarLanguageIndex = nil
         }
+        
+        let reloadCollectionViewDataNeeded: Bool = remoteLocaleExists && remoteLocaleExistsInNavBarLanguages == true && remoteLocaleNavBarLanguage?.id != currentNavBarLanguage.id
+        
+        let pageNavigation = PageNavigationCollectionViewNavigationModel(
+            navigationDirection: nil,
+            page: page ?? super.currentPageNumber,
+            animated: animated,
+            reloadCollectionViewDataNeeded: reloadCollectionViewDataNeeded,
+            insertPages: nil,
+            deletePages: nil
+        )
+        
+        let navigationEvent = MobileContentPagesNavigationEvent(
+            pageNavigation: pageNavigation,
+            setPages: nil,
+            pagePositions: pagePositions,
+            parentPageParams: nil,
+            pageSubIndex: nil
+        )
                 
         if remoteLocaleExists &&
             (remoteLocaleExistsInNavBarLanguages == true) &&
@@ -402,7 +421,7 @@ extension TractViewModel {
             
             super.setPageRenderer(
                 pageRenderer: renderer.value.pageRenderers[remoteLocaleNavBarLanguageIndex],
-                navigationEvent: nil,
+                navigationEvent: navigationEvent,
                 pagePositions: pagePositions
             )
         }
@@ -415,21 +434,6 @@ extension TractViewModel {
             )
         }
         else {
-            
-            let navigationEvent = MobileContentPagesNavigationEvent(
-                pageNavigation: PageNavigationCollectionViewNavigationModel(
-                    navigationDirection: nil,
-                    page: page ?? super.currentPageNumber,
-                    animated: animated,
-                    reloadCollectionViewDataNeeded: false,
-                    insertPages: nil,
-                    deletePages: nil
-                ),
-                setPages: nil,
-                pagePositions: pagePositions,
-                parentPageParams: nil,
-                pageSubIndex: nil
-            )
             
             super.sendPageNavigationEvent(navigationEvent: navigationEvent)
         }


### PR DESCRIPTION
This PR fixes a navigation bug in screen sharing.

The bug: The mirror phone toggles to the parallel language, the lead phone is still on the primary language.  When the lead phone moves to a new page, the mirror phone wouldn't navigate, however, it would toggle back to the primary language.

The fix:  Include the navigation event when the local changes which invokes method setPageRenderer.  The navigation event will be included with reload collection data = true.