### PR TITLE
GT Consolidate app launched into Combine Publisher

### DIFF
--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -591,6 +591,8 @@
 		456BB02927C588E80087CCA4 /* MobileContentHeadingViewModelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456BB02627C588E80087CCA4 /* MobileContentHeadingViewModelType.swift */; };
 		456BB02A27C588E80087CCA4 /* MobileContentHeadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456BB02727C588E80087CCA4 /* MobileContentHeadingView.swift */; };
 		456BB02B27C588E80087CCA4 /* MobileContentHeadingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456BB02827C588E80087CCA4 /* MobileContentHeadingViewModel.swift */; };
+		456BB8D22DB2963900E7BFFD /* AppLaunchObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456BB8D12DB2963800E7BFFD /* AppLaunchObserver.swift */; };
+		456BB8D42DB2966500E7BFFD /* AppLaunchState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456BB8D32DB2965C00E7BFFD /* AppLaunchState.swift */; };
 		456BD2CC27020C75004D7B19 /* MobileContentViewHeightConstraintType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456BD2CB27020C75004D7B19 /* MobileContentViewHeightConstraintType.swift */; };
 		456DA4F02CC96ADE004BFB1E /* OpenUrlWithSwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456DA4ED2CC96ADE004BFB1E /* OpenUrlWithSwiftUI.swift */; };
 		456DA4F12CC96ADE004BFB1E /* UrlOpenerInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456DA4EC2CC96ADE004BFB1E /* UrlOpenerInterface.swift */; };
