### PR TITLE
GT-1719 remove invalid test

### DIFF
--- a/godtoolsTests/App/Features/Favorites/Data-DomainInterface/ToggleToolFavoritedRepositoryTests.swift
+++ b/godtoolsTests/App/Features/Favorites/Data-DomainInterface/ToggleToolFavoritedRepositoryTests.swift
@@ -48,46 +48,6 @@ class ToggleToolFavoritedRepositoryTests: QuickSpec {
             }
             
         }
-        
-        describe("User has only tools A and B favorited.") {
-            
-            context("When a user favorites tool C") {
-                
-                it("Tool C should get added to favorites at position 0.  Positions of tools A and B should update to 1 and 2 respectively") {
-                    
-                    let favoriteResourceA = RealmFavoritedResource()
-                    favoriteResourceA.resourceId = "A"
-                    favoriteResourceA.position = 0
-                    
-                    let favoriteResourceB = RealmFavoritedResource()
-                    favoriteResourceB.resourceId = "B"
-                    favoriteResourceB.position = 0
-                    
-                    let realmDatabase = getConfiguredRealmDatabase(includeFavoritedTools: [favoriteResourceA, favoriteResourceB])
-                    let toggleToolFavoritedRepository = ToggleToolFavoritedRepository(favoritedResourcesRepository: FavoritedResourcesRepository(cache: RealmFavoritedResourcesCache(realmDatabase: realmDatabase)))
-                    
-                    var favoritedResources: [FavoritedResourceDataModel] = Array()
-                    
-                    waitUntil{ done in
-                        toggleToolFavoritedRepository.toggleFavoritedPublisher(toolId: "C")
-                            .sink { _ in
-                                
-                                favoritedResources = realmDatabase.openRealm().objects(RealmFavoritedResource.self).map {
-                                    FavoritedResourceDataModel(id: $0.resourceId, createdAt: $0.createdAt, position: $0.position)
-                                }
-                                
-                                done()
-                            }
-                            .store(in: &cancellables)
-                    }
-                    
-                    expect(favoritedResources.first(where: { $0.id == "C" })?.position).to(equal(0))
-                    expect(favoritedResources.first(where: { $0.id == "A" })?.position).to(equal(1))
-                    expect(favoritedResources.first(where: { $0.id == "B" })?.position).to(equal(2))
-                }
-            }
-            
-        }
     }
     
     private class func getConfiguredRealmDatabase() -> RealmDatabase {


### PR DESCRIPTION
Removing this test because this is a scenario that should never take place.

In this test the existing favorited tools were all at position 0, however, they didn't have a set createdAt date which would never be a scenario in the app.  When storing tool in favorites, the createdAt date is set correctly.