### PR TITLE
GT-2716 create tests for deep linking classes

### DIFF
--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -613,6 +613,8 @@
 		456BB8D42DB2966500E7BFFD /* AppLaunchState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456BB8D32DB2965C00E7BFFD /* AppLaunchState.swift */; };
 		456BD2CC27020C75004D7B19 /* MobileContentViewHeightConstraintType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456BD2CB27020C75004D7B19 /* MobileContentViewHeightConstraintType.swift */; };
 		456C02E62E38F0E000E3E49E /* GetDownloadToolProgressInterfaceStringsRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456C02E32E38F0E000E3E49E /* GetDownloadToolProgressInterfaceStringsRepositoryTests.swift */; };
+		456D39C62E43B89700854D6A /* DeepLinkingParserManifestUrlTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456D39C52E43B89600854D6A /* DeepLinkingParserManifestUrlTests.swift */; };
+		456D39CA2E43B9F100854D6A /* MockEmptyDeepLinkParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456D39C92E43B9E000854D6A /* MockEmptyDeepLinkParser.swift */; };
 		456DA4F02CC96ADE004BFB1E /* OpenUrlWithSwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456DA4ED2CC96ADE004BFB1E /* OpenUrlWithSwiftUI.swift */; };
 		456DA4F12CC96ADE004BFB1E /* UrlOpenerInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456DA4EC2CC96ADE004BFB1E /* UrlOpenerInterface.swift */; };
 		456DA4F22CC96ADE004BFB1E /* OpenUrlWithUIKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456DA4EE2CC96ADE004BFB1E /* OpenUrlWithUIKit.swift */; };
@@ -2425,6 +2427,8 @@
 		456BB8D32DB2965C00E7BFFD /* AppLaunchState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLaunchState.swift; sourceTree = "<group>"; };
 		456BD2CB27020C75004D7B19 /* MobileContentViewHeightConstraintType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MobileContentViewHeightConstraintType.swift; sourceTree = "<group>"; };
 		456C02E32E38F0E000E3E49E /* GetDownloadToolProgressInterfaceStringsRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetDownloadToolProgressInterfaceStringsRepositoryTests.swift; sourceTree = "<group>"; };
+		456D39C52E43B89600854D6A /* DeepLinkingParserManifestUrlTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkingParserManifestUrlTests.swift; sourceTree = "<group>"; };
+		456D39C92E43B9E000854D6A /* MockEmptyDeepLinkParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockEmptyDeepLinkParser.swift; sourceTree = "<group>"; };
 		456DA4EC2CC96ADE004BFB1E /* UrlOpenerInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UrlOpenerInterface.swift; sourceTree = "<group>"; };
 		456DA4ED2CC96ADE004BFB1E /* OpenUrlWithSwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenUrlWithSwiftUI.swift; sourceTree = "<group>"; };
 		456DA4EE2CC96ADE004BFB1E /* OpenUrlWithUIKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenUrlWithUIKit.swift; sourceTree = "<group>"; };
@@ -5073,6 +5077,7 @@
 			isa = PBXGroup;
 			children = (
 				45368A0A2ABB2D840028A570 /* DeepLinkingServiceTests.swift */,
+				456D39C42E43B88400854D6A /* Manifest */,
 			);
 			path = DeepLinkingService;
 			sourceTree = "<group>";
