### PR TITLE
GT 2567 fix realm crash

### DIFF
--- a/godtools/App/Features/Dashboard/Data-DomainInterface/FavoritedToolsLatestToolDownloader.swift
+++ b/godtools/App/Features/Dashboard/Data-DomainInterface/FavoritedToolsLatestToolDownloader.swift
@@ -26,12 +26,10 @@ class FavoritedToolsLatestToolDownloader: FavoritedToolsLatestToolDownloaderInte
         
         return Publishers.CombineLatest(
             resourcesRepository.getResourcesChangedPublisher(),
-            favoritedResourcesRepository.getFavoritedResourcesChangedPublisher()
+            favoritedResourcesRepository.getFavoritedResourcesSortedByPositionPublisher()
         )
-        .flatMap({ (resourcesChanged: Void, favoritedResourcesChanged: Void) -> AnyPublisher<[FavoritedResourceDataModel], Never> in
-            
-            let favoritedTools: [FavoritedResourceDataModel] = self.favoritedResourcesRepository.getFavoritedResourcesSortedByPosition()
-            
+        .flatMap({ (resourcesChanged: Void, favoritedTools: [FavoritedResourceDataModel]) -> AnyPublisher<[FavoritedResourceDataModel], Never> in
+                        
             return Just(favoritedTools)
                 .eraseToAnyPublisher()
         })

--- a/godtools/App/Share/Data/FavoritedResourcesRepository/FavoritedResourcesRepository.swift
+++ b/godtools/App/Share/Data/FavoritedResourcesRepository/FavoritedResourcesRepository.swift
@@ -47,11 +47,6 @@ class FavoritedResourcesRepository {
         return cache.getResourceIsFavorited(id: id)
     }
     
-    func getFavoritedResourcesSortedByPosition() -> [FavoritedResourceDataModel] {
-        
-        return cache.getFavoritedResourcesSortedByPosition()
-    }
-    
     func getFavoritedResourcesSortedByPositionPublisher() -> AnyPublisher<[FavoritedResourceDataModel], Never> {
         
         return cache.getFavoritedResourcesSortedByPositionPublisher()


### PR DESCRIPTION
Changes in this PR:

- Updated favorited tools realm migration to use Combine Publisher and make call to writePublisher extension. I think this will resolve the crash.
- Use the fetch publisher instead of onChange publisher in FavoritedToolsLatestToolDownloader since the fetch publisher will respond to changes. 

<img width="1260" alt="gt-realm-crash" src="https://github.com/user-attachments/assets/d7339006-5235-41f3-9fe4-3a0316fe9602" />
