### PR TITLE
GT-2434 Replaced tool options with published array of ToolSettingsOption

### DIFF
--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -242,6 +242,7 @@
 		452F4B082A97E117003071D1 /* PageNavigationCollectionViewCenterLayoutPageAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 452F4B072A97E117003071D1 /* PageNavigationCollectionViewCenterLayoutPageAttributes.swift */; };
 		452F6E852B69A33C0012AF9C /* FavoritedToolsLatestToolDownloaderInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 452F6E842B69A33C0012AF9C /* FavoritedToolsLatestToolDownloaderInterface.swift */; };
 		452F6E872B69A3420012AF9C /* FavoritedToolsLatestToolDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 452F6E862B69A3420012AF9C /* FavoritedToolsLatestToolDownloader.swift */; };
+		452FD1142DF0B245004ADFD1 /* ToolSettingsOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 452FD1132DF0B240004ADFD1 /* ToolSettingsOption.swift */; };
 		45300B7D2C34282200E6F97D /* LocaleLanguageNameInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45300B7C2C34282200E6F97D /* LocaleLanguageNameInterface.swift */; };
 		45300B7F2C34282900E6F97D /* LocaleLanguageRegionNameInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45300B7E2C34282900E6F97D /* LocaleLanguageRegionNameInterface.swift */; };
 		45300B812C34283200E6F97D /* LocaleLanguageScriptNameInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45300B802C34283200E6F97D /* LocaleLanguageScriptNameInterface.swift */; };
@@ -2006,6 +2007,7 @@
 		452F4B072A97E117003071D1 /* PageNavigationCollectionViewCenterLayoutPageAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageNavigationCollectionViewCenterLayoutPageAttributes.swift; sourceTree = "<group>"; };
 		452F6E842B69A33C0012AF9C /* FavoritedToolsLatestToolDownloaderInterface.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FavoritedToolsLatestToolDownloaderInterface.swift; sourceTree = "<group>"; };
 		452F6E862B69A3420012AF9C /* FavoritedToolsLatestToolDownloader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritedToolsLatestToolDownloader.swift; sourceTree = "<group>"; };
+		452FD1132DF0B240004ADFD1 /* ToolSettingsOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolSettingsOption.swift; sourceTree = "<group>"; };
 		45300B7C2C34282200E6F97D /* LocaleLanguageNameInterface.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocaleLanguageNameInterface.swift; sourceTree = "<group>"; };
 		45300B7E2C34282900E6F97D /* LocaleLanguageRegionNameInterface.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocaleLanguageRegionNameInterface.swift; sourceTree = "<group>"; };
 		45300B802C34283200E6F97D /* LocaleLanguageScriptNameInterface.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocaleLanguageScriptNameInterface.swift; sourceTree = "<group>"; };
@@ -9979,6 +9981,7 @@
 				45CCF68F2B2269010017EDFE /* ToolSettingsOptionView.swift */,
 				45CCF6902B2269010017EDFE /* ToolSettingsOptionViewBackground.swift */,
 				45CCF6912B2269010017EDFE /* ToolSettingsOptionViewTitleColorStyle.swift */,
+				452FD1132DF0B240004ADFD1 /* ToolSettingsOption.swift */,
 			);
 			path = ToolSettingsOption;
 			sourceTree = "<group>";
@@ -13806,6 +13809,7 @@
 				4512D4E02B29129100DFAFB3 /* ToolSettingsToolLanguagesListView.swift in Sources */,
 				453649EC295E0B3F00B5B354 /* LanguageSettingsFlowCompletedState.swift in Sources */,
 				45DBE62B2ACDA6F8008A93BF /* GetFeaturedLessonsRepository.swift in Sources */,
+				452FD1142DF0B245004ADFD1 /* ToolSettingsOption.swift in Sources */,
 				4598BD212BF7DF6800196463 /* SocialCreateAccountInterfaceStringsDomainModel.swift in Sources */,
 				45C152812A44888100F2A1E8 /* LessonEvaluationViewModel.swift in Sources */,
 				4534F92E2AE9A9F800A7A071 /* EvaluateLessonRepositoryInterface.swift in Sources */,

--- a/godtools/App/Features/ToolSettings/Presentation/ToolSettings/Subviews/ToolSettingsOptions/Subviews/ToolSettingsOption/ToolSettingsOption.swift
+++ b/godtools/App/Features/ToolSettings/Presentation/ToolSettings/Subviews/ToolSettingsOptions/Subviews/ToolSettingsOption/ToolSettingsOption.swift
@@ -1,0 +1,22 @@
+//
+//  ToolSettingsOption.swift
+//  godtools
+//
+//  Created by Levi Eggert on 6/4/25.
+//  Copyright © 2025 Cru. All rights reserved.
+//
+
+import Foundation
+
+enum ToolSettingsOption: String {
+    
+    case shareLink
+    case shareScreen
+    case trainingTips
+}
+
+extension ToolSettingsOption: Identifiable {
+    var id: String {
+        return rawValue
+    }
+}

