### PR TITLE
GT-2671 tool settings and tool screen share navigation fixes and gt modal view

### DIFF
--- a/godtools/App/Features/ToolScreenShareQRCode/Presentation/ToolScreenShareQRCode/ToolScreenShareQRCodeView.swift
+++ b/godtools/App/Features/ToolScreenShareQRCode/Presentation/ToolScreenShareQRCode/ToolScreenShareQRCodeView.swift
@@ -18,7 +18,7 @@ struct ToolScreenShareQRCodeView: View {
     
     var body: some View {
 
-        GTModalView {
+        GTModalView { geometry in
             
             VStack {
                 HStack {

--- a/godtools/App/Features/ToolScreenShareQRCode/Presentation/ToolScreenShareQRCode/ToolScreenShareQRCodeView.swift
+++ b/godtools/App/Features/ToolScreenShareQRCode/Presentation/ToolScreenShareQRCode/ToolScreenShareQRCodeView.swift
@@ -12,13 +12,15 @@ struct ToolScreenShareQRCodeView: View {
         
     @ObservedObject private var viewModel: ToolScreenShareQRCodeViewModel
     
+    @State private var modalIsHidden: Bool = true
+    
     init(viewModel: ToolScreenShareQRCodeViewModel) {
         self.viewModel = viewModel
     }
     
     var body: some View {
 
-        GTModalView { geometry in
+        GTModalView (content: { geometry in
             
             VStack {
                 HStack {
@@ -42,15 +44,17 @@ struct ToolScreenShareQRCodeView: View {
                     .padding(.horizontal, 70)
                                 
                 GTBlueButton(title: viewModel.interfaceStrings.closeButtonTitle, font: FontLibrary.sfProDisplayRegular.font(size: 16), width: 150, height: 48) {
+                    
+                    modalIsHidden = true
                     viewModel.closeTapped()
                 }
                 .padding(.bottom, 125)
             }
             
-        } overlayTappedClosure: {
+        }, isHidden: $modalIsHidden, overlayTappedClosure: {
             
             viewModel.closeTapped()
-        }
+        })
         .environment(\.layoutDirection, ApplicationLayout.shared.layoutDirection)
     }
 }

--- a/godtools/App/Features/ToolSettings/Presentation/ToolSettings/ToolSettingsView.swift
+++ b/godtools/App/Features/ToolSettings/Presentation/ToolSettings/ToolSettingsView.swift
@@ -111,3 +111,11 @@ struct ToolSettingsView: View {
         })
     }
 }
+
+extension ToolSettingsView {
+    
+    func setModalIsHidden(isHidden: Bool) {
+    
+        self.modalIsHidden = isHidden
+    }
+}

--- a/godtools/App/Features/ToolSettings/Presentation/ToolSettings/ToolSettingsView.swift
+++ b/godtools/App/Features/ToolSettings/Presentation/ToolSettings/ToolSettingsView.swift
@@ -9,10 +9,7 @@
 import SwiftUI
 
 struct ToolSettingsView: View {
-    
-    private static let backgroundColor: Color = Color.white
-    private static let backgroundCornerRadius: CGFloat = 12
-    
+        
     static let backgroundHorizontalPadding: CGFloat = 10
     
     private let contentInsets: EdgeInsets = EdgeInsets(
@@ -22,131 +19,92 @@ struct ToolSettingsView: View {
         trailing: 15 + Self.backgroundHorizontalPadding
     )
     private let separatorLineSpacing: CGFloat = 25
-    private let overlayTappedClosure: (() -> Void)?
     
     @ObservedObject private var viewModel: ToolSettingsViewModel
     
-    @State private var contentSize: CGSize = CGSize(width: 100, height: 100)
-    @State private var isVisible: Bool = false
+    @State private var scrollContentHeight: CGFloat = 100
     
-    init(viewModel: ToolSettingsViewModel, overlayTappedClosure: (() -> Void)? = nil) {
+    init(viewModel: ToolSettingsViewModel) {
         
         self.viewModel = viewModel
-        self.overlayTappedClosure = overlayTappedClosure
     }
     
     var body: some View {
         
-        GeometryReader { geometry in
+        GTModalView { geometry in
             
-            FullScreenOverlayView(tappedClosure: {
-                
-                setIsVisible(isVisible: false)
-                
-                overlayTappedClosure?()
-            })
-            .opacity(isVisible ? 1 : 0)
-            
-            ZStack(alignment: .bottom) {
-                
-                Color.clear
-                
-                ZStack(alignment: .top) {
-                                              
-                    VStack(alignment: .leading, spacing: 0) {
-                                 
-                        ToolSettingsTopBarView(
-                            title: viewModel.title,
-                            closeTapped: {
-                                setIsVisible(isVisible: false)
-                                viewModel.closeTapped()
-                            }
+            VStack(alignment: .leading, spacing: 0) {
+                         
+                ToolSettingsTopBarView(
+                    title: viewModel.title,
+                    closeTapped: {
+                        viewModel.closeTapped()
+                    }
+                )
+                .padding([.top], contentInsets.top)
+                .padding([.leading], contentInsets.leading)
+                .padding([.trailing], contentInsets.trailing)
+                .padding([.bottom], 10)
+                                    
+                ScrollView(.vertical, showsIndicators: true) {
+                    VStack(spacing: 0) {
+                        
+                        if !viewModel.toolOptions.isEmpty {
+                            
+                            ToolSettingsOptionsView(
+                                viewModel: viewModel
+                            )
+                            .padding([.leading], contentInsets.leading)
+                            .padding([.trailing], contentInsets.trailing)
+                        }
+       
+                        ToolSettingsSeparatorView(
+                            separatorSpacing: 0
                         )
-                        .padding([.top], contentInsets.top)
+                        .padding([.top], separatorLineSpacing)
                         .padding([.leading], contentInsets.leading)
                         .padding([.trailing], contentInsets.trailing)
-                        .padding([.bottom], 10)
-                                            
-                        ScrollView(.vertical, showsIndicators: true) {
-                            VStack(spacing: 0) {
-                                
-                                if !viewModel.toolOptions.isEmpty {
-                                    
-                                    ToolSettingsOptionsView(
-                                        viewModel: viewModel
-                                    )
-                                    .padding([.leading], contentInsets.leading)
-                                    .padding([.trailing], contentInsets.trailing)
-                                }
-               
-                                ToolSettingsSeparatorView(
-                                    separatorSpacing: 0
-                                )
-                                .padding([.top], separatorLineSpacing)
-                                .padding([.leading], contentInsets.leading)
-                                .padding([.trailing], contentInsets.trailing)
-                                                                
-                                ToolSettingsChooseLanguageView(
-                                    viewModel: viewModel
-                                )
-                                .padding([.top], separatorLineSpacing)
-                                .padding([.leading], contentInsets.leading)
-                                .padding([.trailing], contentInsets.trailing)
-                                
-                                if viewModel.shareables.count > 0 {
-                                    
-                                    ToolSettingsSeparatorView(
-                                        separatorSpacing: separatorLineSpacing
-                                    )
-                                    .padding([.leading], contentInsets.leading)
-                                    .padding([.trailing], contentInsets.trailing)
-                                    
-                                    ToolSettingsShareablesView(
-                                        viewModel: viewModel
-                                    )
-                                    .padding([.leading], contentInsets.leading)
-                                    .padding([.trailing], contentInsets.trailing)
-                                }
-                                
-                                Rectangle()
-                                    .frame(width: geometry.size.width, height: contentInsets.bottom)
-                                    .foregroundColor(.clear)
-                            }//end VStack
-                            .background(
-                                GeometryReader { geo -> Color in
-                                    DispatchQueue.main.async {
-                                        contentSize = geo.size
-                                    }
-                                    return Color.clear
-                                }
+                                                        
+                        ToolSettingsChooseLanguageView(
+                            viewModel: viewModel
+                        )
+                        .padding([.top], separatorLineSpacing)
+                        .padding([.leading], contentInsets.leading)
+                        .padding([.trailing], contentInsets.trailing)
+                        
+                        if viewModel.shareables.count > 0 {
+                            
+                            ToolSettingsSeparatorView(
+                                separatorSpacing: separatorLineSpacing
                             )
-                        }//end ScrollView
-                        .clipped()
-                        .frame(maxHeight: contentSize.height)
+                            .padding([.leading], contentInsets.leading)
+                            .padding([.trailing], contentInsets.trailing)
+                            
+                            ToolSettingsShareablesView(
+                                viewModel: viewModel
+                            )
+                            .padding([.leading], contentInsets.leading)
+                            .padding([.trailing], contentInsets.trailing)
+                        }
+                        
+                        Rectangle()
+                            .frame(width: geometry.size.width, height: contentInsets.bottom)
+                            .foregroundColor(.clear)
                     }//end VStack
                     .background(
-                        RoundedRectangle(cornerRadius: Self.backgroundCornerRadius)
-                            .overlay(
-                                RoundedRectangle(cornerRadius: Self.backgroundCornerRadius)
-                                    .foregroundStyle(Self.backgroundColor)
-                            )
-                            .padding(.leading, Self.backgroundHorizontalPadding)
-                            .padding(.trailing, Self.backgroundHorizontalPadding)
+                        GeometryReader { scrollContentGeometry -> Color in
+                            DispatchQueue.main.async {
+                                scrollContentHeight = scrollContentGeometry.size.height
+                            }
+                            return Color.clear
+                        }
                     )
-                }//end ZStack top content
-                .offset(y: !isVisible ? geometry.size.height * 0.75 : 0)
-                
-            }//end ZStack bottom
-        }
-        .onAppear {
-            setIsVisible(isVisible: true)
-        }
-        .environment(\.layoutDirection, ApplicationLayout.shared.layoutDirection)
-    }
-    
-    private func setIsVisible(isVisible: Bool) {
-        withAnimation {
-            self.isVisible = isVisible
+                }//end ScrollView
+                .clipped()
+                .frame(maxHeight: scrollContentHeight)
+            }//end VStack
+        } overlayTappedClosure: {
+            viewModel.closeTapped()
         }
     }
 }

--- a/godtools/App/Features/ToolSettings/Presentation/ToolSettings/ToolSettingsView.swift
+++ b/godtools/App/Features/ToolSettings/Presentation/ToolSettings/ToolSettingsView.swift
@@ -22,6 +22,7 @@ struct ToolSettingsView: View {
     
     @ObservedObject private var viewModel: ToolSettingsViewModel
     
+    @State private var modalIsHidden: Bool = true
     @State private var scrollContentHeight: CGFloat = 100
     
     init(viewModel: ToolSettingsViewModel) {
@@ -31,13 +32,14 @@ struct ToolSettingsView: View {
     
     var body: some View {
         
-        GTModalView { geometry in
+        GTModalView(content: { geometry in
             
             VStack(alignment: .leading, spacing: 0) {
                          
                 ToolSettingsTopBarView(
                     title: viewModel.title,
                     closeTapped: {
+                        modalIsHidden = true
                         viewModel.closeTapped()
                     }
                 )
@@ -103,8 +105,9 @@ struct ToolSettingsView: View {
                 .clipped()
                 .frame(maxHeight: scrollContentHeight)
             }//end VStack
-        } overlayTappedClosure: {
+        }, isHidden: $modalIsHidden, overlayTappedClosure: {
+            
             viewModel.closeTapped()
-        }
+        })
     }
 }

--- a/godtools/App/Flows/ToolScreenShare/ToolScreenShareFlowCreateSessionTrigger.swift
+++ b/godtools/App/Flows/ToolScreenShare/ToolScreenShareFlowCreateSessionTrigger.swift
@@ -10,8 +10,6 @@ import Foundation
 
 enum ToolScreenShareFlowCreateSessionTrigger {
     
-    case automatic
     case generateQRCodeTappedFromScreenShareTutorial
     case shareLinkTappedFromScreenShareTutorial
-    case skipTappedFromScreenShareTutorial
 }

--- a/godtools/App/Flows/ToolSettings/ToolSettingsFlow.swift
+++ b/godtools/App/Flows/ToolSettings/ToolSettingsFlow.swift
@@ -15,6 +15,7 @@ class ToolSettingsFlow: Flow {
     private let toolSettingsObserver: ToolSettingsObserver
     private let toolSettingsDidCloseClosure: (() -> Void)?
     
+    private var toolSettingsView: AppHostingController<ToolSettingsView>?
     private var toolScreenShareFlow: ToolScreenShareFlow?
     private var languagesListModal: UIViewController?
     private var reviewShareShareableModal: UIViewController?
@@ -30,11 +31,11 @@ class ToolSettingsFlow: Flow {
     let appDiContainer: AppDiContainer
     let navigationController: AppNavigationController
     
-    init(flowDelegate: FlowDelegate, appDiContainer: AppDiContainer, sharedNavigationController: AppNavigationController, toolSettingsObserver: ToolSettingsObserver, toolSettingsDidCloseClosure: (() -> Void)? = nil) {
+    init(flowDelegate: FlowDelegate, appDiContainer: AppDiContainer, presentInNavigationController: AppNavigationController, toolSettingsObserver: ToolSettingsObserver, toolSettingsDidCloseClosure: (() -> Void)? = nil) {
             
         self.flowDelegate = flowDelegate
         self.appDiContainer = appDiContainer
-        self.navigationController = sharedNavigationController
+        self.navigationController = presentInNavigationController
         self.toolSettingsObserver = toolSettingsObserver
         self.toolSettingsDidCloseClosure = toolSettingsDidCloseClosure
         
@@ -70,14 +71,12 @@ class ToolSettingsFlow: Flow {
             .getViewedPublisher(toolId: toolSettingsObserver.toolId)
             .receive(on: DispatchQueue.main)
             .assign(to: &$toolScreenShareTutorialHasBeenViewedDomainModel)
+        
+        presentToolSettings()
     }
     
     deinit {
         print("x deinit: \(type(of: self))")
-    }
-    
-    func getInitialView() -> UIViewController {
-        return getToolSettingsView()
     }
     
     func didClose() {
@@ -165,11 +164,47 @@ class ToolSettingsFlow: Flow {
     }
 }
 
-// MARK: -
+// MARK: - ToolSettingsView
 
 extension ToolSettingsFlow {
     
-    private func getToolSettingsView() -> UIViewController {
+    private func presentToolSettings() {
+        
+        guard toolSettingsView == nil else {
+            return
+        }
+        
+        let toolSettingsView: AppHostingController<ToolSettingsView> = getToolSettingsView()
+        
+        self.toolSettingsView = toolSettingsView
+        
+        navigationController.present(
+            toolSettingsView,
+            animated: true
+        )
+    }
+    
+    private func dismissToolSettingsIfPresented(animated: Bool, completion: (() -> Void)?) {
+        
+        guard let toolSettingsView = self.toolSettingsView else {
+            completion?()
+            return
+        }
+        
+        toolSettingsView.rootView.setModalIsHidden(isHidden: true)
+        
+        if animated {
+            toolSettingsView.dismiss(animated: true, completion: completion)
+        }
+        else {
+            toolSettingsView.dismiss(animated: false)
+            completion?()
+        }
+        
+        self.toolSettingsView = nil
+    }
+    
+    private func getToolSettingsView() -> AppHostingController<ToolSettingsView> {
         
         let viewModel = ToolSettingsViewModel(
             flowDelegate: self,
@@ -194,6 +229,11 @@ extension ToolSettingsFlow {
         
         return hostingView
     }
+}
+
+// MARK: - Share Tool View
+
+extension ToolSettingsFlow {
     
     private func getShareToolView(viewShareToolDomainModel: ViewShareToolDomainModel) -> UIViewController {
                 
@@ -271,16 +311,26 @@ extension ToolSettingsFlow {
 extension ToolSettingsFlow {
     
     private func presentToolScreenShareFlow() {
-        guard let toolSettingsObserver = toolSettingsObserver as? ToolScreenShareFlow.ToolScreenShareSettingsObserver else { return }
         
-        let toolScreenShareFlow = ToolScreenShareFlow(
-            flowDelegate: self,
-            appDiContainer: appDiContainer,
-            sharedNavigationController: navigationController,
-            toolSettingsObserver: toolSettingsObserver
-        )
+        guard let toolSettingsObserver = toolSettingsObserver as? ToolScreenShareFlow.ToolScreenShareSettingsObserver else {
+            return
+        }
         
-        self.toolScreenShareFlow = toolScreenShareFlow
+        dismissToolSettingsIfPresented(animated: true) { [weak self] in
+         
+            guard let weakSelf = self else {
+                return
+            }
+            
+            let toolScreenShareFlow = ToolScreenShareFlow(
+                flowDelegate: weakSelf,
+                appDiContainer: weakSelf.appDiContainer,
+                sharedNavigationController: weakSelf.navigationController,
+                toolSettingsObserver: toolSettingsObserver
+            )
+            
+            weakSelf.toolScreenShareFlow = toolScreenShareFlow
+        }
     }
     
     private func dismissToolScreenShareFlow() {

--- a/godtools/App/Flows/ToolSettings/ToolSettingsFlow.swift
+++ b/godtools/App/Flows/ToolSettings/ToolSettingsFlow.swift
@@ -180,10 +180,7 @@ extension ToolSettingsFlow {
             getShareableImageUseCase: appDiContainer.feature.shareables.domainLayer.getShareableImageUseCase()
         )
         
-        let toolSettingsView = ToolSettingsView(viewModel: viewModel, overlayTappedClosure: { [weak self] in
-            
-            self?.navigate(step: .closeTappedFromToolSettings)
-        })
+        let toolSettingsView = ToolSettingsView(viewModel: viewModel)
         
         let hostingView = AppHostingController<ToolSettingsView>(
             rootView: toolSettingsView,

--- a/godtools/App/Flows/ToolSettingsNavigationFlow/ToolSettingsNavigationFlow.swift
+++ b/godtools/App/Flows/ToolSettingsNavigationFlow/ToolSettingsNavigationFlow.swift
@@ -16,15 +16,14 @@ protocol ToolSettingsNavigationFlow: Flow {
 extension ToolSettingsNavigationFlow {
     
     func openToolSettings(toolSettingsObserver: ToolSettingsObserver, toolSettingsDidCloseClosure: (() -> Void)?) {
+        
         let toolSettingsFlow = ToolSettingsFlow(
             flowDelegate: self,
             appDiContainer: appDiContainer,
-            sharedNavigationController: navigationController,
+            presentInNavigationController: navigationController,
             toolSettingsObserver: toolSettingsObserver,
             toolSettingsDidCloseClosure: toolSettingsDidCloseClosure
         )
-        
-        navigationController.present(toolSettingsFlow.getInitialView(), animated: true)
         
         self.toolSettingsFlow = toolSettingsFlow
     }

--- a/godtools/App/Share/SwiftUI Views/GTModalView/GTModalView.swift
+++ b/godtools/App/Share/SwiftUI Views/GTModalView/GTModalView.swift
@@ -16,7 +16,7 @@ struct GTModalView<Content: View>: View {
     private let backgroundColor: Color = Color.white
     private let backgroundCornerRadius: CGFloat = 12
     private let backgroundHorizontalPadding: CGFloat = 10
-    private let contentAnimationDuration: TimeInterval = 0.4
+    private let contentAnimationDuration: TimeInterval = 0.3
     
     @State private var overlayOpacity: CGFloat = 0
     @State private var contentBottomOffsetY: CGFloat = UIScreen.main.bounds.size.height

--- a/godtools/App/Share/SwiftUI Views/GTModalView/GTModalView.swift
+++ b/godtools/App/Share/SwiftUI Views/GTModalView/GTModalView.swift
@@ -57,10 +57,24 @@ struct GTModalView<Content: View>: View {
                                         
                                         let currentContentHeight: CGFloat = self.contentHeight
                                         let newContentHeight: CGFloat = contentGeometry.size.height
+                                        let minimumHeight: CGFloat = floor(geometry.size.height * 0.33)
+                                        let maximumHeight: CGFloat = geometry.size.height
                                         
-                                        if currentContentHeight != newContentHeight {
+                                        let clampedContentHeight: CGFloat
+                                        
+                                        if newContentHeight < minimumHeight {
+                                            clampedContentHeight = minimumHeight
+                                        }
+                                        else if newContentHeight > maximumHeight {
+                                            clampedContentHeight = maximumHeight
+                                        }
+                                        else {
+                                            clampedContentHeight = newContentHeight
+                                        }
+                                        
+                                        if currentContentHeight != clampedContentHeight {
                                             
-                                            contentHeight = contentGeometry.size.height
+                                            contentHeight = clampedContentHeight
                                             
                                             if isHidden {
                                                 contentBottomOffsetY = contentHeight

--- a/godtools/App/Share/SwiftUI Views/GTModalView/GTModalView.swift
+++ b/godtools/App/Share/SwiftUI Views/GTModalView/GTModalView.swift
@@ -10,18 +10,17 @@ import SwiftUI
 
 struct GTModalView<Content: View>: View {
     
-    private let content: Content
+    private let content: (_ geometry: GeometryProxy) -> Content
     private let overlayTappedClosure: (() -> Void)?
-    
     private let backgroundColor: Color = Color.white
     private let backgroundCornerRadius: CGFloat = 12
     private let backgroundHorizontalPadding: CGFloat = 10
     
     @State private var isVisible: Bool = false
     
-    init(@ViewBuilder content: () -> Content, overlayTappedClosure: (() -> Void)? = nil) {
+    init(@ViewBuilder content: @escaping (_ geometry: GeometryProxy) -> Content, overlayTappedClosure: (() -> Void)?) {
         
-        self.content = content()
+        self.content = content
         self.overlayTappedClosure = overlayTappedClosure
     }
     
@@ -45,8 +44,7 @@ struct GTModalView<Content: View>: View {
                                               
                     VStack(alignment: .leading, spacing: 0) {
                                  
-                       content
-                          
+                       content(geometry)
                     }
                     .background(
                         RoundedRectangle(cornerRadius: backgroundCornerRadius)
@@ -59,7 +57,6 @@ struct GTModalView<Content: View>: View {
                     )
                 }
                 .offset(y: !isVisible ? geometry.size.height * 0.75 : 0)
-                
             }
         }
         .onAppear {


### PR DESCRIPTION
Changes in this PR:
- Added isHidden Binding to GTModalView.  This way external views can control showing / hiding the modal.
- Apply GTModalView to ToolSettingsView.
- When tapping share screen from tool settings, the tool settings view will be hidden / dismissed.
- Fixed an issue where the tool screen share session was getting created twice.  Now when tool screen share is tapped it will either start at the beginning of the tutorial if the tutorial hasn't been viewed or the last page of the tutorial with qr code option or share link option.
- Ensure screen share tutorial is dimissed before presenting next view controller. This should address where the view would sometimes delay before being presented. (https://github.com/CruGlobal/godtools-swift/blob/GT-2671-tool-settings-and-tool-screen-share-navigation-fixes/godtools/App/Flows/ToolScreenShare/ToolScreenShareFlow.swift#L125)
- If share tool screen is tapped from tool settings and a screen share is already active, the last page of the tutorial screen is presented with qr code and share link options. The tool screen share session won't be created again.