### PR TITLE
GT-1719 Need to reverse order since last favorited tool will show first

### DIFF
--- a/godtools/App/Features/Dashboard/Data-DomainInterface/StoreInitialFavoritedTools.swift
+++ b/godtools/App/Features/Dashboard/Data-DomainInterface/StoreInitialFavoritedTools.swift
@@ -25,7 +25,7 @@ class StoreInitialFavoritedTools: StoreInitialFavoritedToolsInterface {
                 .eraseToAnyPublisher()
         }
         
-        let favoritedResourceIdsToStore: [String] = ["2", "1", "4", "8"]
+        let favoritedResourceIdsToStore: [String] = ["2", "1", "4", "8"].reversed()
         
         return favoritedResourcesRepository
             .storeFavoritedResourcesPublisher(ids: favoritedResourceIdsToStore)


### PR DESCRIPTION
May need to merge this PR with GT-1719. 

When storing the initial favorited tools into the repository, the next tool in the list will have a date that is later than the prior tool by 1 second.  

For example:
 Store favorited resources....
  index: 0
  createdAtDate: 2025-04-17 20:25:43 +0000
  index: 1
  createdAtDate: 2025-04-17 20:25:44 +0000
  index: 2
  createdAtDate: 2025-04-17 20:25:45 +0000
  index: 3
  createdAtDate: 2025-04-17 20:25:46 +0000

This means the last added tool will show at the top of the favorites list since it has the latest created at date.  However, it was intended that the first added tool in this list is at the top of the favorites list.  

 I couldn't find the exact cause for this issue that is now appearing, but it must have been a programmer error where the list wasn't getting sorted correctly by createdAt. 