### PR TITLE
GT add flag to enable url session

### DIFF
--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -100,13 +100,11 @@
 		450EE29E29A66CA500524F64 /* KnowGodDeepLinkParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450EE29D29A66CA500524F64 /* KnowGodDeepLinkParser.swift */; };
 		450EE2A029A66CDF00524F64 /* KnowGodTractDeepLinkQueryParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450EE29F29A66CDF00524F64 /* KnowGodTractDeepLinkQueryParameters.swift */; };
 		450EE2AB29A6719500524F64 /* GodToolsAppLessonsPathDeepLinkParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450EE2AA29A6719500524F64 /* GodToolsAppLessonsPathDeepLinkParser.swift */; };
-		450EECAC2E422E8F00C0442E /* UITestsLaunchEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450EECAB2E422E7D00C0442E /* UITestsLaunchEnvironment.swift */; };
 		450EECAD2E422E8F00C0442E /* UITestsLaunchEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450EECAB2E422E7D00C0442E /* UITestsLaunchEnvironment.swift */; };
 		450EECAF2E422F4000C0442E /* UITestsLaunchEnvironmentKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450EECAE2E422F4000C0442E /* UITestsLaunchEnvironmentKey.swift */; };
 		450EECB02E422F4000C0442E /* UITestsLaunchEnvironmentKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450EECAE2E422F4000C0442E /* UITestsLaunchEnvironmentKey.swift */; };
 		450EECB52E42347900C0442E /* LaunchEnvironmentWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450EECB42E42347300C0442E /* LaunchEnvironmentWriter.swift */; };
 		450EECB62E42347900C0442E /* LaunchEnvironmentWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450EECB42E42347300C0442E /* LaunchEnvironmentWriter.swift */; };
-		450EECB82E4234A000C0442E /* LaunchEnvironmentKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450EECB72E42349A00C0442E /* LaunchEnvironmentKey.swift */; };
 		450EECB92E4234A000C0442E /* LaunchEnvironmentKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450EECB72E42349A00C0442E /* LaunchEnvironmentKey.swift */; };
 		450EF834247EB3D300978926 /* SF-Pro-Text-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 450EF833247EB3D300978926 /* SF-Pro-Text-Bold.otf */; };
 		450F94DA27A1F0F6009DEA43 /* MobileContentCardCollectionPageCardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450F94D627A1F0F6009DEA43 /* MobileContentCardCollectionPageCardViewModel.swift */; };
@@ -169,7 +167,6 @@
 		451CF5952C4AAC5500CD65C4 /* AppFlowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 451CF5942C4AAC5500CD65C4 /* AppFlowTests.swift */; };
 		451F1EDB2CD3AF14006CCF4E /* DisabledInAppMessaging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 451F1EDA2CD3AF13006CCF4E /* DisabledInAppMessaging.swift */; };
 		451F1EE32CD3B38B006CCF4E /* LaunchEnvironmentReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 451F1EE22CD3B387006CCF4E /* LaunchEnvironmentReader.swift */; };
-		451F1EE42CD3B38B006CCF4E /* LaunchEnvironmentReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 451F1EE22CD3B387006CCF4E /* LaunchEnvironmentReader.swift */; };
 		45210E382E437E7000A5017B /* DoesNotSendUrlRequestSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45210E322E437E7000A5017B /* DoesNotSendUrlRequestSender.swift */; };
 		4521B2802B32851F00C8A473 /* GetShareableImageRepositoryInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4521B27F2B32851F00C8A473 /* GetShareableImageRepositoryInterface.swift */; };
 		4521B2822B32853E00C8A473 /* GetShareableImageRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4521B2812B32853E00C8A473 /* GetShareableImageRepository.swift */; };
@@ -625,6 +622,11 @@
 		457102002AB9DDDB00D1BFFC /* MobileContentApiErrorCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 457101FE2AB9DDDB00D1BFFC /* MobileContentApiErrorCodable.swift */; };
 		457102012AB9DDDB00D1BFFC /* MobileContentApiErrorsCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 457101FF2AB9DDDB00D1BFFC /* MobileContentApiErrorsCodable.swift */; };
 		4571020B2AB9E55F00D1BFFC /* MobileContentApiError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4571020A2AB9E55F00D1BFFC /* MobileContentApiError.swift */; };
+		45720D562E43A0E7005C27BA /* SwiftUIPreviewToolNames.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45720D552E43A0D8005C27BA /* SwiftUIPreviewToolNames.swift */; };
+		45720D572E43A420005C27BA /* SwiftUIPreviewToolNames.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45720D552E43A0D8005C27BA /* SwiftUIPreviewToolNames.swift */; };
+		45720D582E43A4A1005C27BA /* LaunchEnvironmentKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450EECB72E42349A00C0442E /* LaunchEnvironmentKey.swift */; };
+		45720D592E43A4D3005C27BA /* UITestsLaunchEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450EECAB2E422E7D00C0442E /* UITestsLaunchEnvironment.swift */; };
+		45720D5A2E43A4D9005C27BA /* LaunchEnvironmentReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 451F1EE22CD3B387006CCF4E /* LaunchEnvironmentReader.swift */; };
 		45723DF72ABA24CE00C697E6 /* MobileContentApiErrorCodableCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45723DF62ABA24CE00C697E6 /* MobileContentApiErrorCodableCode.swift */; };
 		4572E4B228CBCF120014DB2E /* FavoritingToolMessageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4572E4B128CBCF110014DB2E /* FavoritingToolMessageCache.swift */; };
 		4573133728C1821100481640 /* ToolDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4573132928C1821100481640 /* ToolDetailsViewModel.swift */; };