@@ -6737,6 +6742,7 @@
 		456834FB2E3405B100657255 /* Data */ = {
 			isa = PBXGroup;
 			children = (
+				456D39C82E43B9D200854D6A /* DeepLinkingService */,
 				4568352C2E3408E400657255 /* LanguagesRepository */,
 				4568352F2E34092400657255 /* LaunchCountRepository */,
 				456834F82E3405B100657255 /* LocalizationLanguageNameRepository */,
@@ -7070,6 +7076,30 @@
 				456C02E42E38F0E000E3E49E /* Data-DomainInterface */,
 			);
 			path = DownloadToolProgress;
+			sourceTree = "<group>";
+		};
+		456D39C42E43B88400854D6A /* Manifest */ = {
+			isa = PBXGroup;
+			children = (
+				456D39C52E43B89600854D6A /* DeepLinkingParserManifestUrlTests.swift */,
+			);
+			path = Manifest;
+			sourceTree = "<group>";
+		};
+		456D39C72E43B9D200854D6A /* Parsers */ = {
+			isa = PBXGroup;
+			children = (
+				456D39C92E43B9E000854D6A /* MockEmptyDeepLinkParser.swift */,
+			);
+			path = Parsers;
+			sourceTree = "<group>";
+		};
+		456D39C82E43B9D200854D6A /* DeepLinkingService */ = {
+			isa = PBXGroup;
+			children = (
+				456D39C72E43B9D200854D6A /* Parsers */,
+			);
+			path = DeepLinkingService;
 			sourceTree = "<group>";
 		};
 		456DA4EF2CC96ADE004BFB1E /* UrlOpener */ = {
@@ -15072,9 +15102,11 @@
 				459D375F2E37C83B007BCF27 /* StoreInitialAppLanguageTests.swift in Sources */,
 				459D37602E37C83B007BCF27 /* SearchAppLanguageInAppLanguagesListRepositoryTests.swift in Sources */,
 				450AC6B72DEE40D1003E49E6 /* GetTranslatedNumberCountTests.swift in Sources */,
+				456D39C62E43B89700854D6A /* DeepLinkingParserManifestUrlTests.swift in Sources */,
 				452447202E3D114F00C0831A /* GetLessonFilterLanguagesInterfaceStringsRepositoryTests.swift in Sources */,
 				452447212E3D114F00C0831A /* GetUserLessonFiltersRepositoryTests.swift in Sources */,
 				452447222E3D114F00C0831A /* SearchLessonFilterLanguagesRepositoryTests.swift in Sources */,
+				456D39CA2E43B9F100854D6A /* MockEmptyDeepLinkParser.swift in Sources */,
 				452447232E3D114F00C0831A /* GetLessonFilterLanguagesRepositoryTests.swift in Sources */,
 				450FB8902BFBA1060015D945 /* RealmDatabaseDeleteTests.swift in Sources */,
 				456835032E3405FE00657255 /* MockRealmResource.swift in Sources */,

--- a/godtools/App/Share/Data/DeepLinkingService/GodToolsManifest/GodToolsDeepLinkingManifest.swift
+++ b/godtools/App/Share/Data/DeepLinkingService/GodToolsManifest/GodToolsDeepLinkingManifest.swift
@@ -23,79 +23,79 @@ class GodToolsDeepLinkingManifest: DeepLinkingManifestInterface {
         parserManifests = [
             DeepLinkingParserManifestUrl(
                 scheme: Self.schemeGodTools,
-                host: Self.hostGodTools,
+                hosts: [Self.hostGodTools],
                 path: "dashboard",
                 parserClass: DashboardPathDeepLinkParser.self
             ),
             DeepLinkingParserManifestUrl(
                 scheme: Self.schemeHttps,
-                host: Self.hostGodToolsApp,
+                hosts: [Self.hostGodToolsApp],
                 path: "deeplink/dashboard",
                 parserClass: DashboardPathDeepLinkParser.self
             ),
             DeepLinkingParserManifestUrl(
                 scheme: Self.schemeGodTools,
-                host: Self.hostGodTools,
+                hosts: [Self.hostGodTools],
                 path: "tool",
                 parserClass: ToolPathDeepLinkParser.self
             ),
             DeepLinkingParserManifestUrl(
                 scheme: Self.schemeHttps,
-                host: Self.hostGodToolsApp,
+                hosts: [Self.hostGodToolsApp],
                 path: "deeplink/tool",
                 parserClass: ToolPathDeepLinkParser.self
             ),
             DeepLinkingParserManifestUrl(
                 scheme: Self.schemeHttps,
-                host: Self.hostGodToolsApp,
+                hosts: [Self.hostGodToolsApp],
                 path: "article/aem",
                 parserClass: ArticleAemPathDeepLinkParser.self
             ),
             DeepLinkingParserManifestUrl(
                 scheme: Self.schemeHttps,
-                host: Self.hostKnowGod,
+                hosts: [Self.hostKnowGod],
                 path: nil,
                 parserClass: KnowGodDeepLinkParser.self
             ),
             DeepLinkingParserManifestUrl(
                 scheme: Self.schemeGodTools,
-                host: Self.hostKnowGod,
+                hosts: [Self.hostKnowGod],
                 path: nil,
                 parserClass: KnowGodDeepLinkParser.self
             ),
             DeepLinkingParserManifestUrl(
                 scheme: Self.schemeHttps,
-                host: Self.hostKnowGod,
+                hosts: [Self.hostKnowGod],
                 path: nil,
                 parserClass: LegacyKnowGodDeepLinkParser.self
             ),
             DeepLinkingParserManifestUrl(
                 scheme: Self.schemeGodTools,
-                host: Self.hostKnowGod,
+                hosts: [Self.hostKnowGod],
                 path: nil,
                 parserClass: LegacyKnowGodDeepLinkParser.self
             ),
             DeepLinkingParserManifestUrl(
                 scheme: Self.schemeHttps,
-                host: Self.hostGodToolsApp,
+                hosts: [Self.hostGodToolsApp],
                 path: "lessons",
                 parserClass: GodToolsAppLessonsPathDeepLinkParser.self
             ),
             DeepLinkingParserManifestUrl(
                 scheme: Self.schemeGodTools,
-                host: Self.hostGodTools,
+                hosts: [Self.hostGodTools],
                 path: "settings/language",
                 parserClass: LanguageSettingsDeepLinkParser.self
             ),
             DeepLinkingParserManifestUrl(
                 scheme: Self.schemeHttps,
-                host: Self.hostGodToolsApp,
+                hosts: [Self.hostGodToolsApp],
                 path: "deeplink/settings/language",
                 parserClass: LanguageSettingsDeepLinkParser.self
             ),
             DeepLinkingParserManifestUrl(
                 scheme: Self.schemeGodTools,
-                host: Self.hostGodTools,
+                hosts: [Self.hostGodTools],
                 path: "ui_tests",
                 parserClass: UITestsDeepLinkParser.self
             )

--- a/godtools/App/Share/Data/DeepLinkingService/GodToolsManifest/GodToolsDeepLinkingManifest.swift
+++ b/godtools/App/Share/Data/DeepLinkingService/GodToolsManifest/GodToolsDeepLinkingManifest.swift
@@ -10,86 +10,92 @@ import Foundation
 
 class GodToolsDeepLinkingManifest: DeepLinkingManifestInterface {
     
+    private static let schemeGodTools: String = "godtools"
+    private static let schemeHttps: String = "https"
+    private static let hostGodTools: String = "org.cru.godtools"
+    private static let hostGodToolsApp: String = "godtoolsapp.com"
+    private static let hostKnowGod: String = "knowgod.com"
+    
     let parserManifests: [DeepLinkingParserManifestInterface]
     
     init() {
         
         parserManifests = [
             DeepLinkingParserManifestUrl(
-                scheme: "godtools",
-                host: "org.cru.godtools",
+                scheme: Self.schemeGodTools,
+                host: Self.hostGodTools,
                 path: "dashboard",
                 parserClass: DashboardPathDeepLinkParser.self
             ),
             DeepLinkingParserManifestUrl(
-                scheme: "https",
-                host: "godtoolsapp.com",
+                scheme: Self.schemeHttps,
+                host: Self.hostGodToolsApp,
                 path: "deeplink/dashboard",
                 parserClass: DashboardPathDeepLinkParser.self
             ),
             DeepLinkingParserManifestUrl(
-                scheme: "godtools",
-                host: "org.cru.godtools",
+                scheme: Self.schemeGodTools,
+                host: Self.hostGodTools,
                 path: "tool",
                 parserClass: ToolPathDeepLinkParser.self
             ),
             DeepLinkingParserManifestUrl(
-                scheme: "https",
-                host: "godtoolsapp.com",
+                scheme: Self.schemeHttps,
+                host: Self.hostGodToolsApp,
                 path: "deeplink/tool",
                 parserClass: ToolPathDeepLinkParser.self
             ),
             DeepLinkingParserManifestUrl(
-                scheme: "https",
-                host: "godtoolsapp.com",
+                scheme: Self.schemeHttps,
+                host: Self.hostGodToolsApp,
                 path: "article/aem",
                 parserClass: ArticleAemPathDeepLinkParser.self
             ),
             DeepLinkingParserManifestUrl(
-                scheme: "https",
-                host: "knowgod.com",
+                scheme: Self.schemeHttps,
+                host: Self.hostKnowGod,
                 path: nil,
                 parserClass: KnowGodDeepLinkParser.self
             ),
             DeepLinkingParserManifestUrl(
-                scheme: "godtools",
-                host: "knowgod.com",
+                scheme: Self.schemeGodTools,
+                host: Self.hostKnowGod,
                 path: nil,
                 parserClass: KnowGodDeepLinkParser.self
             ),
             DeepLinkingParserManifestUrl(
-                scheme: "https",
-                host: "knowgod.com",
+                scheme: Self.schemeHttps,
+                host: Self.hostKnowGod,
                 path: nil,
                 parserClass: LegacyKnowGodDeepLinkParser.self
             ),
             DeepLinkingParserManifestUrl(
-                scheme: "godtools",
-                host: "knowgod.com",
+                scheme: Self.schemeGodTools,
+                host: Self.hostKnowGod,
                 path: nil,
                 parserClass: LegacyKnowGodDeepLinkParser.self
             ),
             DeepLinkingParserManifestUrl(
-                scheme: "https",
-                host: "godtoolsapp.com",
+                scheme: Self.schemeHttps,
+                host: Self.hostGodToolsApp,
                 path: "lessons",
                 parserClass: GodToolsAppLessonsPathDeepLinkParser.self
             ),
             DeepLinkingParserManifestUrl(
-                scheme: "godtools",
-                host: "org.cru.godtools",
+                scheme: Self.schemeGodTools,
+                host: Self.hostGodTools,
                 path: "settings/language",
                 parserClass: LanguageSettingsDeepLinkParser.self
             ),
             DeepLinkingParserManifestUrl(
-                scheme: "https",
-                host: "godtoolsapp.com",
+                scheme: Self.schemeHttps,
+                host: Self.hostGodToolsApp,
                 path: "deeplink/settings/language",
                 parserClass: LanguageSettingsDeepLinkParser.self
             ),
             DeepLinkingParserManifestUrl(
-                scheme: "godtools",
-                host: "org.cru.godtools",
+                scheme: Self.schemeGodTools,
+                host: Self.hostGodTools,
                 path: "ui_tests",
                 parserClass: UITestsDeepLinkParser.self
             )

--- a/godtools/App/Share/Data/DeepLinkingService/Manifest/DeepLinkingParserManifestUrl.swift
+++ b/godtools/App/Share/Data/DeepLinkingService/Manifest/DeepLinkingParserManifestUrl.swift
@@ -29,6 +29,12 @@ class DeepLinkingParserManifestUrl: DeepLinkingParserManifestInterface {
         
         case .url(let incomingUrl):
             
+            let schemeOrHostIsEmpty: Bool = scheme.isEmpty || host.isEmpty
+            
+            guard !schemeOrHostIsEmpty else {
+                return nil
+            }
+            
             guard scheme == incomingUrl.url.scheme else {
                 return nil
             }

--- a/godtools/App/Share/Data/DeepLinkingService/Manifest/DeepLinkingParserManifestUrl.swift
+++ b/godtools/App/Share/Data/DeepLinkingService/Manifest/DeepLinkingParserManifestUrl.swift
@@ -53,21 +53,33 @@ class DeepLinkingParserManifestUrl: DeepLinkingParserManifestInterface {
     
     private func isValidPath(incomingUrl: IncomingDeepLinkUrl) -> Bool {
         
-        let path: String = self.path ?? ""
-        
-        guard !path.isEmpty else {
+        guard let path = self.path else {
             return true
+        }
+        
+        let incomingUrlRootPath: String? = incomingUrl.rootPath
+        let incomingUrlRootPathIsEmpty: Bool
+        
+        if let incomingUrlRootPath = incomingUrlRootPath {
+            incomingUrlRootPathIsEmpty = incomingUrlRootPath.isEmpty
+        }
+        else {
+            incomingUrlRootPathIsEmpty = true
+        }
+        
+        if path.isEmpty && incomingUrlRootPathIsEmpty {
+            return true
+        }
+        else if path.isEmpty && !incomingUrlRootPathIsEmpty {
+            return false
         }
         
         let pathComponents: [String] = path.components(separatedBy: "/").filter({$0 != "/"})
-        
-        guard !pathComponents.isEmpty else {
-            return true
-        }
-        
         let incomingPathComponents: [String] = incomingUrl.pathComponents.filter({$0 != "/"})
         
-        guard pathComponents.count <= incomingPathComponents.count else {
+        let pathComponentsIsLessThanOrEqualToIncomingPathComponents: Bool = pathComponents.count <= incomingPathComponents.count
+        
+        guard pathComponentsIsLessThanOrEqualToIncomingPathComponents else {
             return false
         }
         

--- a/godtools/App/Share/Data/DeepLinkingService/Manifest/DeepLinkingParserManifestUrl.swift
+++ b/godtools/App/Share/Data/DeepLinkingService/Manifest/DeepLinkingParserManifestUrl.swift
@@ -11,14 +11,14 @@ import Foundation
 class DeepLinkingParserManifestUrl: DeepLinkingParserManifestInterface {
     
     let scheme: String
-    let host: String
+    let hosts: [String]
     let path: String?
     let parserClass: DeepLinkParserInterface.Type
     
-    init(scheme: String, host: String, path: String?, parserClass: DeepLinkParserInterface.Type) {
+    init(scheme: String, hosts: [String], path: String?, parserClass: DeepLinkParserInterface.Type) {
         
         self.scheme = scheme
-        self.host = host
+        self.hosts = hosts
         self.path = path
         self.parserClass = parserClass
     }
@@ -29,7 +29,7 @@ class DeepLinkingParserManifestUrl: DeepLinkingParserManifestInterface {
         
         case .url(let incomingUrl):
             
-            let schemeOrHostIsEmpty: Bool = scheme.isEmpty || host.isEmpty
+            let schemeOrHostIsEmpty: Bool = scheme.isEmpty || hosts.isEmpty
             
             guard !schemeOrHostIsEmpty else {
                 return nil
@@ -39,7 +39,7 @@ class DeepLinkingParserManifestUrl: DeepLinkingParserManifestInterface {
                 return nil
             }
             
-            guard host == incomingUrl.url.host else {
+            guard let incomingUrlHost = incomingUrl.url.host, hosts.contains(incomingUrlHost) else {
                 return nil
             }
             

--- a/godtoolsTests/App/Share/Data/DeepLinkingService/Manifest/DeepLinkingParserManifestUrlTests.swift
+++ b/godtoolsTests/App/Share/Data/DeepLinkingService/Manifest/DeepLinkingParserManifestUrlTests.swift
@@ -1,0 +1,205 @@
+//
+//  DeepLinkingParserManifestUrlTests.swift
+//  godtools
+//
+//  Created by Levi Eggert on 8/6/25.
+//  Copyright © 2025 Cru. All rights reserved.
+//
+
+import Testing
+@testable import godtools
+import Foundation
+import Combine
+
+struct DeepLinkingParserManifestUrlTests {
+    
+    private static let schemeGodtools: String = "godtools"
+    private static let schemeHttp: String = "http"
+    private static let schemeHttps: String = "https"
+    private static let hostGodTools: String = "org.cru.godtools"
+    private static let hostGodToolsApp: String = "godtoolsapp.com"
+    private static let hostKnowGod: String = "knowgod.com"
+    
+    struct TestArgument {
+        let scheme: String
+        let host: String
+        let path: String?
+        let parserClass: DeepLinkParserInterface.Type
+        let incomingDeepLinkUrl: String
+        let expectedParserClass: DeepLinkParserInterface.Type?
+    }
+    
+    @Test(
+        "Should return a matching parser when both scheme and host match the incoming deep link url.",
+        arguments: [
+            TestArgument(
+                scheme: Self.schemeHttps,
+                host: Self.hostGodToolsApp,
+                path: nil,
+                parserClass: MockEmptyDeepLinkParser.self,
+                incomingDeepLinkUrl: "https://godtoolsapp.com",
+                expectedParserClass: MockEmptyDeepLinkParser.self
+            ),
+            TestArgument(
+                scheme: Self.schemeHttp,
+                host: Self.hostGodToolsApp,
+                path: nil,
+                parserClass: MockEmptyDeepLinkParser.self,
+                incomingDeepLinkUrl: "http://godtoolsapp.com",
+                expectedParserClass: MockEmptyDeepLinkParser.self
+            ),
+            TestArgument(
+                scheme: Self.schemeGodtools,
+                host: Self.hostKnowGod,
+                path: nil,
+                parserClass: MockEmptyDeepLinkParser.self,
+                incomingDeepLinkUrl: "godtools://knowgod.com",
+                expectedParserClass: MockEmptyDeepLinkParser.self
+            )
+        ]
+    )
+    func findsDeepLinkParserWhenSchemeAndHostAreSupported(argument: TestArgument) async {
+        
+        let deepLinkingParserUrlManifest = DeepLinkingParserManifestUrl(
+            scheme: argument.scheme,
+            host: argument.host,
+            path: argument.path,
+            parserClass: argument.parserClass
+        )
+        
+        let url = IncomingDeepLinkUrl(url: URL(string: argument.incomingDeepLinkUrl)!)
+        
+        let incomingDeepLink: IncomingDeepLinkType = .url(incomingUrl: url)
+        
+        let parser: DeepLinkParserInterface? = deepLinkingParserUrlManifest.getParserIfValidIncomingDeepLink(incomingDeepLink: incomingDeepLink)
+                        
+        #expect(parser != nil)
+        #expect(Self.getParserTypesMatch(parser: parser, expectedParserType: argument.expectedParserClass))
+    }
+    
+    @Test(
+        "Should return a null parser if either the scheme or host are an empty string on the manifest.",
+        arguments: [
+            TestArgument(
+                scheme: "",
+                host: Self.hostGodToolsApp,
+                path: nil,
+                parserClass: MockEmptyDeepLinkParser.self,
+                incomingDeepLinkUrl: "https://godtoolsapp.com",
+                expectedParserClass: nil
+            ),
+            TestArgument(
+                scheme: "",
+                host: Self.hostGodToolsApp,
+                path: nil,
+                parserClass: MockEmptyDeepLinkParser.self,
+                incomingDeepLinkUrl: "://godtoolsapp.com",
+                expectedParserClass: nil
+            ),
+            TestArgument(
+                scheme: Self.schemeHttps,
+                host: "",
+                path: nil,
+                parserClass: MockEmptyDeepLinkParser.self,
+                incomingDeepLinkUrl: "https://",
+                expectedParserClass: nil
+            ),
+            TestArgument(
+                scheme: Self.schemeHttps,
+                host: "",
+                path: nil,
+                parserClass: MockEmptyDeepLinkParser.self,
+                incomingDeepLinkUrl: "https://godtoolsapp.com",
+                expectedParserClass: nil
+            )
+        ]
+    )
+    func returnsNullDeepLinkParserWhenEitherSchemeOrHostAreEmptyStrings(argument: TestArgument) async {
+        
+        let deepLinkingParserUrlManifest = DeepLinkingParserManifestUrl(
+            scheme: argument.scheme,
+            host: argument.host,
+            path: argument.path,
+            parserClass: argument.parserClass
+        )
+        
+        let url = IncomingDeepLinkUrl(url: URL(string: argument.incomingDeepLinkUrl)!)
+        
+        let incomingDeepLink: IncomingDeepLinkType = .url(incomingUrl: url)
+        
+        let parser: DeepLinkParserInterface? = deepLinkingParserUrlManifest.getParserIfValidIncomingDeepLink(incomingDeepLink: incomingDeepLink)
+                        
+        #expect(parser == nil)
+        #expect(Self.getParserTypesMatch(parser: parser, expectedParserType: argument.expectedParserClass) == false)
+    }
+    
+    @Test(
+        "Should return a null parser if either the scheme or host do not match the incoming deep link url.",
+        arguments: [
+            TestArgument(
+                scheme: Self.schemeHttps,
+                host: Self.hostGodToolsApp,
+                path: nil,
+                parserClass: MockEmptyDeepLinkParser.self,
+                incomingDeepLinkUrl: "http://godtoolsapp.com",
+                expectedParserClass: MockEmptyDeepLinkParser.self
+            ),
+            TestArgument(
+                scheme: Self.schemeHttp,
+                host: Self.hostGodToolsApp,
+                path: nil,
+                parserClass: MockEmptyDeepLinkParser.self,
+                incomingDeepLinkUrl: "https://knowgod.com",
+                expectedParserClass: MockEmptyDeepLinkParser.self
+            ),
+            TestArgument(
+                scheme: Self.schemeGodtools,
+                host: Self.hostKnowGod,
+                path: nil,
+                parserClass: MockEmptyDeepLinkParser.self,
+                incomingDeepLinkUrl: "godtools://godtoolsapp.com",
+                expectedParserClass: MockEmptyDeepLinkParser.self
+            )
+        ]
+    )
+    func returnsNullDeepLinkParserWhenEitherSchemeOrHostAreNotSupported(argument: TestArgument) async {
+        
+        let deepLinkingParserUrlManifest = DeepLinkingParserManifestUrl(
+            scheme: argument.scheme,
+            host: argument.host,
+            path: argument.path,
+            parserClass: argument.parserClass
+        )
+        
+        let url = IncomingDeepLinkUrl(url: URL(string: argument.incomingDeepLinkUrl)!)
+        
+        let incomingDeepLink: IncomingDeepLinkType = .url(incomingUrl: url)
+        
+        let parser: DeepLinkParserInterface? = deepLinkingParserUrlManifest.getParserIfValidIncomingDeepLink(incomingDeepLink: incomingDeepLink)
+                        
+        #expect(parser == nil)
+        #expect(Self.getParserTypesMatch(parser: parser, expectedParserType: argument.expectedParserClass) == false)
+    }
+}
+
+extension DeepLinkingParserManifestUrlTests {
+    
+    private static func getParserTypesMatch(parser: DeepLinkParserInterface?, expectedParserType: DeepLinkParserInterface.Type?) -> Bool {
+        
+        let parserTypesMatch: Bool
+        
+        if let parser = parser, let expectedParserType = expectedParserType {
+            
+            let parserType: DeepLinkParserInterface.Type = type(of: parser)
+            let expectedType: DeepLinkParserInterface.Type = expectedParserType
+            
+            parserTypesMatch = parserType == expectedType
+        }
+        else {
+            
+            parserTypesMatch = false
+        }
+        
+        return parserTypesMatch
+    }
+}

--- a/godtoolsTests/App/Share/Data/DeepLinkingService/Manifest/DeepLinkingParserManifestUrlTests.swift
+++ b/godtoolsTests/App/Share/Data/DeepLinkingService/Manifest/DeepLinkingParserManifestUrlTests.swift
@@ -22,7 +22,7 @@ struct DeepLinkingParserManifestUrlTests {
     
     struct TestArgument {
         let scheme: String
-        let host: String
+        let hosts: [String]
         let path: String?
         let parserClass: DeepLinkParserInterface.Type
         let incomingDeepLinkUrl: String
@@ -34,7 +34,7 @@ struct DeepLinkingParserManifestUrlTests {
         arguments: [
             TestArgument(
                 scheme: Self.schemeHttps,
-                host: Self.hostGodToolsApp,
+                hosts: [Self.hostGodToolsApp],
                 path: nil,
                 parserClass: MockEmptyDeepLinkParser.self,
                 incomingDeepLinkUrl: "https://godtoolsapp.com",
@@ -42,7 +42,7 @@ struct DeepLinkingParserManifestUrlTests {
             ),
             TestArgument(
                 scheme: Self.schemeHttp,
-                host: Self.hostGodToolsApp,
+                hosts: [Self.hostGodToolsApp],
                 path: nil,
                 parserClass: MockEmptyDeepLinkParser.self,
                 incomingDeepLinkUrl: "http://godtoolsapp.com",
@@ -50,7 +50,7 @@ struct DeepLinkingParserManifestUrlTests {
             ),
             TestArgument(
                 scheme: Self.schemeGodtools,
-                host: Self.hostKnowGod,
+                hosts: [Self.hostKnowGod],
                 path: nil,
                 parserClass: MockEmptyDeepLinkParser.self,
                 incomingDeepLinkUrl: "godtools://knowgod.com",
@@ -62,7 +62,7 @@ struct DeepLinkingParserManifestUrlTests {
         
         let deepLinkingParserUrlManifest = DeepLinkingParserManifestUrl(
             scheme: argument.scheme,
-            host: argument.host,
+            hosts: argument.hosts,
             path: argument.path,
             parserClass: argument.parserClass
         )
@@ -82,7 +82,7 @@ struct DeepLinkingParserManifestUrlTests {
         arguments: [
             TestArgument(
                 scheme: "",
-                host: Self.hostGodToolsApp,
+                hosts: [Self.hostGodToolsApp],
                 path: nil,
                 parserClass: MockEmptyDeepLinkParser.self,
                 incomingDeepLinkUrl: "https://godtoolsapp.com",
@@ -90,7 +90,7 @@ struct DeepLinkingParserManifestUrlTests {
             ),
             TestArgument(
                 scheme: "",
-                host: Self.hostGodToolsApp,
+                hosts: [Self.hostGodToolsApp],
                 path: nil,
                 parserClass: MockEmptyDeepLinkParser.self,
                 incomingDeepLinkUrl: "://godtoolsapp.com",
@@ -98,7 +98,7 @@ struct DeepLinkingParserManifestUrlTests {
             ),
             TestArgument(
                 scheme: Self.schemeHttps,
-                host: "",
+                hosts: [""],
                 path: nil,
                 parserClass: MockEmptyDeepLinkParser.self,
                 incomingDeepLinkUrl: "https://",
@@ -106,7 +106,15 @@ struct DeepLinkingParserManifestUrlTests {
             ),
             TestArgument(
                 scheme: Self.schemeHttps,
-                host: "",
+                hosts: [""],
+                path: nil,
+                parserClass: MockEmptyDeepLinkParser.self,
+                incomingDeepLinkUrl: "https://godtoolsapp.com",
+                expectedParserClass: nil
+            ),
+            TestArgument(
+                scheme: Self.schemeHttps,
+                hosts: [],
                 path: nil,
                 parserClass: MockEmptyDeepLinkParser.self,
                 incomingDeepLinkUrl: "https://godtoolsapp.com",
@@ -118,7 +126,7 @@ struct DeepLinkingParserManifestUrlTests {
         
         let deepLinkingParserUrlManifest = DeepLinkingParserManifestUrl(
             scheme: argument.scheme,
-            host: argument.host,
+            hosts: argument.hosts,
             path: argument.path,
             parserClass: argument.parserClass
         )
@@ -138,7 +146,7 @@ struct DeepLinkingParserManifestUrlTests {
         arguments: [
             TestArgument(
                 scheme: Self.schemeHttps,
-                host: Self.hostGodToolsApp,
+                hosts: [Self.hostGodToolsApp],
                 path: nil,
                 parserClass: MockEmptyDeepLinkParser.self,
                 incomingDeepLinkUrl: "http://godtoolsapp.com",
@@ -146,7 +154,7 @@ struct DeepLinkingParserManifestUrlTests {
             ),
             TestArgument(
                 scheme: Self.schemeHttp,
-                host: Self.hostGodToolsApp,
+                hosts: [Self.hostGodToolsApp],
                 path: nil,
                 parserClass: MockEmptyDeepLinkParser.self,
                 incomingDeepLinkUrl: "https://godtoolsapp.com",
@@ -154,7 +162,7 @@ struct DeepLinkingParserManifestUrlTests {
             ),
             TestArgument(
                 scheme: Self.schemeGodtools,
-                host: Self.hostKnowGod,
+                hosts: [Self.hostKnowGod],
                 path: nil,
                 parserClass: MockEmptyDeepLinkParser.self,
                 incomingDeepLinkUrl: "godtools://godtoolsapp.com",
@@ -166,7 +174,7 @@ struct DeepLinkingParserManifestUrlTests {
         
         let deepLinkingParserUrlManifest = DeepLinkingParserManifestUrl(
             scheme: argument.scheme,
-            host: argument.host,
+            hosts: argument.hosts,
             path: argument.path,
             parserClass: argument.parserClass
         )
@@ -186,7 +194,7 @@ struct DeepLinkingParserManifestUrlTests {
         arguments: [
             TestArgument(
                 scheme: Self.schemeHttps,
-                host: Self.hostGodToolsApp,
+                hosts: [Self.hostGodToolsApp],
                 path: nil,
                 parserClass: MockEmptyDeepLinkParser.self,
                 incomingDeepLinkUrl: "https://godtoolsapp.com/",
@@ -194,7 +202,7 @@ struct DeepLinkingParserManifestUrlTests {
             ),
             TestArgument(
                 scheme: Self.schemeHttps,
-                host: Self.hostGodToolsApp,
+                hosts: [Self.hostGodToolsApp],
                 path: nil,
                 parserClass: MockEmptyDeepLinkParser.self,
                 incomingDeepLinkUrl: "https://godtoolsapp.com/path_0",
@@ -202,7 +210,7 @@ struct DeepLinkingParserManifestUrlTests {
             ),
             TestArgument(
                 scheme: Self.schemeHttps,
-                host: Self.hostGodToolsApp,
+                hosts: [Self.hostGodToolsApp],
                 path: nil,
                 parserClass: MockEmptyDeepLinkParser.self,
                 incomingDeepLinkUrl: "https://godtoolsapp.com/path_0/path_1?param_0=0",
@@ -214,7 +222,7 @@ struct DeepLinkingParserManifestUrlTests {
         
         let deepLinkingParserUrlManifest = DeepLinkingParserManifestUrl(
             scheme: argument.scheme,
-            host: argument.host,
+            hosts: argument.hosts,
             path: argument.path,
             parserClass: argument.parserClass
         )
@@ -234,7 +242,7 @@ struct DeepLinkingParserManifestUrlTests {
         arguments: [
             TestArgument(
                 scheme: Self.schemeHttps,
-                host: Self.hostGodToolsApp,
+                hosts: [Self.hostGodToolsApp],
                 path: "",
                 parserClass: MockEmptyDeepLinkParser.self,
                 incomingDeepLinkUrl: "https://godtoolsapp.com/",
@@ -242,7 +250,7 @@ struct DeepLinkingParserManifestUrlTests {
             ),
             TestArgument(
                 scheme: Self.schemeHttps,
-                host: Self.hostGodToolsApp,
+                hosts: [Self.hostGodToolsApp],
                 path: "",
                 parserClass: MockEmptyDeepLinkParser.self,
                 incomingDeepLinkUrl: "https://godtoolsapp.com",
@@ -254,7 +262,7 @@ struct DeepLinkingParserManifestUrlTests {
         
         let deepLinkingParserUrlManifest = DeepLinkingParserManifestUrl(
             scheme: argument.scheme,
-            host: argument.host,
+            hosts: argument.hosts,
             path: argument.path,
             parserClass: argument.parserClass
         )
@@ -274,7 +282,7 @@ struct DeepLinkingParserManifestUrlTests {
         arguments: [
             TestArgument(
                 scheme: Self.schemeHttps,
-                host: Self.hostGodToolsApp,
+                hosts: [Self.hostGodToolsApp],
                 path: "",
                 parserClass: MockEmptyDeepLinkParser.self,
                 incomingDeepLinkUrl: "https://godtoolsapp.com/path_0",
@@ -282,7 +290,7 @@ struct DeepLinkingParserManifestUrlTests {
             ),
             TestArgument(
                 scheme: Self.schemeHttps,
-                host: Self.hostGodToolsApp,
+                hosts: [Self.hostGodToolsApp],
                 path: "",
                 parserClass: MockEmptyDeepLinkParser.self,
                 incomingDeepLinkUrl: "https://godtoolsapp.com/path_0/path_1?param_0=0",
@@ -294,7 +302,7 @@ struct DeepLinkingParserManifestUrlTests {
         
         let deepLinkingParserUrlManifest = DeepLinkingParserManifestUrl(
             scheme: argument.scheme,
-            host: argument.host,
+            hosts: argument.hosts,
             path: argument.path,
             parserClass: argument.parserClass
         )
@@ -314,7 +322,7 @@ struct DeepLinkingParserManifestUrlTests {
         arguments: [
             TestArgument(
                 scheme: Self.schemeHttps,
-                host: Self.hostGodToolsApp,
+                hosts: [Self.hostGodToolsApp],
                 path: "path_0/path_1/path_2",
                 parserClass: MockEmptyDeepLinkParser.self,
                 incomingDeepLinkUrl: "https://godtoolsapp.com/path_0",
@@ -322,7 +330,7 @@ struct DeepLinkingParserManifestUrlTests {
             ),
             TestArgument(
                 scheme: Self.schemeHttps,
-                host: Self.hostGodToolsApp,
+                hosts: [Self.hostGodToolsApp],
                 path: "path_0/path_1/path_2",
                 parserClass: MockEmptyDeepLinkParser.self,
                 incomingDeepLinkUrl: "https://godtoolsapp.com/path_0/path_1",
@@ -334,7 +342,7 @@ struct DeepLinkingParserManifestUrlTests {
         
         let deepLinkingParserUrlManifest = DeepLinkingParserManifestUrl(
             scheme: argument.scheme,
-            host: argument.host,
+            hosts: argument.hosts,
             path: argument.path,
             parserClass: argument.parserClass
         )
@@ -354,7 +362,7 @@ struct DeepLinkingParserManifestUrlTests {
         arguments: [
             TestArgument(
                 scheme: Self.schemeHttps,
-                host: Self.hostGodToolsApp,
+                hosts: [Self.hostGodToolsApp],
                 path: "path_0/path_1/path_2",
                 parserClass: MockEmptyDeepLinkParser.self,
                 incomingDeepLinkUrl: "https://godtoolsapp.com/path_2/path_1/path_0",
@@ -362,7 +370,7 @@ struct DeepLinkingParserManifestUrlTests {
             ),
             TestArgument(
                 scheme: Self.schemeHttps,
-                host: Self.hostGodToolsApp,
+                hosts: [Self.hostGodToolsApp],
                 path: "path_0/path_1/path_2",
                 parserClass: MockEmptyDeepLinkParser.self,
                 incomingDeepLinkUrl: "https://godtoolsapp.com/path_0/path_0/path_2",
@@ -374,7 +382,7 @@ struct DeepLinkingParserManifestUrlTests {
         
         let deepLinkingParserUrlManifest = DeepLinkingParserManifestUrl(
             scheme: argument.scheme,
-            host: argument.host,
+            hosts: argument.hosts,
             path: argument.path,
             parserClass: argument.parserClass
         )
@@ -394,7 +402,7 @@ struct DeepLinkingParserManifestUrlTests {
         arguments: [
             TestArgument(
                 scheme: Self.schemeHttps,
-                host: Self.hostGodToolsApp,
+                hosts: [Self.hostGodToolsApp],
                 path: "path_0",
                 parserClass: MockEmptyDeepLinkParser.self,
                 incomingDeepLinkUrl: "https://godtoolsapp.com/path_0",
@@ -402,7 +410,7 @@ struct DeepLinkingParserManifestUrlTests {
             ),
             TestArgument(
                 scheme: Self.schemeHttps,
-                host: Self.hostGodToolsApp,
+                hosts: [Self.hostGodToolsApp],
                 path: "path_0",
                 parserClass: MockEmptyDeepLinkParser.self,
                 incomingDeepLinkUrl: "https://godtoolsapp.com/path_0/path_1",
@@ -410,7 +418,7 @@ struct DeepLinkingParserManifestUrlTests {
             ),
             TestArgument(
                 scheme: Self.schemeHttps,
-                host: Self.hostGodToolsApp,
+                hosts: [Self.hostGodToolsApp],
                 path: "path_0",
                 parserClass: MockEmptyDeepLinkParser.self,
                 incomingDeepLinkUrl: "https://godtoolsapp.com/path_0/path_1?param_0=0",
@@ -418,7 +426,7 @@ struct DeepLinkingParserManifestUrlTests {
             ),
             TestArgument(
                 scheme: Self.schemeHttps,
-                host: Self.hostGodToolsApp,
+                hosts: [Self.hostGodToolsApp],
                 path: "path_0/path_1",
                 parserClass: MockEmptyDeepLinkParser.self,
                 incomingDeepLinkUrl: "https://godtoolsapp.com/path_0/path_1/path_2",
@@ -426,7 +434,7 @@ struct DeepLinkingParserManifestUrlTests {
             ),
             TestArgument(
                 scheme: Self.schemeHttps,
-                host: Self.hostGodToolsApp,
+                hosts: [Self.hostGodToolsApp],
                 path: "path_0/path_1/path_2",
                 parserClass: MockEmptyDeepLinkParser.self,
                 incomingDeepLinkUrl: "https://godtoolsapp.com/path_0/path_1/path_2",
@@ -434,7 +442,7 @@ struct DeepLinkingParserManifestUrlTests {
             ),
             TestArgument(
                 scheme: Self.schemeHttps,
-                host: Self.hostGodToolsApp,
+                hosts: [Self.hostGodToolsApp],
                 path: "path_0/path_1/path_2",
                 parserClass: MockEmptyDeepLinkParser.self,
                 incomingDeepLinkUrl: "https://godtoolsapp.com/path_0/path_1/path_2?param_0=0",
@@ -446,7 +454,7 @@ struct DeepLinkingParserManifestUrlTests {
         
         let deepLinkingParserUrlManifest = DeepLinkingParserManifestUrl(
             scheme: argument.scheme,
-            host: argument.host,
+            hosts: argument.hosts,
             path: argument.path,
             parserClass: argument.parserClass
         )

--- a/godtoolsTests/App/Share/Data/DeepLinkingService/Manifest/DeepLinkingParserManifestUrlTests.swift
+++ b/godtoolsTests/App/Share/Data/DeepLinkingService/Manifest/DeepLinkingParserManifestUrlTests.swift
@@ -149,7 +149,7 @@ struct DeepLinkingParserManifestUrlTests {
                 host: Self.hostGodToolsApp,
                 path: nil,
                 parserClass: MockEmptyDeepLinkParser.self,
-                incomingDeepLinkUrl: "https://knowgod.com",
+                incomingDeepLinkUrl: "https://godtoolsapp.com",
                 expectedParserClass: MockEmptyDeepLinkParser.self
             ),
             TestArgument(
@@ -179,6 +179,286 @@ struct DeepLinkingParserManifestUrlTests {
                         
         #expect(parser == nil)
         #expect(Self.getParserTypesMatch(parser: parser, expectedParserType: argument.expectedParserClass) == false)
+    }
+    
+    @Test(
+        "Should return a matching parser when manifest path is null and incoming deep link url has a path.",
+        arguments: [
+            TestArgument(
+                scheme: Self.schemeHttps,
+                host: Self.hostGodToolsApp,
+                path: nil,
+                parserClass: MockEmptyDeepLinkParser.self,
+                incomingDeepLinkUrl: "https://godtoolsapp.com/",
+                expectedParserClass: MockEmptyDeepLinkParser.self
+            ),
+            TestArgument(
+                scheme: Self.schemeHttps,
+                host: Self.hostGodToolsApp,
+                path: nil,
+                parserClass: MockEmptyDeepLinkParser.self,
+                incomingDeepLinkUrl: "https://godtoolsapp.com/path_0",
+                expectedParserClass: MockEmptyDeepLinkParser.self
+            ),
+            TestArgument(
+                scheme: Self.schemeHttps,
+                host: Self.hostGodToolsApp,
+                path: nil,
+                parserClass: MockEmptyDeepLinkParser.self,
+                incomingDeepLinkUrl: "https://godtoolsapp.com/path_0/path_1?param_0=0",
+                expectedParserClass: MockEmptyDeepLinkParser.self
+            )
+        ]
+    )
+    func findsDeepLinkParserWhenPathIsNullAndIncomingDeepLinkUrlHasAPath(argument: TestArgument) async {
+        
+        let deepLinkingParserUrlManifest = DeepLinkingParserManifestUrl(
+            scheme: argument.scheme,
+            host: argument.host,
+            path: argument.path,
+            parserClass: argument.parserClass
+        )
+        
+        let url = IncomingDeepLinkUrl(url: URL(string: argument.incomingDeepLinkUrl)!)
+        
+        let incomingDeepLink: IncomingDeepLinkType = .url(incomingUrl: url)
+        
+        let parser: DeepLinkParserInterface? = deepLinkingParserUrlManifest.getParserIfValidIncomingDeepLink(incomingDeepLink: incomingDeepLink)
+                        
+        #expect(parser != nil)
+        #expect(Self.getParserTypesMatch(parser: parser, expectedParserType: argument.expectedParserClass))
+    }
+    
+    @Test(
+        "Should return a parser when manifest path is empty and incoming deep link url path is empty.",
+        arguments: [
+            TestArgument(
+                scheme: Self.schemeHttps,
+                host: Self.hostGodToolsApp,
+                path: "",
+                parserClass: MockEmptyDeepLinkParser.self,
+                incomingDeepLinkUrl: "https://godtoolsapp.com/",
+                expectedParserClass: MockEmptyDeepLinkParser.self
+            ),
+            TestArgument(
+                scheme: Self.schemeHttps,
+                host: Self.hostGodToolsApp,
+                path: "",
+                parserClass: MockEmptyDeepLinkParser.self,
+                incomingDeepLinkUrl: "https://godtoolsapp.com",
+                expectedParserClass: MockEmptyDeepLinkParser.self
+            )
+        ]
+    )
+    func returnsDeepLinkParserWhenPathIsEmptyAndIncomingDeepLinkUrlPathIsEmpty(argument: TestArgument) async {
+        
+        let deepLinkingParserUrlManifest = DeepLinkingParserManifestUrl(
+            scheme: argument.scheme,
+            host: argument.host,
+            path: argument.path,
+            parserClass: argument.parserClass
+        )
+        
+        let url = IncomingDeepLinkUrl(url: URL(string: argument.incomingDeepLinkUrl)!)
+        
+        let incomingDeepLink: IncomingDeepLinkType = .url(incomingUrl: url)
+        
+        let parser: DeepLinkParserInterface? = deepLinkingParserUrlManifest.getParserIfValidIncomingDeepLink(incomingDeepLink: incomingDeepLink)
+                        
+        #expect(parser != nil)
+        #expect(Self.getParserTypesMatch(parser: parser, expectedParserType: argument.expectedParserClass))
+    }
+    
+    @Test(
+        "Should return a null parser when manifest path is empty and incoming deep link url has a path.",
+        arguments: [
+            TestArgument(
+                scheme: Self.schemeHttps,
+                host: Self.hostGodToolsApp,
+                path: "",
+                parserClass: MockEmptyDeepLinkParser.self,
+                incomingDeepLinkUrl: "https://godtoolsapp.com/path_0",
+                expectedParserClass: MockEmptyDeepLinkParser.self
+            ),
+            TestArgument(
+                scheme: Self.schemeHttps,
+                host: Self.hostGodToolsApp,
+                path: "",
+                parserClass: MockEmptyDeepLinkParser.self,
+                incomingDeepLinkUrl: "https://godtoolsapp.com/path_0/path_1?param_0=0",
+                expectedParserClass: MockEmptyDeepLinkParser.self
+            )
+        ]
+    )
+    func returnsNullDeepLinkParserWhenPathIsEmptyAndIncomingDeepLinkUrlHasAPath(argument: TestArgument) async {
+        
+        let deepLinkingParserUrlManifest = DeepLinkingParserManifestUrl(
+            scheme: argument.scheme,
+            host: argument.host,
+            path: argument.path,
+            parserClass: argument.parserClass
+        )
+        
+        let url = IncomingDeepLinkUrl(url: URL(string: argument.incomingDeepLinkUrl)!)
+        
+        let incomingDeepLink: IncomingDeepLinkType = .url(incomingUrl: url)
+        
+        let parser: DeepLinkParserInterface? = deepLinkingParserUrlManifest.getParserIfValidIncomingDeepLink(incomingDeepLink: incomingDeepLink)
+                        
+        #expect(parser == nil)
+        #expect(Self.getParserTypesMatch(parser: parser, expectedParserType: argument.expectedParserClass) == false)
+    }
+    
+    @Test(
+        "Should return a null parser when manifest path is larger than incoming deep link url path.",
+        arguments: [
+            TestArgument(
+                scheme: Self.schemeHttps,
+                host: Self.hostGodToolsApp,
+                path: "path_0/path_1/path_2",
+                parserClass: MockEmptyDeepLinkParser.self,
+                incomingDeepLinkUrl: "https://godtoolsapp.com/path_0",
+                expectedParserClass: MockEmptyDeepLinkParser.self
+            ),
+            TestArgument(
+                scheme: Self.schemeHttps,
+                host: Self.hostGodToolsApp,
+                path: "path_0/path_1/path_2",
+                parserClass: MockEmptyDeepLinkParser.self,
+                incomingDeepLinkUrl: "https://godtoolsapp.com/path_0/path_1",
+                expectedParserClass: MockEmptyDeepLinkParser.self
+            )
+        ]
+    )
+    func returnsNullDeepLinkParserWhenPathIsLargerThanIncomingDeepLinkUrlPath(argument: TestArgument) async {
+        
+        let deepLinkingParserUrlManifest = DeepLinkingParserManifestUrl(
+            scheme: argument.scheme,
+            host: argument.host,
+            path: argument.path,
+            parserClass: argument.parserClass
+        )
+        
+        let url = IncomingDeepLinkUrl(url: URL(string: argument.incomingDeepLinkUrl)!)
+        
+        let incomingDeepLink: IncomingDeepLinkType = .url(incomingUrl: url)
+        
+        let parser: DeepLinkParserInterface? = deepLinkingParserUrlManifest.getParserIfValidIncomingDeepLink(incomingDeepLink: incomingDeepLink)
+                        
+        #expect(parser == nil)
+        #expect(Self.getParserTypesMatch(parser: parser, expectedParserType: argument.expectedParserClass) == false)
+    }
+    
+    @Test(
+        "Should return a null parser when manifest path does not match incoming deep link url path.",
+        arguments: [
+            TestArgument(
+                scheme: Self.schemeHttps,
+                host: Self.hostGodToolsApp,
+                path: "path_0/path_1/path_2",
+                parserClass: MockEmptyDeepLinkParser.self,
+                incomingDeepLinkUrl: "https://godtoolsapp.com/path_2/path_1/path_0",
+                expectedParserClass: MockEmptyDeepLinkParser.self
+            ),
+            TestArgument(
+                scheme: Self.schemeHttps,
+                host: Self.hostGodToolsApp,
+                path: "path_0/path_1/path_2",
+                parserClass: MockEmptyDeepLinkParser.self,
+                incomingDeepLinkUrl: "https://godtoolsapp.com/path_0/path_0/path_2",
+                expectedParserClass: MockEmptyDeepLinkParser.self
+            )
+        ]
+    )
+    func returnsNullDeepLinkParserWhenPathDoesNotMatchIncomingDeepLinkUrlPath(argument: TestArgument) async {
+        
+        let deepLinkingParserUrlManifest = DeepLinkingParserManifestUrl(
+            scheme: argument.scheme,
+            host: argument.host,
+            path: argument.path,
+            parserClass: argument.parserClass
+        )
+        
+        let url = IncomingDeepLinkUrl(url: URL(string: argument.incomingDeepLinkUrl)!)
+        
+        let incomingDeepLink: IncomingDeepLinkType = .url(incomingUrl: url)
+        
+        let parser: DeepLinkParserInterface? = deepLinkingParserUrlManifest.getParserIfValidIncomingDeepLink(incomingDeepLink: incomingDeepLink)
+                        
+        #expect(parser == nil)
+        #expect(Self.getParserTypesMatch(parser: parser, expectedParserType: argument.expectedParserClass) == false)
+    }
+    
+    @Test(
+        "Should return a parser when manifest path matches some or all of the incoming deep link url path.",
+        arguments: [
+            TestArgument(
+                scheme: Self.schemeHttps,
+                host: Self.hostGodToolsApp,
+                path: "path_0",
+                parserClass: MockEmptyDeepLinkParser.self,
+                incomingDeepLinkUrl: "https://godtoolsapp.com/path_0",
+                expectedParserClass: MockEmptyDeepLinkParser.self
+            ),
+            TestArgument(
+                scheme: Self.schemeHttps,
+                host: Self.hostGodToolsApp,
+                path: "path_0",
+                parserClass: MockEmptyDeepLinkParser.self,
+                incomingDeepLinkUrl: "https://godtoolsapp.com/path_0/path_1",
+                expectedParserClass: MockEmptyDeepLinkParser.self
+            ),
+            TestArgument(
+                scheme: Self.schemeHttps,
+                host: Self.hostGodToolsApp,
+                path: "path_0",
+                parserClass: MockEmptyDeepLinkParser.self,
+                incomingDeepLinkUrl: "https://godtoolsapp.com/path_0/path_1?param_0=0",
+                expectedParserClass: MockEmptyDeepLinkParser.self
+            ),
+            TestArgument(
+                scheme: Self.schemeHttps,
+                host: Self.hostGodToolsApp,
+                path: "path_0/path_1",
+                parserClass: MockEmptyDeepLinkParser.self,
+                incomingDeepLinkUrl: "https://godtoolsapp.com/path_0/path_1/path_2",
+                expectedParserClass: MockEmptyDeepLinkParser.self
+            ),
+            TestArgument(
+                scheme: Self.schemeHttps,
+                host: Self.hostGodToolsApp,
+                path: "path_0/path_1/path_2",
+                parserClass: MockEmptyDeepLinkParser.self,
+                incomingDeepLinkUrl: "https://godtoolsapp.com/path_0/path_1/path_2",
+                expectedParserClass: MockEmptyDeepLinkParser.self
+            ),
+            TestArgument(
+                scheme: Self.schemeHttps,
+                host: Self.hostGodToolsApp,
+                path: "path_0/path_1/path_2",
+                parserClass: MockEmptyDeepLinkParser.self,
+                incomingDeepLinkUrl: "https://godtoolsapp.com/path_0/path_1/path_2?param_0=0",
+                expectedParserClass: MockEmptyDeepLinkParser.self
+            )
+        ]
+    )
+    func returnsDeepLinkParserWhenManifestHasAPathAndIncomingDeepLinkUrlHasAPath(argument: TestArgument) async {
+        
+        let deepLinkingParserUrlManifest = DeepLinkingParserManifestUrl(
+            scheme: argument.scheme,
+            host: argument.host,
+            path: argument.path,
+            parserClass: argument.parserClass
+        )
+        
+        let url = IncomingDeepLinkUrl(url: URL(string: argument.incomingDeepLinkUrl)!)
+        
+        let incomingDeepLink: IncomingDeepLinkType = .url(incomingUrl: url)
+        
+        let parser: DeepLinkParserInterface? = deepLinkingParserUrlManifest.getParserIfValidIncomingDeepLink(incomingDeepLink: incomingDeepLink)
+                        
+        #expect(parser != nil)
+        #expect(Self.getParserTypesMatch(parser: parser, expectedParserType: argument.expectedParserClass))
     }
 }
 

--- a/godtoolsTests/Mock/App/Share/Data/DeepLinkingService/Parsers/MockEmptyDeepLinkParser.swift
+++ b/godtoolsTests/Mock/App/Share/Data/DeepLinkingService/Parsers/MockEmptyDeepLinkParser.swift
@@ -1,0 +1,17 @@
+//
+//  MockEmptyDeepLinkParser.swift
+//  godtools
+//
+//  Created by Levi Eggert on 8/6/25.
+//  Copyright © 2025 Cru. All rights reserved.
+//
+
+import Foundation
+@testable import godtools
+
+struct MockEmptyDeepLinkParser: DeepLinkParserInterface {
+    
+    init() {
+        
+    }
+}


### PR DESCRIPTION
This PR begins adding unit tests to the deep linking classes.

- Added unit tests for DeepLinkingParserManifestUrl.swift.
- Updated DeepLinkingParserManifestUrl to support multiple hosts (Useful for sharing same parsing logic across hosts).