### PR TITLE
GT Verify tests post code coverage

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -27,18 +27,18 @@ jobs:
         uses: ./.github/actions/pod-install
 
       # - Run all tests and build single xcresult.
-      # - name: Run All Tests and Generate Code Coverage Report (.xcresult)
-      #   run: bundle exec fastlane cru_shared_lane_run_tests testplan:AllTests output_directory:fastlane_scan_output_directory result_bundle:true reset_simulator:true should_clear_derived_data:true
+      - name: Run All Tests and Generate Code Coverage Report (.xcresult)
+        run: bundle exec fastlane cru_shared_lane_run_tests testplan:AllTests output_directory:fastlane_scan_output_directory result_bundle:true reset_simulator:true should_clear_derived_data:true
 
       # - Runs Tests and UITests separately and merges xcresults into single xcresult.
-      - name: Run Tests and Generate Code Coverage Report (.xcresult)
-        run: bundle exec fastlane cru_shared_lane_run_tests testplan:Tests output_directory:fastlane_scan_output_directory/tests result_bundle:true reset_simulator:true should_clear_derived_data:true
+      # - name: Run Tests and Generate Code Coverage Report (.xcresult)
+      #   run: bundle exec fastlane cru_shared_lane_run_tests testplan:Tests output_directory:fastlane_scan_output_directory/tests result_bundle:true reset_simulator:true should_clear_derived_data:true
 
-      - name: Run UITests and Generate Code Coverage Report (.xcresult)
-        run: bundle exec fastlane cru_shared_lane_run_tests testplan:UITests output_directory:fastlane_scan_output_directory/uitests result_bundle:true reset_simulator:true should_clear_derived_data:true
+      # - name: Run UITests and Generate Code Coverage Report (.xcresult)
+      #   run: bundle exec fastlane cru_shared_lane_run_tests testplan:UITests output_directory:fastlane_scan_output_directory/uitests result_bundle:true reset_simulator:true should_clear_derived_data:true
 
-      - name: Merge XCResult Files
-        run: xcrun xcresulttool merge /Users/runner/work/godtools-swift/godtools-swift/fastlane_scan_output_directory/tests/GodTools-Production.xcresult /Users/runner/work/godtools-swift/godtools-swift/fastlane_scan_output_directory/uitests/GodTools-Production.xcresult --output-path /Users/runner/work/godtools-swift/godtools-swift/fastlane_scan_output_directory/GodTools-Production.xcresult
+      # - name: Merge XCResult Files
+      #   run: xcrun xcresulttool merge /Users/runner/work/godtools-swift/godtools-swift/fastlane_scan_output_directory/tests/GodTools-Production.xcresult /Users/runner/work/godtools-swift/godtools-swift/fastlane_scan_output_directory/uitests/GodTools-Production.xcresult --output-path /Users/runner/work/godtools-swift/godtools-swift/fastlane_scan_output_directory/GodTools-Production.xcresult
 
       - name: Install XCResultParser
         run: brew install a7ex/homebrew-formulae/xcresultparser

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -27,17 +27,17 @@ jobs:
         uses: ./.github/actions/pod-install
 
       # - Run all tests and build single xcresult.
-      - name: Run All Tests and Generate Code Coverage Report (.xcresult)
+      - name: Run Tests and Generate Code Coverage Report (.xcresult)
         run: bundle exec fastlane cru_shared_lane_run_tests testplan:AllTests output_directory:fastlane_scan_output_directory result_bundle:true reset_simulator:true should_clear_derived_data:true
 
       # - Runs Tests and UITests separately and merges xcresults into single xcresult.
-      # - name: Run Tests and Generate Code Coverage Report (.xcresult)
+      # - name: Run Tests and Generate Tests Code Coverage Report (.xcresult)
       #   run: bundle exec fastlane cru_shared_lane_run_tests testplan:Tests output_directory:fastlane_scan_output_directory/tests result_bundle:true reset_simulator:true should_clear_derived_data:true
 
-      # - name: Run UITests and Generate Code Coverage Report (.xcresult)
+      # - name: Run UITests and Generate UITests Code Coverage Report (.xcresult)
       #   run: bundle exec fastlane cru_shared_lane_run_tests testplan:UITests output_directory:fastlane_scan_output_directory/uitests result_bundle:true reset_simulator:true should_clear_derived_data:true
 
-      # - name: Merge XCResult Files
+      # - name: Merge Tests and UITests XCResult Files
       #   run: xcrun xcresulttool merge /Users/runner/work/godtools-swift/godtools-swift/fastlane_scan_output_directory/tests/GodTools-Production.xcresult /Users/runner/work/godtools-swift/godtools-swift/fastlane_scan_output_directory/uitests/GodTools-Production.xcresult --output-path /Users/runner/work/godtools-swift/godtools-swift/fastlane_scan_output_directory/GodTools-Production.xcresult
 
       - name: Install XCResultParser

--- a/godtools.xcodeproj/xcshareddata/xcschemes/GodTools-Production.xcscheme
+++ b/godtools.xcodeproj/xcshareddata/xcschemes/GodTools-Production.xcscheme
@@ -58,11 +58,11 @@
             reference = "container:TestPlans/UITests.xctestplan">
          </TestPlanReference>
          <TestPlanReference
-            reference = "container:TestPlans/Tests.xctestplan"
-            default = "YES">
+            reference = "container:TestPlans/Tests.xctestplan">
          </TestPlanReference>
          <TestPlanReference
-            reference = "container:TestPlans/AllTests.xctestplan">
+            reference = "container:TestPlans/AllTests.xctestplan"
+            default = "YES">
          </TestPlanReference>
       </TestPlans>
    </TestAction>


### PR DESCRIPTION
Changes in PR:
- Updated run tests to run xcode build against all tests and generate single xc result file for code coverage.
- Updated godtools-production scheme to default to all tests test plan.