@@ -1065,7 +1067,6 @@
 		45B212B629229CBA00C9A94D /* SwiftUIPreviewDiContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B212B529229CBA00C9A94D /* SwiftUIPreviewDiContainer.swift */; };
 		45B224F72E3B909F002C4042 /* LearnToShareToolFlowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B224F62E3B9099002C4042 /* LearnToShareToolFlowTests.swift */; };
 		45B224FE2E3B9791002C4042 /* XCUIApplication+Query.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B224FA2E3B9791002C4042 /* XCUIApplication+Query.swift */; };
-		45B225002E3B97A0002C4042 /* ToolNames.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B224FF2E3B979B002C4042 /* ToolNames.swift */; };
 		45B3382B2AF42A3900D18C63 /* GetTutorialInterfaceStringsRepositoryInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B3382A2AF42A3900D18C63 /* GetTutorialInterfaceStringsRepositoryInterface.swift */; };
 		45B3382F2AF42A6400D18C63 /* TutorialInterfaceStringsDomainModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B3382E2AF42A6400D18C63 /* TutorialInterfaceStringsDomainModel.swift */; };
 		45B338312AF42A9400D18C63 /* GetTutorialInterfaceStringsRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B338302AF42A9400D18C63 /* GetTutorialInterfaceStringsRepository.swift */; };
@@ -2433,6 +2434,7 @@
 		457101FE2AB9DDDB00D1BFFC /* MobileContentApiErrorCodable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MobileContentApiErrorCodable.swift; sourceTree = "<group>"; };
 		457101FF2AB9DDDB00D1BFFC /* MobileContentApiErrorsCodable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MobileContentApiErrorsCodable.swift; sourceTree = "<group>"; };
 		4571020A2AB9E55F00D1BFFC /* MobileContentApiError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MobileContentApiError.swift; sourceTree = "<group>"; };
+		45720D552E43A0D8005C27BA /* SwiftUIPreviewToolNames.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIPreviewToolNames.swift; sourceTree = "<group>"; };
 		45723DF62ABA24CE00C697E6 /* MobileContentApiErrorCodableCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileContentApiErrorCodableCode.swift; sourceTree = "<group>"; };
 		4572E4B128CBCF110014DB2E /* FavoritingToolMessageCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FavoritingToolMessageCache.swift; sourceTree = "<group>"; };
 		4573132928C1821100481640 /* ToolDetailsViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToolDetailsViewModel.swift; sourceTree = "<group>"; };
@@ -2863,7 +2865,6 @@
 		45B212B529229CBA00C9A94D /* SwiftUIPreviewDiContainer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftUIPreviewDiContainer.swift; sourceTree = "<group>"; };
 		45B224F62E3B9099002C4042 /* LearnToShareToolFlowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnToShareToolFlowTests.swift; sourceTree = "<group>"; };
 		45B224FA2E3B9791002C4042 /* XCUIApplication+Query.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIApplication+Query.swift"; sourceTree = "<group>"; };
-		45B224FF2E3B979B002C4042 /* ToolNames.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolNames.swift; sourceTree = "<group>"; };
 		45B3382A2AF42A3900D18C63 /* GetTutorialInterfaceStringsRepositoryInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetTutorialInterfaceStringsRepositoryInterface.swift; sourceTree = "<group>"; };
 		45B3382E2AF42A6400D18C63 /* TutorialInterfaceStringsDomainModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TutorialInterfaceStringsDomainModel.swift; sourceTree = "<group>"; };
 		45B338302AF42A9400D18C63 /* GetTutorialInterfaceStringsRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetTutorialInterfaceStringsRepository.swift; sourceTree = "<group>"; };
@@ -9467,19 +9468,10 @@
 			path = Extensions;
 			sourceTree = "<group>";
 		};
-		45B224FC2E3B9791002C4042 /* Strings */ = {
-			isa = PBXGroup;
-			children = (
-				45B224FF2E3B979B002C4042 /* ToolNames.swift */,
-			);
-			path = Strings;
-			sourceTree = "<group>";
-		};
 		45B224FD2E3B9791002C4042 /* Share */ = {
 			isa = PBXGroup;
 			children = (
 				45B224FB2E3B9791002C4042 /* Extensions */,
-				45B224FC2E3B9791002C4042 /* Strings */,
 			);
 			path = Share;
 			sourceTree = "<group>";
@@ -10651,6 +10643,7 @@
 			children = (
 				45F305822A9BAF4200BDFB93 /* SwiftUIPreviewDatabase.swift */,
 				45D7CAEA2A9BA23C00913E12 /* SwiftUIPreviewDatabaseConfiguration.swift */,
+				45720D552E43A0D8005C27BA /* SwiftUIPreviewToolNames.swift */,
 			);
 			path = RealmDatabase;
 			sourceTree = "<group>";
@@ -13460,27 +13453,27 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				450EECB82E4234A000C0442E /* LaunchEnvironmentKey.swift in Sources */,
 				450FC7592C49591700F87282 /* MenuFlowTests.swift in Sources */,
-				451F1EE42CD3B38B006CCF4E /* LaunchEnvironmentReader.swift in Sources */,
 				45B224FE2E3B9791002C4042 /* XCUIApplication+Query.swift in Sources */,
 				45FBE5722AB8A33200BFBE92 /* AccessibilityStrings.swift in Sources */,
+				45720D572E43A420005C27BA /* SwiftUIPreviewToolNames.swift in Sources */,
 				45D318F12AE6F9D300D74A87 /* LanguageCodeDomainModel.swift in Sources */,
 				450EECB52E42347900C0442E /* LaunchEnvironmentWriter.swift in Sources */,
+				45720D5A2E43A4D9005C27BA /* LaunchEnvironmentReader.swift in Sources */,
 				453835262DF78148005F1ABA /* DashboardFlowTests.swift in Sources */,
 				4585E4B82B05895200223A9B /* BCP47LanguageIdentifier.swift in Sources */,
-				45B225002E3B97A0002C4042 /* ToolNames.swift in Sources */,
 				45DC19152BB5B33F007542A5 /* ChooseAppLanguageFlowTests.swift in Sources */,
 				452447292E3D2F0B00C0831A /* ToolScreenShareFlowTests.swift in Sources */,
 				451CF5952C4AAC5500CD65C4 /* AppFlowTests.swift in Sources */,
 				45B224F72E3B909F002C4042 /* LearnToShareToolFlowTests.swift in Sources */,
 				45D318FB2AE7020200D74A87 /* AppLanguageDataModel.swift in Sources */,
-				450EECAC2E422E8F00C0442E /* UITestsLaunchEnvironment.swift in Sources */,
 				450EECB02E422F4000C0442E /* UITestsLaunchEnvironmentKey.swift in Sources */,
+				45720D592E43A4D3005C27BA /* UITestsLaunchEnvironment.swift in Sources */,
 				45A415F32A99429C0030E2C7 /* OnboardingFlowTests.swift in Sources */,
 				45DC19122BB5AB2C007542A5 /* LanguageSettingsFlowTests.swift in Sources */,
 				45DC19172BB5B34D007542A5 /* BaseFlowTests.swift in Sources */,
 				452556472C383CFA00AA0046 /* AppLanguageDataModelInterface.swift in Sources */,
+				45720D582E43A4A1005C27BA /* LaunchEnvironmentKey.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -14691,6 +14684,7 @@
 				4587212C2BFB7E0C005DA242 /* ViewDeleteAccountUseCase.swift in Sources */,
 				45A8BE032ACC9FB3007A1EBB /* GetLessonsListRepository.swift in Sources */,
 				45B6FF482BAA39DE0037B240 /* SearchLanguageInDownloadableLanguagesRepositoryInterface.swift in Sources */,
+				45720D562E43A0E7005C27BA /* SwiftUIPreviewToolNames.swift in Sources */,
 				4561AC94279C4C7D003718C0 /* MobileContentContentPageView.swift in Sources */,
 				45E39ED327457CB5006A59E4 /* MobileContentAnimationView.swift in Sources */,
 				45880D8D2BD2BD65008F021C /* ShareGodToolsInterfaceStringsDomainModel.swift in Sources */,

--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -170,6 +170,7 @@
 		451F1EDB2CD3AF14006CCF4E /* DisabledInAppMessaging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 451F1EDA2CD3AF13006CCF4E /* DisabledInAppMessaging.swift */; };
 		451F1EE32CD3B38B006CCF4E /* LaunchEnvironmentReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 451F1EE22CD3B387006CCF4E /* LaunchEnvironmentReader.swift */; };
 		451F1EE42CD3B38B006CCF4E /* LaunchEnvironmentReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 451F1EE22CD3B387006CCF4E /* LaunchEnvironmentReader.swift */; };
