### PR TITLE
GT-2649 update deep linking to use combine publisher

### DIFF
--- a/godtools/App/Flows/Tract/TractFlow.swift
+++ b/godtools/App/Flows/Tract/TractFlow.swift
@@ -157,7 +157,7 @@ extension TractFlow {
         
         let navBarLayoutDirection: UISemanticContentAttribute = ApplicationLayout.shared.currentDirection.semanticContentAttribute
         
-        let parentFlowIsHomeFlow: Bool = flowDelegate is AppFlow
+        let parentFlowIsHomeFlow: Bool = flowDelegate is DashboardFlow
         
         let viewModel = TractViewModel(
             flowDelegate: self,

--- a/godtools/App/Share/Data/DeepLinkingService/DeepLinkingService.swift
+++ b/godtools/App/Share/Data/DeepLinkingService/DeepLinkingService.swift
@@ -8,17 +8,15 @@
 
 import Foundation
 
-class DeepLinkingService: NSObject {
+class DeepLinkingService {
     
     private let manifest: DeepLinkingManifestInterface
     
     let deepLinkObserver: PassthroughValue<ParsedDeepLinkType?> = PassthroughValue()
         
-    required init(manifest: DeepLinkingManifestInterface) {
+    init(manifest: DeepLinkingManifestInterface) {
         
         self.manifest = manifest
-        
-        super.init()
     }
     
     func parseDeepLink(incomingDeepLink: IncomingDeepLinkType) -> ParsedDeepLinkType? {

--- a/godtools/App/Share/Data/DeepLinkingService/DeepLinkingService.swift
+++ b/godtools/App/Share/Data/DeepLinkingService/DeepLinkingService.swift
@@ -7,16 +7,20 @@
 //
 
 import Foundation
+import Combine
 
 class DeepLinkingService {
     
     private let manifest: DeepLinkingManifestInterface
-    
-    let deepLinkObserver: PassthroughValue<ParsedDeepLinkType?> = PassthroughValue()
-        
+    private let lastParsedDeepLinkSubject: PassthroughSubject<ParsedDeepLinkType?, Never> = PassthroughSubject()
+            
     init(manifest: DeepLinkingManifestInterface) {
         
         self.manifest = manifest
+    }
+    
+    var parsedDeepLinkPublisher: AnyPublisher<ParsedDeepLinkType?, Never> {
+        return lastParsedDeepLinkSubject.eraseToAnyPublisher()
     }
     
     func parseDeepLink(incomingDeepLink: IncomingDeepLinkType) -> ParsedDeepLinkType? {
@@ -56,7 +60,7 @@ class DeepLinkingService {
             return false
         }
         
-        deepLinkObserver.accept(value: parsedDeepLink)
+        lastParsedDeepLinkSubject.send(parsedDeepLink)
         
         return true
     }


### PR DESCRIPTION
Removes the Legacy PassthroughValue Observer and instead uses Combine PassthroughSubject in DeepLinkingService.

Also made a fix when moving some AppFlow logic into DashboardFlow.  Deep linking to a tool from AppFlow will now go through the DashboardFlow. 