--- a/godtools/App/Features/ToolSettings/Presentation/ToolSettings/Subviews/ToolSettingsOptions/ToolSettingsOptionsView.swift
+++ b/godtools/App/Features/ToolSettings/Presentation/ToolSettings/Subviews/ToolSettingsOptions/ToolSettingsOptionsView.swift
@@ -23,43 +23,43 @@ struct ToolSettingsOptionsView: View {
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack {
                     
-                    if !viewModel.hidesShareLinkButton {
+                    ForEach(viewModel.toolOptions) { toolOption in
                         
-                        ToolSettingsOptionView(
-                            viewBackground: .color(color: Color(.sRGB, red: 59 / 256, green: 164 / 256, blue: 219 / 256, opacity: 1)),
-                            title: viewModel.shareLinkTitle,
-                            titleColorStyle: .darkBackground,
-                            iconImage: ImageCatalog.toolSettingsOptionShareLink.image,
-                            tappedClosure: {
-                                viewModel.shareLinkTapped()
-                            }
-                        )
-                    }
-                    
-                    if !viewModel.hidesShareScreenButton {
+                        switch toolOption {
                         
-                        ToolSettingsOptionView(
-                            viewBackground: .color(color: Color(.sRGB, red: 245 / 256, green: 245 / 256, blue: 245 / 256, opacity: 1)),
-                            title: viewModel.screenShareTitle,
-                            titleColorStyle: .lightBackground,
-                            iconImage: ImageCatalog.toolSettingsOptionScreenShare.image,
-                            tappedClosure: {
-                                viewModel.screenShareTapped()
-                            }
-                        )
-                    }
-                    
-                    if !viewModel.hidesTrainingTipsButton {
-                        
-                        ToolSettingsOptionView(
-                            viewBackground: .image(image: ImageCatalog.toolSettingsOptionTrainingTipsBackground.image),
-                            title: viewModel.trainingTipsTitle,
-                            titleColorStyle: .lightBackground,
-                            iconImage: viewModel.trainingTipsIcon,
-                            tappedClosure: {
-                                viewModel.trainingTipsTapped()
-                            }
-                        )
+                        case .shareLink:
+                            ToolSettingsOptionView(
+                                viewBackground: .color(color: Color(.sRGB, red: 59 / 256, green: 164 / 256, blue: 219 / 256, opacity: 1)),
+                                title: viewModel.shareLinkTitle,
+                                titleColorStyle: .darkBackground,
+                                iconImage: ImageCatalog.toolSettingsOptionShareLink.image,
+                                tappedClosure: {
+                                    viewModel.shareLinkTapped()
+                                }
+                            )
+                            
+                        case .shareScreen:
+                            ToolSettingsOptionView(
+                                viewBackground: .color(color: Color(.sRGB, red: 245 / 256, green: 245 / 256, blue: 245 / 256, opacity: 1)),
+                                title: viewModel.screenShareTitle,
+                                titleColorStyle: .lightBackground,
+                                iconImage: ImageCatalog.toolSettingsOptionScreenShare.image,
+                                tappedClosure: {
+                                    viewModel.screenShareTapped()
+                                }
+                            )
+                            
+                        case .trainingTips:
+                            ToolSettingsOptionView(
+                                viewBackground: .image(image: ImageCatalog.toolSettingsOptionTrainingTipsBackground.image),
+                                title: viewModel.trainingTipsTitle,
+                                titleColorStyle: .lightBackground,
+                                iconImage: viewModel.trainingTipsIcon,
+                                tappedClosure: {
+                                    viewModel.trainingTipsTapped()
+                                }
+                            )
+                        }
                     }
                 }
             }

--- a/godtools/App/Features/ToolSettings/Presentation/ToolSettings/ToolSettingsView.swift
+++ b/godtools/App/Features/ToolSettings/Presentation/ToolSettings/ToolSettingsView.swift
@@ -70,7 +70,7 @@ struct ToolSettingsView: View {
                         ScrollView(.vertical, showsIndicators: true) {
                             VStack(spacing: 0) {
                                 
-                                if viewModel.hidesToolOptions == false {
+                                if !viewModel.toolOptions.isEmpty {
                                     
                                     ToolSettingsOptionsView(
                                         viewModel: viewModel


### PR DESCRIPTION
Changes in this PR:
- Removes the 3 published properties for each tool option and instead uses an array of type ToolSettingsOption.