### PR TITLE
GT-2478 GT-2543 fix language download not fully downloading articles

### DIFF
--- a/godtools/App/Share/Data/ToolDownloader/ToolDownloader.swift
+++ b/godtools/App/Share/Data/ToolDownloader/ToolDownloader.swift
@@ -146,7 +146,7 @@ class ToolDownloader {
             return self.translationsRepository.getTranslationManifestFromCacheElseRemote(
                 translation: translation,
                 manifestParserType: .manifestOnly,
-                includeRelatedFiles: false,
+                includeRelatedFiles: true,
                 shouldFallbackToLatestDownloadedTranslationIfRemoteFails: false
             )
             .map { (translationManifestDataModel: TranslationManifestFileDataModel) in


### PR DESCRIPTION
This PR fixes an issue where articles couldn't be opened offline even after downloading the language from downloadable languages.

Changes include:
- Changed the article downloading to include related files when downloading against the TranslationsRepository.  I don't think this was actually necessary because I don't think articles have related files, but decided better to be safe and include true on that flag.
- Previously, tapping an article from the tools list where a tool filter language was selected would cause the article to attempt to open with app language primary and tool filter language parallel.  This meant the downloader would attempt to download both app language and tool filter language.  I've updated the flow to detect when an article is tapped and default to the tool filter language if supported otherwise fallback to app language. 