@@ -2359,6 +2361,8 @@
 		456BB02627C588E80087CCA4 /* MobileContentHeadingViewModelType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MobileContentHeadingViewModelType.swift; sourceTree = "<group>"; };
 		456BB02727C588E80087CCA4 /* MobileContentHeadingView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MobileContentHeadingView.swift; sourceTree = "<group>"; };
 		456BB02827C588E80087CCA4 /* MobileContentHeadingViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MobileContentHeadingViewModel.swift; sourceTree = "<group>"; };
+		456BB8D12DB2963800E7BFFD /* AppLaunchObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLaunchObserver.swift; sourceTree = "<group>"; };
+		456BB8D32DB2965C00E7BFFD /* AppLaunchState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLaunchState.swift; sourceTree = "<group>"; };
 		456BD2CB27020C75004D7B19 /* MobileContentViewHeightConstraintType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MobileContentViewHeightConstraintType.swift; sourceTree = "<group>"; };
 		456DA4EC2CC96ADE004BFB1E /* UrlOpenerInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UrlOpenerInterface.swift; sourceTree = "<group>"; };
 		456DA4ED2CC96ADE004BFB1E /* OpenUrlWithSwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenUrlWithSwiftUI.swift; sourceTree = "<group>"; };
@@ -6761,6 +6765,15 @@
 			path = Heading;
 			sourceTree = "<group>";
 		};
+		456BB8D02DB2962F00E7BFFD /* AppLaunchObserver */ = {
+			isa = PBXGroup;
+			children = (
+				456BB8D32DB2965C00E7BFFD /* AppLaunchState.swift */,
+				456BB8D12DB2963800E7BFFD /* AppLaunchObserver.swift */,
+			);
+			path = AppLaunchObserver;
+			sourceTree = "<group>";
+		};
 		456DA4EF2CC96ADE004BFB1E /* UrlOpener */ = {
 			isa = PBXGroup;
 			children = (
@@ -8924,6 +8937,7 @@
 			children = (
 				45E347972A49C0EC0014CCD1 /* AnimatableValue */,
 				456B95E02D774B21008BC455 /* AnimateDownloadProgress */,
+				456BB8D02DB2962F00E7BFFD /* AppLaunchObserver */,
 				4585E4B32B05738600223A9B /* BCP47LanguageIdentifier */,
 				45AD20AC25938EE500A096A0 /* FileCache */,
 				45AD20E8259391B000A096A0 /* Json */,
@@ -13605,6 +13619,7 @@
 				45325F25285CF8B40078D932 /* AnimatedSwiftUIView.swift in Sources */,
 				D40D77B52AA900FB008D3642 /* ToolStringKeys.swift in Sources */,
 				4598BD1C2BF7DF6800196463 /* AuthenticateUserAuthPlatformDomainModel.swift in Sources */,
+				456BB8D42DB2966500E7BFFD /* AppLaunchState.swift in Sources */,
 				455583E9269F2DA500C3FF14 /* MobileContentButtonViewModel.swift in Sources */,
 				45E066D02AE16B60004393CD /* TrackViewedOnboardingTutorialUseCase.swift in Sources */,
 				454B47E72AE024E000C7B5E7 /* OnboardingDiContainer.swift in Sources */,
@@ -13895,6 +13910,7 @@
 				45D63E5B288F6896009B4610 /* TranslationModel.swift in Sources */,
 				452DFB482B7FE24F003A4A59 /* LanguageSupportable.swift in Sources */,
 				45BE4A842AF287E3004021DA /* ConfirmAppLanguageInterfaceStringsDomainModel.swift in Sources */,
+				456BB8D22DB2963900E7BFFD /* AppLaunchObserver.swift in Sources */,
 				4587212E2BFB7E33005DA242 /* ViewDeleteAccountDomainModel.swift in Sources */,
 				D4BC79D5299D6BFB0040651B /* CompletedTrainingTipRepository.swift in Sources */,
 				45A5200E26C481DB009B68D4 /* MobileContentRendererManifestResourcesCache.swift in Sources */,

--- a/godtools/App/Flows/Flow/FlowStep.swift
+++ b/godtools/App/Flows/Flow/FlowStep.swift
@@ -13,8 +13,7 @@ import Combine
 enum FlowStep {
     
     // app
-    case appLaunchedFromTerminatedState
-    case appLaunchedFromBackgroundState
+    case appLaunched(state: AppLaunchState)
     case deepLink(deepLinkType: ParsedDeepLinkType)
     case showOnboardingTutorial(animated: Bool)
     case onboardingFlowCompleted(onboardingFlowCompletedState: OnboardingFlowCompletedState?)

--- a/godtools/App/Share/Common/AppLaunchObserver/AppLaunchObserver.swift
+++ b/godtools/App/Share/Common/AppLaunchObserver/AppLaunchObserver.swift
@@ -75,12 +75,12 @@ class AppLaunchObserver {
                 }
                 else {
                     
-                    launchState = .unknown
+                    launchState = .notDetermined
                 }
             }
             else {
                 
-                launchState = .unknown
+                launchState = .notDetermined
             }
             
             return launchState

--- a/godtools/App/Share/Common/AppLaunchObserver/AppLaunchObserver.swift
+++ b/godtools/App/Share/Common/AppLaunchObserver/AppLaunchObserver.swift
@@ -1,0 +1,90 @@
+//
+//  AppLaunchObserver.swift
+//  godtools
+//
+//  Created by Levi Eggert on 4/21/25.
+//  Copyright © 2025 Cru. All rights reserved.
+//
+
+import Foundation
+import UIKit
+import Combine
+
+class AppLaunchObserver {
+        
+    private var resignedActiveDate: Date?
+    private var appIsInBackground: Bool = false
+    
+    private(set) var appLaunched: Bool = false
+    
+    init() {
+
+    }
+    
+    func onAppLaunchPublisher() -> AnyPublisher<AppLaunchState, Never> {
+        
+        return Publishers.Merge3(
+            NotificationCenter.default.publisher(for: UIApplication.willResignActiveNotification),
+            NotificationCenter.default.publisher(for: UIApplication.didEnterBackgroundNotification),
+            NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)
+        )
+        .map { (notification: Notification) in
+                        
+            let launchState: AppLaunchState
+            
+            if notification.name == UIApplication.willResignActiveNotification {
+                                
+                launchState = .inBackground
+                
+                self.resignedActiveDate = Date()
+            }
+            else if notification.name == UIApplication.didEnterBackgroundNotification {
+                                
+                launchState = .inBackground
+                
+                self.appIsInBackground = true
+            }
+            else if notification.name == UIApplication.didBecomeActiveNotification {
+                                
+                let appLaunchedFromTerminatedState: Bool = !self.appLaunched
+                let appLaunchedFromBackgroundState: Bool = self.appLaunched && self.appIsInBackground
+                
+                if appLaunchedFromTerminatedState {
+                                        
+                    launchState = .fromTerminatedState
+                    
+                    self.appLaunched = true
+                }
+                else if appLaunchedFromBackgroundState {
+                                        
+                    self.appIsInBackground = false
+                    
+                    let currentDate: Date = Date()
+                    let secondsInBackground: TimeInterval
+                    
+                    if let resignedActiveDate = self.resignedActiveDate {
+                        secondsInBackground = currentDate.timeIntervalSince(resignedActiveDate)
+                    }
+                    else {
+                        secondsInBackground = 0
+                    }
+                    
+                    launchState = .fromBackgroundState(secondsInBackground: secondsInBackground)
+                    
+                    self.resignedActiveDate = nil
+                }
+                else {
+                    
+                    launchState = .unknown
+                }
+            }
+            else {
+                
+                launchState = .unknown
+            }
+            
+            return launchState
+        }
+        .eraseToAnyPublisher()
+    }
+}

--- a/godtools/App/Share/Common/AppLaunchObserver/AppLaunchState.swift
+++ b/godtools/App/Share/Common/AppLaunchObserver/AppLaunchState.swift
@@ -1,0 +1,17 @@
+//
+//  AppLaunchState.swift
+//  godtools
+//
+//  Created by Levi Eggert on 4/21/25.
+//  Copyright © 2025 Cru. All rights reserved.
+//
+
+import Foundation
+
+enum AppLaunchState {
+    
+    case inBackground
+    case fromBackgroundState(secondsInBackground: TimeInterval)
+    case fromTerminatedState
+    case notDetermined
+}


### PR DESCRIPTION
This PR removes the UIApplication life cycle observers from AppFlow and moves those into class AppLauncher which can now be observed using Combine.

This helps remove some code from AppFlow and also consolidates the app launch state into a single step in AppFlow rather than monitoring a step for launched from terminated state and step for launched from background state.