### PR TITLE
GT-1502 fetch prev next from translated strings

### DIFF
--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -16107,7 +16107,7 @@
 			repositoryURL = "https://github.com/CruGlobal/localization-services-ios";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.2.1;
+				minimumVersion = 0.2.2;
 			};
 		};
 		D4997E0C28D4CED800205B4C /* XCRemoteSwiftPackageReference "youtube-ios-player-helper" */ = {

--- a/godtools.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/godtools.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -159,8 +159,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CruGlobal/localization-services-ios",
       "state" : {
-        "revision" : "6d8f7d243854e3ce7caef1de672b8b7102f8cdbd",
-        "version" : "0.2.1"
+        "revision" : "b4e174fe755f17f8a97ccc20ad2801d954a19beb",
+        "version" : "0.2.2"
       }
     },
     {

--- a/godtools/App/Services/Renderer/Views/Tract/Views/Card/TractPageCardViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/Tract/Views/Card/TractPageCardViewModel.swift
@@ -124,7 +124,14 @@ class TractPageCardViewModel: MobileContentViewModel {
         
         let prevLocalizedKey: String = LocalizableStringKeys.cardPrevButtonTitle.key
         
-        return localizationServices.stringForLocaleElseSystemElseEnglish(localeIdentifier: renderedPageContext.language.localeId, key: prevLocalizedKey)
+        if let languageTranslation = localizationServices.stringsRepository.stringForLocale(localeIdentifier: renderedPageContext.language.localeId, key: prevLocalizedKey) {
+            return languageTranslation
+        }
+        else if let appLanguageTranslation = localizationServices.stringsRepository.stringForLocale(localeIdentifier: renderedPageContext.appLanguage, key: prevLocalizedKey) {
+            return appLanguageTranslation
+        }
+        
+        return localizationServices.stringForEnglish(key: prevLocalizedKey)
     }
     
     var previousButtonTitleColor: UIColor {
@@ -139,7 +146,14 @@ class TractPageCardViewModel: MobileContentViewModel {
         
         let nextLocalizedKey: String = LocalizableStringKeys.cardNextButtonTitle.key
         
-        return localizationServices.stringForLocaleElseSystemElseEnglish(localeIdentifier: renderedPageContext.language.localeId, key: nextLocalizedKey)
+        if let languageTranslation = localizationServices.stringsRepository.stringForLocale(localeIdentifier: renderedPageContext.language.localeId, key: nextLocalizedKey) {
+            return languageTranslation
+        }
+        else if let appLanguageTranslation = localizationServices.stringsRepository.stringForLocale(localeIdentifier: renderedPageContext.appLanguage, key: nextLocalizedKey) {
+            return appLanguageTranslation
+        }
+        
+        return localizationServices.stringForEnglish(key: nextLocalizedKey)
     }
     
     var nextButtonTitleColor: UIColor {

--- a/godtools/App/Services/Renderer/Views/Tract/Views/Card/TractPageCardViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/Tract/Views/Card/TractPageCardViewModel.swift
@@ -121,7 +121,10 @@ class TractPageCardViewModel: MobileContentViewModel {
     }
     
     var previousButtonTitle: String? {
-        return localizationServices.stringForLocaleElseSystemElseEnglish(localeIdentifier: renderedPageContext.language.localeId, key: "card_status1")
+        
+        let prevLocalizedKey: String = LocalizableStringKeys.cardPrevButtonTitle.key
+        
+        return localizationServices.stringForLocaleElseSystemElseEnglish(localeIdentifier: renderedPageContext.language.localeId, key: prevLocalizedKey)
     }
     
     var previousButtonTitleColor: UIColor {
@@ -133,7 +136,10 @@ class TractPageCardViewModel: MobileContentViewModel {
     }
     
     var nextButtonTitle: String? {
-        return localizationServices.stringForLocaleElseSystemElseEnglish(localeIdentifier: renderedPageContext.language.localeId, key: "card_status2")
+        
+        let nextLocalizedKey: String = LocalizableStringKeys.cardNextButtonTitle.key
+        
+        return localizationServices.stringForLocaleElseSystemElseEnglish(localeIdentifier: renderedPageContext.language.localeId, key: nextLocalizedKey)
     }
     
     var nextButtonTitleColor: UIColor {

--- a/godtools/App/Services/Renderer/Views/Tract/Views/Card/TractPageCardViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/Tract/Views/Card/TractPageCardViewModel.swift
@@ -87,6 +87,18 @@ class TractPageCardViewModel: MobileContentViewModel {
         return ""
     }
     
+    private func getTranslatedStringFromToolLanguageElseAppLanguage(localizedKey: String) -> String {
+        
+        if let languageTranslation = localizationServices.stringsRepository.stringForLocale(localeIdentifier: renderedPageContext.language.localeId, key: localizedKey) {
+            return languageTranslation
+        }
+        else if let appLanguageTranslation = localizationServices.stringsRepository.stringForLocale(localeIdentifier: renderedPageContext.appLanguage, key: localizedKey) {
+            return appLanguageTranslation
+        }
+        
+        return localizationServices.stringForEnglish(key: localizedKey)
+    }
+    
     var title: String? {
         return cardModel.label?.text
     }
@@ -124,14 +136,7 @@ class TractPageCardViewModel: MobileContentViewModel {
         
         let prevLocalizedKey: String = LocalizableStringKeys.cardPrevButtonTitle.key
         
-        if let languageTranslation = localizationServices.stringsRepository.stringForLocale(localeIdentifier: renderedPageContext.language.localeId, key: prevLocalizedKey) {
-            return languageTranslation
-        }
-        else if let appLanguageTranslation = localizationServices.stringsRepository.stringForLocale(localeIdentifier: renderedPageContext.appLanguage, key: prevLocalizedKey) {
-            return appLanguageTranslation
-        }
-        
-        return localizationServices.stringForEnglish(key: prevLocalizedKey)
+        return getTranslatedStringFromToolLanguageElseAppLanguage(localizedKey: prevLocalizedKey)
     }
     
     var previousButtonTitleColor: UIColor {
@@ -146,14 +151,7 @@ class TractPageCardViewModel: MobileContentViewModel {
         
         let nextLocalizedKey: String = LocalizableStringKeys.cardNextButtonTitle.key
         
-        if let languageTranslation = localizationServices.stringsRepository.stringForLocale(localeIdentifier: renderedPageContext.language.localeId, key: nextLocalizedKey) {
-            return languageTranslation
-        }
-        else if let appLanguageTranslation = localizationServices.stringsRepository.stringForLocale(localeIdentifier: renderedPageContext.appLanguage, key: nextLocalizedKey) {
-            return appLanguageTranslation
-        }
-        
-        return localizationServices.stringForEnglish(key: nextLocalizedKey)
+        return getTranslatedStringFromToolLanguageElseAppLanguage(localizedKey: nextLocalizedKey)
     }
     
     var nextButtonTitleColor: UIColor {

--- a/godtools/App/Share/Application/Strings/LocalizableStringKeys.swift
+++ b/godtools/App/Share/Application/Strings/LocalizableStringKeys.swift
@@ -17,6 +17,7 @@ enum LocalizableStringKeys: String {
     case articlesRetryDownloadButtonTitle = "articles.downloadArticlesButton.title.retryDownload"
     case cancel = "cancel"
     case cardNextButtonTitle = "card_status2"
+    case cardPrevButtonTitle = "card_status1"
     case close = "close"
     case confirmDeleteAccountTitle = "confirmDeleteAccount.title"
     case confirmDeleteAccountConfirmButtonTitle = "confirmDeleteAccount.confirmButton.title"


### PR DESCRIPTION
This PR updates the fetch language order for prev / next in tool cards to be tool language > app language > english language. 