+		45210E382E437E7000A5017B /* DoesNotSendUrlRequestSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45210E322E437E7000A5017B /* DoesNotSendUrlRequestSender.swift */; };
 		4521B2802B32851F00C8A473 /* GetShareableImageRepositoryInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4521B27F2B32851F00C8A473 /* GetShareableImageRepositoryInterface.swift */; };
 		4521B2822B32853E00C8A473 /* GetShareableImageRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4521B2812B32853E00C8A473 /* GetShareableImageRepository.swift */; };
 		4521E5EB2D690BCC003E01FE /* SwiftUITimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4521E5E92D690BCC003E01FE /* SwiftUITimer.swift */; };
@@ -1978,6 +1979,7 @@
 		451F1EE22CD3B387006CCF4E /* LaunchEnvironmentReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchEnvironmentReader.swift; sourceTree = "<group>"; };
 		451F7A802ABD2F1100006EF2 /* Quick.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Quick.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		451F7A822ABD2F1400006EF2 /* Nimble.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Nimble.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		45210E322E437E7000A5017B /* DoesNotSendUrlRequestSender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoesNotSendUrlRequestSender.swift; sourceTree = "<group>"; };
 		4521B27F2B32851F00C8A473 /* GetShareableImageRepositoryInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetShareableImageRepositoryInterface.swift; sourceTree = "<group>"; };
 		4521B2812B32853E00C8A473 /* GetShareableImageRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetShareableImageRepository.swift; sourceTree = "<group>"; };
 		4521E5E92D690BCC003E01FE /* SwiftUITimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUITimer.swift; sourceTree = "<group>"; };
@@ -4146,6 +4148,7 @@
 				D42FEBDD287605D60002FAD9 /* OptInOnboardingBannerEnabledRepository */,
 				45B212A82922965F00C9A94D /* RealmDatabase */,
 				455258482D36F66E00FAC98D /* RemoteConfigRepository */,
+				45210E352E437E7000A5017B /* RequestSender */,
 				45D63E8C288F77D4009B4610 /* ResourcesRepository */,
 				45E8FA9D2882FD1B00D7D569 /* ResourcesSHA256FileCache */,
 				45BDA5B92954F5CF007E259B /* ResourceViewsService */,
@@ -4481,6 +4484,14 @@
 				451F1EDA2CD3AF13006CCF4E /* DisabledInAppMessaging.swift */,
 			);
 			path = DisabledInAppMessaging;
