### PR TITLE
GT- Fix app launch

### DIFF
--- a/godtools/App/Flows/App/AppFlow.swift
+++ b/godtools/App/Flows/App/AppFlow.swift
@@ -119,14 +119,14 @@ class AppFlow: NSObject, ToolNavigationFlow, Flow {
                 AppBackgroundState.shared.start(appDiContainer: appDiContainer)
                             
                 ApplicationLayout.shared.configure(appLanguageFeatureDiContainer: appDiContainer.feature.appLanguage)
-                
-                loadInitialData()
-                countAppSessionLaunch()
             }
             
             switch launchState {
            
             case .fromTerminatedState:
+                
+                loadInitialData()
+                countAppSessionLaunch()
                 
                 let getOnboardingTutorialIsAvailableUseCase: GetOnboardingTutorialIsAvailableUseCase = appDiContainer.feature.onboarding.domainLayer.getOnboardingTutorialIsAvailableUseCase()
                 let shouldPromptForOptInNotificationUseCase: ShouldPromptForOptInNotificationUseCase = appDiContainer.feature.optInNotification.domainLayer.getShouldPromptForOptInNotificationUseCase()
@@ -170,6 +170,9 @@ class AppFlow: NSObject, ToolNavigationFlow, Flow {
                 guard elapsedTimeInMinutes >= 120 else {
                     return
                 }
+                
+                loadInitialData()
+                countAppSessionLaunch()
                 
                 let loadingView: UIView = attachLaunchedFromBackgroundLoadingView()
                 

--- a/godtools/App/Flows/App/AppFlow.swift
+++ b/godtools/App/Flows/App/AppFlow.swift
@@ -114,12 +114,19 @@ class AppFlow: NSObject, ToolNavigationFlow, Flow {
             
         case .appLaunched(let launchState):
             
-            switch launchState {
-           
-            case .fromTerminatedState:
+            if launchState.isLaunching {
+                
+                AppBackgroundState.shared.start(appDiContainer: appDiContainer)
+                            
+                ApplicationLayout.shared.configure(appLanguageFeatureDiContainer: appDiContainer.feature.appLanguage)
                 
                 loadInitialData()
                 countAppSessionLaunch()
+            }
+            
+            switch launchState {
+           
+            case .fromTerminatedState:
                 
                 let getOnboardingTutorialIsAvailableUseCase: GetOnboardingTutorialIsAvailableUseCase = appDiContainer.feature.onboarding.domainLayer.getOnboardingTutorialIsAvailableUseCase()
                 let shouldPromptForOptInNotificationUseCase: ShouldPromptForOptInNotificationUseCase = appDiContainer.feature.optInNotification.domainLayer.getShouldPromptForOptInNotificationUseCase()

--- a/godtools/App/Share/Common/AppLaunchObserver/AppLaunchState.swift
+++ b/godtools/App/Share/Common/AppLaunchObserver/AppLaunchState.swift
@@ -15,3 +15,17 @@ enum AppLaunchState {
     case fromTerminatedState
     case notDetermined
 }
+
+extension AppLaunchState {
+    
+    var isLaunching: Bool {
+        switch self {
+        case .fromBackgroundState( _):
+            return true
+        case .fromTerminatedState:
+            return true
+        default:
+            return false
+        }
+    }
+}


### PR DESCRIPTION
In the code change that moved App launching triggering to a combine publisher I forgot to add these calls back in!

```AppBackgroundState.shared.start(appDiContainer: appDiContainer)```
```ApplicationLayout.shared.configure(appLanguageFeatureDiContainer: appDiContainer.feature.appLanguage)```

See in release 6.3.8 (https://github.com/CruGlobal/godtools-swift/blob/releases/6.3.8/godtools/App/Flows/App/AppFlow.swift#L1403)

These two calls happen on application did become active prior to invoking app launched from terminated state or background state. 

Also, loadInitialData() and countAppSessionLaunch() need to happen separately.  Either from terminated state or background state in background 2 hours or more.  