+			sourceTree = "<group>";
+		};
+		45210E352E437E7000A5017B /* RequestSender */ = {
+			isa = PBXGroup;
+			children = (
+				45210E322E437E7000A5017B /* DoesNotSendUrlRequestSender.swift */,
+			);
+			path = RequestSender;
 			sourceTree = "<group>";
 		};
 		4521E5EA2D690BCC003E01FE /* SwiftUITimer */ = {
@@ -15025,6 +15036,7 @@
 				45E4DBCB2BECFB20006ED2F3 /* AppLanguageCodable.swift in Sources */,
 				4534F9202AE99EBC00A7A071 /* GetLessonEvaluationInterfaceStringsRepository.swift in Sources */,
 				45D63E76288F698C009B4610 /* MobileContentLanguagesApi.swift in Sources */,
+				45210E382E437E7000A5017B /* DoesNotSendUrlRequestSender.swift in Sources */,
 				D4C2A5812C348FAD0035AB4D /* SearchLessonFilterLanguagesRepository.swift in Sources */,
 				454B47E82AE024E000C7B5E7 /* OnboardingDataLayerDependencies.swift in Sources */,
 				457766E72AD6F3180093B19A /* GetToolDetailsInterfaceStringsRepository.swift in Sources */,

--- a/godtools/App/DependencyContainer/AppDiContainer.swift
+++ b/godtools/App/DependencyContainer/AppDiContainer.swift
@@ -19,7 +19,7 @@ class AppDiContainer {
     let domainLayer: AppDomainLayerDependencies
     let feature: AppFeatureDiContainer
         
-    init(appBuild: AppBuild, appConfig: AppConfig, realmDatabase: RealmDatabase, firebaseEnabled: Bool) {
+    init(appBuild: AppBuild, appConfig: AppConfig, realmDatabase: RealmDatabase, firebaseEnabled: Bool, urlSessionEnabled: Bool) {
                
         self.appBuild = appBuild
         self.realmDatabase = realmDatabase
@@ -28,7 +28,8 @@ class AppDiContainer {
             appBuild: appBuild,
             appConfig: appConfig,
             realmDatabase: realmDatabase,
-            firebaseEnabled: firebaseEnabled
+            firebaseEnabled: firebaseEnabled,
+            urlSessionEnabled: urlSessionEnabled
         )
         
         domainLayer = AppDomainLayerDependencies(dataLayer: dataLayer)

--- a/godtools/App/Features/GlobalActivity/Data/GlobalAnalyticsRepository/Api/MobileContentGlobalAnalyticsApi.swift
+++ b/godtools/App/Features/GlobalActivity/Data/GlobalAnalyticsRepository/Api/MobileContentGlobalAnalyticsApi.swift
@@ -15,13 +15,14 @@ class MobileContentGlobalAnalyticsApi {
     static let sharedGlobalAnalyticsId: String = "1"
     
     private let requestBuilder: RequestBuilder = RequestBuilder()
-    private let requestSender: RequestSender = RequestSender()
     private let urlSessionPriority: URLSessionPriority
+    private let requestSender: RequestSender
     private let baseUrl: String
     
-    init(baseUrl: String, urlSessionPriority: URLSessionPriority) {
+    init(baseUrl: String, urlSessionPriority: URLSessionPriority, requestSender: RequestSender) {
         
         self.urlSessionPriority = urlSessionPriority
+        self.requestSender = requestSender
         self.baseUrl = baseUrl
     }
       

--- a/godtools/App/Features/GlobalActivity/DependencyContainer/GlobalActivityDataLayerDependencies.swift
+++ b/godtools/App/Features/GlobalActivity/DependencyContainer/GlobalActivityDataLayerDependencies.swift
@@ -24,7 +24,8 @@ class GlobalActivityDataLayerDependencies {
         return GlobalAnalyticsRepository(
             api: MobileContentGlobalAnalyticsApi(
                 baseUrl: coreDataLayer.getAppConfig().getMobileContentApiBaseUrl(),
-                urlSessionPriority: coreDataLayer.getSharedUrlSessionPriority()
+                urlSessionPriority: coreDataLayer.getSharedUrlSessionPriority(),
+                requestSender: coreDataLayer.getSharedRequestSender()
             ),
             cache: RealmGlobalAnalyticsCache(
                 realmDatabase: coreDataLayer.getSharedRealmDatabase()

--- a/godtools/App/GodToolsApp.swift
+++ b/godtools/App/GodToolsApp.swift
@@ -34,7 +34,7 @@ struct GodToolsApp: App {
     }
     
     private static var urlSessionEnabled: Bool {
-        return !isUITests
+        return true//!isUITests
     }
     
     private let appFlow: AppFlow

--- a/godtools/App/GodToolsApp.swift
+++ b/godtools/App/GodToolsApp.swift
@@ -21,7 +21,8 @@ struct GodToolsApp: App {
         appBuild: appBuild,
         appConfig: appConfig,
         realmDatabase: realmDatabase,
-        firebaseEnabled: firebaseEnabled
+        firebaseEnabled: firebaseEnabled,
+        urlSessionEnabled: urlSessionEnabled
     )
     
     private static var isUITests: Bool {
@@ -29,6 +30,10 @@ struct GodToolsApp: App {
     }
 
     private static var firebaseEnabled: Bool {
+        return !isUITests
+    }
+    
+    private static var urlSessionEnabled: Bool {
         return !isUITests
     }
     

--- a/godtools/App/Preview/Data/RealmDatabase/SwiftUIPreviewDatabase.swift
+++ b/godtools/App/Preview/Data/RealmDatabase/SwiftUIPreviewDatabase.swift
@@ -11,7 +11,7 @@ import RealmSwift
 
 class SwiftUIPreviewDatabase: RealmDatabase {
     
-    override init(databaseConfiguration: RealmDatabaseConfiguration, realmInstanceCreationType: RealmInstanceCreationType = .alwaysCreatesANewRealmInstance) {
+    override init(databaseConfiguration: RealmDatabaseConfiguration, realmInstanceCreationType: RealmInstanceCreationType = .usesASingleSharedRealmInstance) {
         
         super.init(databaseConfiguration: databaseConfiguration, realmInstanceCreationType: realmInstanceCreationType)
         

--- a/godtools/App/Preview/Data/RealmDatabase/SwiftUIPreviewDatabase.swift
+++ b/godtools/App/Preview/Data/RealmDatabase/SwiftUIPreviewDatabase.swift
@@ -11,9 +11,9 @@ import RealmSwift
 
 class SwiftUIPreviewDatabase: RealmDatabase {
     
-    override init(databaseConfiguration: RealmDatabaseConfiguration, realmInstanceCreationType: RealmInstanceCreationType = .usesASingleSharedRealmInstance) {
+    init() {
         
-        super.init(databaseConfiguration: databaseConfiguration, realmInstanceCreationType: realmInstanceCreationType)
+        super.init(databaseConfiguration: SwiftUIPreviewDatabaseConfiguration(), realmInstanceCreationType: .usesASingleSharedRealmInstance)
         
         let objects: [Object] = getResources() + getLanguages()
         
@@ -33,17 +33,11 @@ class SwiftUIPreviewDatabase: RealmDatabase {
     
     private func getResources() -> [RealmResource] {
         
-        let resourceKgpGospel = RealmResource()
-        
-        resourceKgpGospel.abbreviation = "kgp"
-        resourceKgpGospel.attrCategory = "gospel"
-        resourceKgpGospel.attrSpotlight = true
-        resourceKgpGospel.id = "1"
-        resourceKgpGospel.name = "Preview Resource"
-        resourceKgpGospel.resourceDescription = ""
-        resourceKgpGospel.totalViews = 12579
-        
-        return [resourceKgpGospel]
+        return [
+            Self.getKgpTool(),
+            Self.getTeachMeToShareTool(),
+            Self.getFourSpiritualLawsTool()
+        ]
     }
     
     private func getLanguages() -> [RealmLanguage] {
@@ -56,5 +50,53 @@ class SwiftUIPreviewDatabase: RealmDatabase {
         english.name = "English"
         
         return [english]
+    }
+}
+
+extension SwiftUIPreviewDatabase {
+    
+    private static func getKgpTool() -> RealmResource {
+        
+        let resource = RealmResource()
+        
+        resource.abbreviation = "kgp"
+        resource.attrCategory = "gospel"
+        resource.attrSpotlight = true
+        resource.id = "1"
+        resource.name = SwiftUIPreviewToolNames.English.knowingGodPersonally
+        resource.resourceDescription = "A Gospel presentation that uses hand drawn images to help illustrate God's invitation to know Him personally. \n\nConversation starter: Has anyone ever shared with you how you can know God personally?\n\nAll Bible references are from the New Living Translation."
+        resource.totalViews = 12579
+        
+        return resource
+    }
+    
+    private static func getTeachMeToShareTool() -> RealmResource {
+        
+        let resource = RealmResource()
+        
+        resource.abbreviation = "teachmetoshare"
+        resource.attrCategory = "training"
+        resource.attrSpotlight = true
+        resource.id = "8"
+        resource.name = SwiftUIPreviewToolNames.English.teachMeToShare
+        resource.resourceDescription = "Training tips on how to share your faith."
+        resource.totalViews = 615670
+        
+        return resource
+    }
+    
+    private static func getFourSpiritualLawsTool() -> RealmResource {
+        
+        let resource = RealmResource()
+        
+        resource.abbreviation = "fourlaws"
+        resource.attrCategory = "gospel"
+        resource.attrSpotlight = false
+        resource.id = "4"
+        resource.name = SwiftUIPreviewToolNames.English.fourSpiritualLaws
+        resource.resourceDescription = "Classic gospel presentation of God's invitation to those who don't yet know him. \n\nConversation starter: I have a summary of the Bible's message using four simple ideas. May I share it with you?\n\nAll Bible references are from the New American Standard Bible unless otherwise stated."
+        resource.totalViews = 2533146
+        
+        return resource
     }
 }

--- a/godtools/App/Preview/Data/RealmDatabase/SwiftUIPreviewToolNames.swift
+++ b/godtools/App/Preview/Data/RealmDatabase/SwiftUIPreviewToolNames.swift
@@ -1,14 +1,17 @@
 //
-//  ToolNames.swift
+//  SwiftUIPreviewToolNames.swift
 //  godtools
 //
-//  Created by Levi Eggert on 7/31/25.
+//  Created by Levi Eggert on 8/6/25.
 //  Copyright © 2025 Cru. All rights reserved.
 //
 
-struct ToolNames {
+import Foundation
+
+struct SwiftUIPreviewToolNames {
     struct English {
         static let fourSpiritualLaws: String = "four spiritual laws"
+        static let knowingGodPersonally: String = "knowing god personally"
         static let teachMeToShare: String = "teach me to share"
     }
 }

--- a/godtools/App/Preview/DependencyContainer/SwiftUIPreviewDiContainer.swift
+++ b/godtools/App/Preview/DependencyContainer/SwiftUIPreviewDiContainer.swift
@@ -25,7 +25,8 @@ class SwiftUIPreviewDiContainer {
             appBuild: appBuild,
             appConfig: AppConfig(appBuild: appBuild),
             realmDatabase: SwiftUIPreviewDiContainer.previewDatabase,
-            firebaseEnabled: false
+            firebaseEnabled: false,
+            urlSessionEnabled: false
         )
     }
 }

--- a/godtools/App/Preview/DependencyContainer/SwiftUIPreviewDiContainer.swift
+++ b/godtools/App/Preview/DependencyContainer/SwiftUIPreviewDiContainer.swift
@@ -11,7 +11,7 @@ import RealmSwift
 
 class SwiftUIPreviewDiContainer {
     
-    private static let previewDatabase: SwiftUIPreviewDatabase = SwiftUIPreviewDatabase(databaseConfiguration: SwiftUIPreviewDatabaseConfiguration())
+    private static let previewDatabase: SwiftUIPreviewDatabase = SwiftUIPreviewDatabase()
     
     init() {
         

--- a/godtools/App/Preview/Presentation/TestPreview/TestPreview.swift
+++ b/godtools/App/Preview/Presentation/TestPreview/TestPreview.swift
@@ -10,9 +10,19 @@ import SwiftUI
 
 struct TestPreview: View {
 
+    private let title: String
+    
+    init(title: String) {
+        self.title = title
+    }
+    
     var body: some View {
         GeometryReader { geometry in
             VStack(alignment: .center, spacing: 0) {
+                
+                Text(title)
+                    .foregroundStyle(.black)
+                
                 Rectangle()
                     .fill(Color.red)
                     .frame(width: 100, height: 100)
@@ -22,5 +32,11 @@ struct TestPreview: View {
 }
 
 #Preview {
-    TestPreview()
+    
+    let appDiContainer: AppDiContainer = SwiftUIPreviewDiContainer().getAppDiContainer()
+    let resource: ResourceModel? = appDiContainer.dataLayer.getResourcesRepository().getResource(id: "1")
+    
+    TestPreview(
+        title: resource?.name ?? "no name"
+    )
 }

--- a/godtools/App/Share/Data/ArticlesRepository/Articles/Downloader/ArticleAemDownloader.swift
+++ b/godtools/App/Share/Data/ArticlesRepository/Articles/Downloader/ArticleAemDownloader.swift
@@ -12,13 +12,14 @@ import Combine
 
 class ArticleAemDownloader {
             
-    private let requestSender: RequestSender = RequestSender()
     private let urlSessionPriority: URLSessionPriority
+    private let requestSender: RequestSender
     private let maxAemJsonTreeLevels: Int = 9999
         
-    init(urlSessionPriority: URLSessionPriority) {
+    init(urlSessionPriority: URLSessionPriority, requestSender: RequestSender) {
         
         self.urlSessionPriority = urlSessionPriority
+        self.requestSender = requestSender
     }
     
     func downloadPublisher(aemUris: [String], downloadCachePolicy: ArticleAemDownloaderCachePolicy, requestPriority: RequestPriority) -> AnyPublisher<ArticleAemDownloaderResult, Never> {

--- a/godtools/App/Share/Data/ArticlesRepository/Articles/WebArchiver/ArticleWebArchiver.swift
+++ b/godtools/App/Share/Data/ArticlesRepository/Articles/WebArchiver/ArticleWebArchiver.swift
@@ -13,14 +13,15 @@ import Fuzi
 
 class ArticleWebArchiver {
     
-    private let requestSender: RequestSender = RequestSender()
     private let urlSessionPriority: URLSessionPriority
+    private let requestSender: RequestSender
     private let includeJavascript: Bool = true
     private let errorDomain: String = "ArticleWebArchiver"
         
-    init(urlSessionPriority: URLSessionPriority) {
+    init(urlSessionPriority: URLSessionPriority, requestSender: RequestSender) {
         
         self.urlSessionPriority = urlSessionPriority
+        self.requestSender = requestSender
     }
     
     func archivePublisher(webArchiveUrls: [WebArchiveUrl], requestPriority: RequestPriority) -> AnyPublisher<ArticleWebArchiverResult, Never> {

--- a/godtools/App/Share/Data/AttachmentsRepository/Api/MobileContentAttachmentsApi.swift
+++ b/godtools/App/Share/Data/AttachmentsRepository/Api/MobileContentAttachmentsApi.swift
@@ -12,13 +12,14 @@ import RequestOperation
 
 class MobileContentAttachmentsApi {
     
-    private let requestSender: RequestSender = RequestSender()
     private let urlSessionPriority: URLSessionPriority
+    private let requestSender: RequestSender
     private let baseUrl: String
     
-    init(config: AppConfig, urlSessionPriority: URLSessionPriority) {
+    init(config: AppConfig, urlSessionPriority: URLSessionPriority, requestSender: RequestSender) {
                     
         self.urlSessionPriority = urlSessionPriority
+        self.requestSender = requestSender
         baseUrl = config.getMobileContentApiBaseUrl()
     }
     

--- a/godtools/App/Share/Data/EmailSignUpService/Api/EmailSignUpApi.swift
+++ b/godtools/App/Share/Data/EmailSignUpService/Api/EmailSignUpApi.swift
@@ -13,14 +13,15 @@ import Combine
 class EmailSignUpApi {
     
     private let requestBuilder: RequestBuilder = RequestBuilder()
-    private let requestSender: RequestSender = RequestSender()
     private let urlSessionPriority: URLSessionPriority
+    private let requestSender: RequestSender
     private let baseUrl: String = "https://campaign-forms.cru.org"
     private let campaignId: String = "3fb6022c-5ef9-458c-928a-0380c4a0e57b"
     
-    init(urlSessionPriority: URLSessionPriority) {
+    init(urlSessionPriority: URLSessionPriority, requestSender: RequestSender) {
         
         self.urlSessionPriority = urlSessionPriority
+        self.requestSender = requestSender
     }
     
     private func getEmailSignUpRequest(emailSignUp: EmailSignUpModelType, urlSession: URLSession) -> URLRequest {

--- a/godtools/App/Share/Data/FollowUpsService/Api/FollowUpsApi.swift
+++ b/godtools/App/Share/Data/FollowUpsService/Api/FollowUpsApi.swift
@@ -13,13 +13,14 @@ import Combine
 class FollowUpsApi {
     
     private let requestBuilder: RequestBuilder = RequestBuilder()
-    private let requestSender: RequestSender = RequestSender()
     private let urlSessionPriority: URLSessionPriority
+    private let requestSender: RequestSender
     private let baseUrl: String
     
-    init(baseUrl: String, urlSessionPriority: URLSessionPriority) {
+    init(baseUrl: String, urlSessionPriority: URLSessionPriority, requestSender: RequestSender) {
         
         self.urlSessionPriority = urlSessionPriority
+        self.requestSender = requestSender
         self.baseUrl = baseUrl
     }
     

--- a/godtools/App/Share/Data/LanguagesRepository/Api/MobileContentLanguagesApi.swift
+++ b/godtools/App/Share/Data/LanguagesRepository/Api/MobileContentLanguagesApi.swift
@@ -17,13 +17,14 @@ class MobileContentLanguagesApi {
     }
     
     private let requestBuilder: RequestBuilder = RequestBuilder()
-    private let requestSender: RequestSender = RequestSender()
     private let urlSessionPriority: URLSessionPriority
+    private let requestSender: RequestSender
     private let baseUrl: String
     
-    init(config: AppConfig, urlSessionPriority: URLSessionPriority) {
+    init(config: AppConfig, urlSessionPriority: URLSessionPriority, requestSender: RequestSender) {
             
         self.urlSessionPriority = urlSessionPriority
+        self.requestSender = requestSender
         baseUrl = config.getMobileContentApiBaseUrl()
     }
     

--- a/godtools/App/Share/Data/MobileContentApiAuthSession/MobileContentApiAuthSession.swift
+++ b/godtools/App/Share/Data/MobileContentApiAuthSession/MobileContentApiAuthSession.swift
@@ -12,15 +12,16 @@ import Combine
 
 class MobileContentApiAuthSession {
     
-    private let requestSender: RequestSender = RequestSender()
+    private let requestSender: RequestSender
     
     let mobileContentAuthTokenRepository: MobileContentAuthTokenRepository
     let userAuthentication: UserAuthentication
     
     private let requestBuilder: RequestBuilder = RequestBuilder()
     
-    init(mobileContentAuthTokenRepository: MobileContentAuthTokenRepository, userAuthentication: UserAuthentication) {
+    init(requestSender: RequestSender, mobileContentAuthTokenRepository: MobileContentAuthTokenRepository, userAuthentication: UserAuthentication) {
      
+        self.requestSender = requestSender
         self.mobileContentAuthTokenRepository = mobileContentAuthTokenRepository
         self.userAuthentication = userAuthentication
     }

--- a/godtools/App/Share/Data/MobileContentAuthTokenRepository/Api/MobileContentAuthTokenAPI.swift
+++ b/godtools/App/Share/Data/MobileContentAuthTokenRepository/Api/MobileContentAuthTokenAPI.swift
@@ -13,13 +13,14 @@ import Combine
 class MobileContentAuthTokenAPI {
     
     private let requestBuilder: RequestBuilder = RequestBuilder()
-    private let requestSender: RequestSender = RequestSender()
     private let urlSessionPriority: URLSessionPriority
+    private let requestSender: RequestSender
     private let baseURL: String
     
-    init(config: AppConfig, urlSessionPriority: URLSessionPriority) {
+    init(config: AppConfig, urlSessionPriority: URLSessionPriority, requestSender: RequestSender) {
         
         self.urlSessionPriority = urlSessionPriority
+        self.requestSender = requestSender
         baseURL = config.getMobileContentApiBaseUrl()
     }
     

--- a/godtools/App/Share/Data/RequestSender/DoesNotSendUrlRequestSender.swift
+++ b/godtools/App/Share/Data/RequestSender/DoesNotSendUrlRequestSender.swift
@@ -1,0 +1,27 @@
+//
+//  DoesNotSendUrlRequestSender.swift
+//  godtools
+//
+//  Created by Levi Eggert on 8/6/25.
+//  Copyright © 2025 Cru. All rights reserved.
+//
+
+import Foundation
+import Combine
+import RequestOperation
+
+class DoesNotSendUrlRequestSender: RequestSender {
+    
+    override func sendDataTaskPublisher(urlRequest: URLRequest, urlSession: URLSession) -> AnyPublisher<RequestDataResponse, Error> {
+                
+        let stringData = "String data"
+        let data: Data = stringData.data(using: .utf8) ?? Data()
+        let urlResponse = URLResponse()
+        
+        let response = RequestDataResponse(data: data, urlResponse: urlResponse)
+        
+        return Just(response)
+            .setFailureType(to: Error.self)
+            .eraseToAnyPublisher()
+    }
+}

--- a/godtools/App/Share/Data/ResourceViewsService/Api/MobileContentResourceViewsApi.swift
+++ b/godtools/App/Share/Data/ResourceViewsService/Api/MobileContentResourceViewsApi.swift
@@ -13,13 +13,14 @@ import Combine
 class MobileContentResourceViewsApi {
     
     private let requestBuilder: RequestBuilder = RequestBuilder()
-    private let requestSender: RequestSender = RequestSender()
     private let urlSessionPriority: URLSessionPriority
+    private let requestSender: RequestSender
     private let baseUrl: String
     
-    init(config: AppConfig, urlSessionPriority: URLSessionPriority) {
+    init(config: AppConfig, urlSessionPriority: URLSessionPriority, requestSender: RequestSender) {
                     
         self.urlSessionPriority = urlSessionPriority
+        self.requestSender = requestSender
         baseUrl = config.getMobileContentApiBaseUrl()
     }
     

--- a/godtools/App/Share/Data/ResourcesRepository/Api/MobileContentResourcesApi.swift
+++ b/godtools/App/Share/Data/ResourcesRepository/Api/MobileContentResourcesApi.swift
@@ -12,14 +12,15 @@ import Combine
 
 class MobileContentResourcesApi {
     
-    private let requestSender: RequestSender = RequestSender()
     private let requestBuilder: RequestBuilder = RequestBuilder()
     private let urlSessionPriority: URLSessionPriority
+    private let requestSender: RequestSender
     private let baseUrl: String
     
-    init(config: AppConfig, urlSessionPriority: URLSessionPriority) {
+    init(config: AppConfig, urlSessionPriority: URLSessionPriority, requestSender: RequestSender) {
                     
         self.urlSessionPriority = urlSessionPriority
+        self.requestSender = requestSender
         baseUrl = config.getMobileContentApiBaseUrl()
     }
     

--- a/godtools/App/Share/Data/TranslationsRepository/Api/MobileContentTranslationsApi.swift
+++ b/godtools/App/Share/Data/TranslationsRepository/Api/MobileContentTranslationsApi.swift
@@ -13,13 +13,14 @@ import Combine
 class MobileContentTranslationsApi {
     
     private let requestBuilder: RequestBuilder = RequestBuilder()
-    private let requestSender: RequestSender = RequestSender()
     private let urlSessionPriority: URLSessionPriority
+    private let requestSender: RequestSender
     private let baseUrl: String
     
-    required init(config: AppConfig, urlSessionPriority: URLSessionPriority) {
+    required init(config: AppConfig, urlSessionPriority: URLSessionPriority, requestSender: RequestSender) {
                     
         self.urlSessionPriority = urlSessionPriority
+        self.requestSender = requestSender
         baseUrl = config.getMobileContentApiBaseUrl()
     }
     

--- a/godtoolsTests/App/DependencyContainer/TestsDiContainer.swift
+++ b/godtoolsTests/App/DependencyContainer/TestsDiContainer.swift
@@ -21,7 +21,8 @@ class TestsDiContainer: AppDiContainer {
             appBuild: appBuild,
             appConfig: appConfig,
             realmDatabase: realmDatabase,
-            firebaseEnabled: false
+            firebaseEnabled: false,
+            urlSessionEnabled: false
         )
     }
 }

--- a/godtoolsUITests/App/Flows/App/AppFlowTests.swift
+++ b/godtoolsUITests/App/Flows/App/AppFlowTests.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 import XCTest
-@testable import godtools
 
 class AppFlowTests: BaseFlowTests {
         

--- a/godtoolsUITests/App/Flows/BaseFlowTests.swift
+++ b/godtoolsUITests/App/Flows/BaseFlowTests.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 import XCTest
-@testable import godtools
 
 class BaseFlowTests: XCTestCase {
         

--- a/godtoolsUITests/App/Flows/ChooseAppLanguage/ChooseAppLanguageFlowTests.swift
+++ b/godtoolsUITests/App/Flows/ChooseAppLanguage/ChooseAppLanguageFlowTests.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 import XCTest
-@testable import godtools
 
 class ChooseAppLanguageFlowTests: BaseFlowTests {
         

--- a/godtoolsUITests/App/Flows/Dashboard/DashboardFlowTests.swift
+++ b/godtoolsUITests/App/Flows/Dashboard/DashboardFlowTests.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 import XCTest
-@testable import godtools
 
 class DashboardFlowTests: BaseFlowTests {
         
@@ -203,7 +202,7 @@ extension DashboardFlowTests {
         
         tabToTools()
         
-        let tool = app.queryDescendants(id: AccessibilityStrings.Button.tool.rawValue + " " + ToolNames.English.teachMeToShare)
+        let tool = app.queryDescendants(id: AccessibilityStrings.Button.tool.rawValue + " " + SwiftUIPreviewToolNames.English.teachMeToShare)
                 
         guard let tool = tool else {
             XCTAssertNotNil(tool, "Found nil element.")

--- a/godtoolsUITests/App/Flows/LanguageSettings/LanguageSettingsFlowTests.swift
+++ b/godtoolsUITests/App/Flows/LanguageSettings/LanguageSettingsFlowTests.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 import XCTest
-@testable import godtools
 
 class LanguageSettingsFlowTests: BaseFlowTests {
         

--- a/godtoolsUITests/App/Flows/LearnToShareTool/LearnToShareToolFlowTests.swift
+++ b/godtoolsUITests/App/Flows/LearnToShareTool/LearnToShareToolFlowTests.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 import XCTest
-@testable import godtools
 
 class LearnToShareToolFlowTests: BaseFlowTests {
     
@@ -66,14 +65,14 @@ class LearnToShareToolFlowTests: BaseFlowTests {
         
         launchAppToDashboardTools()
                 
-        openToolToToolDetailsAndNavigateToLearnToShareFlow(toolName: ToolNames.English.fourSpiritualLaws)
+        openToolToToolDetailsAndNavigateToLearnToShareFlow(toolName: SwiftUIPreviewToolNames.English.fourSpiritualLaws)
     }
     
     func testTappingCloseLearnToShareOpensTool() {
         
         launchAppToDashboardTools()
                 
-        openToolToToolDetailsAndNavigateToLearnToShareFlow(toolName: ToolNames.English.fourSpiritualLaws)
+        openToolToToolDetailsAndNavigateToLearnToShareFlow(toolName: SwiftUIPreviewToolNames.English.fourSpiritualLaws)
         
         let closeButton: XCUIElement = app.queryButton(buttonAccessibility: .close)
         
@@ -88,7 +87,7 @@ class LearnToShareToolFlowTests: BaseFlowTests {
         
         launchAppToDashboardTools()
                 
-        openToolToToolDetailsAndNavigateToLearnToShareFlow(toolName: ToolNames.English.fourSpiritualLaws)
+        openToolToToolDetailsAndNavigateToLearnToShareFlow(toolName: SwiftUIPreviewToolNames.English.fourSpiritualLaws)
         
         var continueButton: XCUIElement = getContinueButtonFromLearnToShare()
         

--- a/godtoolsUITests/App/Flows/Menu/MenuFlowTests.swift
+++ b/godtoolsUITests/App/Flows/Menu/MenuFlowTests.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 import XCTest
-@testable import godtools
 
 class MenuFlowTests: BaseFlowTests {
         

--- a/godtoolsUITests/App/Flows/Onboarding/OnboardingFlowTests.swift
+++ b/godtoolsUITests/App/Flows/Onboarding/OnboardingFlowTests.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 import XCTest
-@testable import godtools
 
 class OnboardingFlowTests: BaseFlowTests {
         

--- a/godtoolsUITests/App/Flows/ToolScreenShare/ToolScreenShareFlowTests.swift
+++ b/godtoolsUITests/App/Flows/ToolScreenShare/ToolScreenShareFlowTests.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 import XCTest
-@testable import godtools
 
 class ToolScreenShareFlowTests: BaseFlowTests {
     


### PR DESCRIPTION
Changes in PR:
- Adds flag ```urlSessionEnabled: Bool``` to AppDiContainer.
- Creates a shared RequestSender in AppDataLayerDependencies.
- When urlSessionEnabled is disabled, uses ```DoesNotSendUrlRequestSender: RequestSender```.
