### PR TITLE
GT-2726 Begin interface for app core data layer dependencies

### DIFF
--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -2053,7 +2053,7 @@
 			repositoryURL = "https://github.com/CruGlobal/localization-services-ios";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.3.0;
+				minimumVersion = 0.3.1;
 			};
 		};
 		D4997E0C28D4CED800205B4C /* XCRemoteSwiftPackageReference "youtube-ios-player-helper" */ = {

--- a/godtools.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/godtools.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -159,8 +159,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CruGlobal/localization-services-ios",
       "state" : {
-        "revision" : "a1f85525f06d7595f29690f3bc136cdfd37ba496",
-        "version" : "0.3.0"
+        "revision" : "fbc2f1ee089c02df4c8560cb791972d929c0ef7e",
+        "version" : "0.3.1"
       }
     },
     {

--- a/godtools/App/AppBackgroundState.swift
+++ b/godtools/App/AppBackgroundState.swift
@@ -51,7 +51,7 @@ class AppBackgroundState {
                 
         syncInitialFavoritedTools(
             resourcesRepository: appDiContainer.dataLayer.getResourcesRepository(),
-            launchCountRepository: appDiContainer.dataLayer.getSharedLaunchCountRepository(),
+            launchCountRepository: appDiContainer.dataLayer.getLaunchCountRepository(),
             storeInitialFavoritedToolsUseCase: appDiContainer.feature.dashboard.domainLayer.getStoreInitialFavoritedToolsUseCase()
         )
         
@@ -78,7 +78,7 @@ class AppBackgroundState {
             .store(in: &cancellables)
     }
     
-    private func syncInitialFavoritedTools(resourcesRepository: ResourcesRepository, launchCountRepository: LaunchCountRepository, storeInitialFavoritedToolsUseCase: StoreInitialFavoritedToolsUseCase) {
+    private func syncInitialFavoritedTools(resourcesRepository: ResourcesRepository, launchCountRepository: LaunchCountRepositoryInterface, storeInitialFavoritedToolsUseCase: StoreInitialFavoritedToolsUseCase) {
         
         Publishers.CombineLatest(
             resourcesRepository.getResourcesChangedPublisher().prepend(Void()),

--- a/godtools/App/DependencyContainer/AppDataLayerDependencies.swift
+++ b/godtools/App/DependencyContainer/AppDataLayerDependencies.swift
@@ -11,7 +11,7 @@ import RequestOperation
 import SocialAuthentication
 import LocalizationServices
 
-class AppDataLayerDependencies {
+class AppDataLayerDependencies: DataLayerDependenciesInterface {
     
     enum WebSocketType {
         case starscream
@@ -102,7 +102,7 @@ class AppDataLayerDependencies {
             categoryArticlesCache: RealmCategoryArticlesCache(
                 realmDatabase: sharedRealmDatabase
             ),
-            sharedUserDefaultsCache: getSharedUserDefaultsCache()
+            userDefaultsCache: getUserDefaultsCache()
         )
     }
     
@@ -200,6 +200,10 @@ class AppDataLayerDependencies {
         )
     }
     
+    func getLaunchCountRepository() -> LaunchCountRepositoryInterface {
+        return LaunchCountRepository.shared
+    }
+    
     func getLessonListItemProgressRepository() -> GetLessonListItemProgressRepository {
         return GetLessonListItemProgressRepository(
             lessonProgressRepository: getUserLessonProgressRepository(),
@@ -215,7 +219,7 @@ class AppDataLayerDependencies {
         )
     }
     
-    func getLocalizationServices() -> LocalizationServices {
+    func getLocalizationServices() -> LocalizationServicesInterface {
         return LocalizationServices(
             localizableStringsFilesBundle: Bundle.main,
             isUsingBaseInternationalization: false
@@ -288,7 +292,7 @@ class AppDataLayerDependencies {
             cache: cache,
             attachmentsRepository: getAttachmentsRepository(),
             languagesRepository: getLanguagesRepository(),
-            sharedUserDefaultsCache: getSharedUserDefaultsCache()
+            userDefaultsCache: getUserDefaultsCache()
         )
     }
     
@@ -310,10 +314,6 @@ class AppDataLayerDependencies {
         )
     }
     
-    func getSharedLaunchCountRepository() -> LaunchCountRepository {
-        return LaunchCountRepository.shared
-    }
-    
     func getSharedUrlSessionPriority() -> URLSessionPriority {
         return sharedUrlSessionPriority
     }
@@ -324,10 +324,6 @@ class AppDataLayerDependencies {
     
     func getSharedRequestSender() -> RequestSender {
         return sharedRequestSender
-    }
-    
-    func getSharedUserDefaultsCache() -> SharedUserDefaultsCache {
-        return sharedUserDefaultsCache
     }
     
     func getStringWithLocaleCount() -> StringWithLocaleCountInterface {
@@ -456,6 +452,10 @@ class AppDataLayerDependencies {
             cache: cache,
             remoteUserCountersSync: RemoteUserCountersSync(api: api, cache: cache)
         )
+    }
+    
+    func getUserDefaultsCache() -> UserDefaultsCacheInterface {
+        return sharedUserDefaultsCache
     }
     
     func getUserLessonFiltersRepository() -> UserLessonFiltersRepository {

--- a/godtools/App/DependencyContainer/AppDiContainer.swift
+++ b/godtools/App/DependencyContainer/AppDiContainer.swift
@@ -98,7 +98,7 @@ class AppDiContainer {
     }
     
     func getCardJumpService() -> CardJumpService {
-        return CardJumpService(cardJumpCache: CardJumpUserDefaultsCache(sharedUserDefaultsCache: sharedUserDefaultsCache))
+        return CardJumpService(cardJumpCache: CardJumpUserDefaultsCache(userDefaultsCache: sharedUserDefaultsCache))
     }
     
     func getUrlOpener() -> UrlOpenerInterface {

--- a/godtools/App/DependencyContainer/Interface/DataLayerDependenciesInterface.swift
+++ b/godtools/App/DependencyContainer/Interface/DataLayerDependenciesInterface.swift
@@ -1,0 +1,17 @@
+//
+//  DataLayerDependenciesInterface.swift
+//  godtools
+//
+//  Created by Levi Eggert on 8/20/25.
+//  Copyright © 2025 Cru. All rights reserved.
+//
+
+import Foundation
+import LocalizationServices
+
+protocol DataLayerDependenciesInterface {
+    
+    func getLaunchCountRepository() -> LaunchCountRepositoryInterface
+    func getLocalizationServices() -> LocalizationServicesInterface
+    func getUserDefaultsCache() -> UserDefaultsCacheInterface
+}

--- a/godtools/App/Features/Account/Data-DomainInterface/GetAccountInterfaceStringsRepository.swift
+++ b/godtools/App/Features/Account/Data-DomainInterface/GetAccountInterfaceStringsRepository.swift
@@ -12,9 +12,9 @@ import LocalizationServices
 
 class GetAccountInterfaceStringsRepository: GetAccountInterfaceStringsRepositoryInterface {
     
-    private let localizationServices: LocalizationServices
+    private let localizationServices: LocalizationServicesInterface
     
-    init(localizationServices: LocalizationServices) {
+    init(localizationServices: LocalizationServicesInterface) {
         self.localizationServices = localizationServices
     }
     

--- a/godtools/App/Features/Account/Data-DomainInterface/GetDeleteAccountInterfaceStringsRepository.swift
+++ b/godtools/App/Features/Account/Data-DomainInterface/GetDeleteAccountInterfaceStringsRepository.swift
@@ -12,9 +12,9 @@ import LocalizationServices
 
 class GetDeleteAccountInterfaceStringsRepository: GetDeleteAccountInterfaceStringsRepositoryInterface {
     
-    private let localizationServices: LocalizationServices
+    private let localizationServices: LocalizationServicesInterface
     
-    init(localizationServices: LocalizationServices) {
+    init(localizationServices: LocalizationServicesInterface) {
         
         self.localizationServices = localizationServices
     }

--- a/godtools/App/Features/Account/Data-DomainInterface/GetDeleteAccountProgressInterfaceStringsRepository.swift
+++ b/godtools/App/Features/Account/Data-DomainInterface/GetDeleteAccountProgressInterfaceStringsRepository.swift
@@ -12,9 +12,9 @@ import LocalizationServices
 
 class GetDeleteAccountProgressInterfaceStringsRepository: GetDeleteAccountProgressInterfaceStringsInterface {
     
-    private let localizationServices: LocalizationServices
+    private let localizationServices: LocalizationServicesInterface
     
-    init(localizationServices: LocalizationServices) {
+    init(localizationServices: LocalizationServicesInterface) {
         
         self.localizationServices = localizationServices
     }

--- a/godtools/App/Features/Account/Data-DomainInterface/GetSocialCreateAccountInterfaceStringsRepository.swift
+++ b/godtools/App/Features/Account/Data-DomainInterface/GetSocialCreateAccountInterfaceStringsRepository.swift
@@ -12,9 +12,9 @@ import LocalizationServices
 
 class GetSocialCreateAccountInterfaceStringsRepository: GetSocialCreateAccountInterfaceStringsRepositoryInterface {
     
-    private let localizationServices: LocalizationServices
+    private let localizationServices: LocalizationServicesInterface
     
-    init(localizationServices: LocalizationServices) {
+    init(localizationServices: LocalizationServicesInterface) {
         
         self.localizationServices = localizationServices
     }

--- a/godtools/App/Features/Account/Data-DomainInterface/GetSocialSignInInterfaceStringsRepository.swift
+++ b/godtools/App/Features/Account/Data-DomainInterface/GetSocialSignInInterfaceStringsRepository.swift
@@ -12,9 +12,9 @@ import LocalizationServices
 
 class GetSocialSignInInterfaceStringsRepository: GetSocialSignInInterfaceStringsRepositoryInterface {
     
-    private let localizationServices: LocalizationServices
+    private let localizationServices: LocalizationServicesInterface
     
-    init(localizationServices: LocalizationServices) {
+    init(localizationServices: LocalizationServicesInterface) {
         
         self.localizationServices = localizationServices
     }

--- a/godtools/App/Features/AppLanguage/Data-DomainInterface/GetConfirmAppLanguageInterfaceStringsRepository.swift
+++ b/godtools/App/Features/AppLanguage/Data-DomainInterface/GetConfirmAppLanguageInterfaceStringsRepository.swift
@@ -12,10 +12,10 @@ import LocalizationServices
 
 class GetConfirmAppLanguageInterfaceStringsRepository: GetConfirmAppLanguageInterfaceStringsRepositoryInterface {
     
-    private let localizationServices: LocalizationServices
+    private let localizationServices: LocalizationServicesInterface
     private let getTranslatedLanguageName: GetTranslatedLanguageName
     
-    init(localizationServices: LocalizationServices, getTranslatedLanguageName: GetTranslatedLanguageName) {
+    init(localizationServices: LocalizationServicesInterface, getTranslatedLanguageName: GetTranslatedLanguageName) {
         
         self.localizationServices = localizationServices
         self.getTranslatedLanguageName = getTranslatedLanguageName

--- a/godtools/App/Features/AppLanguage/Data-DomainInterface/GetDownloadableLanguagesInterfaceStringsRepository.swift
+++ b/godtools/App/Features/AppLanguage/Data-DomainInterface/GetDownloadableLanguagesInterfaceStringsRepository.swift
@@ -12,9 +12,9 @@ import LocalizationServices
 
 class GetDownloadableLanguagesInterfaceStringsRepository: GetDownloadableLanguagesInterfaceStringsRepositoryInterface {
     
-    private let localizationServices: LocalizationServices
+    private let localizationServices: LocalizationServicesInterface
     
-    init(localizationServices: LocalizationServices) {
+    init(localizationServices: LocalizationServicesInterface) {
         
         self.localizationServices = localizationServices
     }

--- a/godtools/App/Features/AppLanguage/Data/AppLanguagesRepository/Sync/AppLanguagesRepositorySync.swift
+++ b/godtools/App/Features/AppLanguage/Data/AppLanguagesRepository/Sync/AppLanguagesRepositorySync.swift
@@ -15,7 +15,7 @@ class AppLanguagesRepositorySync: AppLanguagesRepositorySyncInterface {
     private let cache: RealmAppLanguagesCache
     private let syncInvalidator: SyncInvalidator
     
-    init(api: AppLanguagesApi, cache: RealmAppLanguagesCache, userDefaultsCache: SharedUserDefaultsCache) {
+    init(api: AppLanguagesApi, cache: RealmAppLanguagesCache, userDefaultsCache: UserDefaultsCacheInterface) {
         
         self.api = api
         self.cache = cache

--- a/godtools/App/Features/AppLanguage/DependencyContainer/AppLanguageFeatureDataLayerDependencies.swift
+++ b/godtools/App/Features/AppLanguage/DependencyContainer/AppLanguageFeatureDataLayerDependencies.swift
@@ -25,7 +25,7 @@ class AppLanguageFeatureDataLayerDependencies {
             realmDatabase: realmDatabase ?? coreDataLayer.getSharedRealmDatabase()
         )
         
-        let sync: AppLanguagesRepositorySyncInterface = sync ?? AppLanguagesRepositorySync(api: AppLanguagesApi(), cache: cache, userDefaultsCache: coreDataLayer.getSharedUserDefaultsCache())
+        let sync: AppLanguagesRepositorySyncInterface = sync ?? AppLanguagesRepositorySync(api: AppLanguagesApi(), cache: cache, userDefaultsCache: coreDataLayer.getUserDefaultsCache())
         
         return AppLanguagesRepository(
             cache: cache,

--- a/godtools/App/Features/Articles/Presentation/Articles/ArticlesViewModel.swift
+++ b/godtools/App/Features/Articles/Presentation/Articles/ArticlesViewModel.swift
@@ -22,7 +22,7 @@ class ArticlesViewModel: NSObject {
     private let downloadArticlesObservable: DownloadManifestArticlesObservable
     private let articleManifestAemRepository: ArticleManifestAemRepository
     private let getCurrentAppLanguageUseCase: GetCurrentAppLanguageUseCase
-    private let localizationServices: LocalizationServices
+    private let localizationServices: LocalizationServicesInterface
     private let trackScreenViewAnalyticsUseCase: TrackScreenViewAnalyticsUseCase
         
     private var cancellables: Set<AnyCancellable> = Set()
@@ -37,7 +37,7 @@ class ArticlesViewModel: NSObject {
     @Published private var appLanguage: AppLanguageDomainModel = LanguageCodeDomainModel.english.rawValue
     @Published private var articleAemCacheObjects: [ArticleAemCacheObject] = Array()
     
-    init(flowDelegate: FlowDelegate, resource: ResourceModel, language: LanguageModel, category: GodToolsToolParser.Category, manifest: Manifest, downloadArticlesObservable: DownloadManifestArticlesObservable, articleManifestAemRepository: ArticleManifestAemRepository, getCurrentAppLanguageUseCase: GetCurrentAppLanguageUseCase, localizationServices: LocalizationServices, trackScreenViewAnalyticsUseCase: TrackScreenViewAnalyticsUseCase) {
+    init(flowDelegate: FlowDelegate, resource: ResourceModel, language: LanguageModel, category: GodToolsToolParser.Category, manifest: Manifest, downloadArticlesObservable: DownloadManifestArticlesObservable, articleManifestAemRepository: ArticleManifestAemRepository, getCurrentAppLanguageUseCase: GetCurrentAppLanguageUseCase, localizationServices: LocalizationServicesInterface, trackScreenViewAnalyticsUseCase: TrackScreenViewAnalyticsUseCase) {
         
         self.flowDelegate = flowDelegate
         self.resource = resource

--- a/godtools/App/Features/Articles/Presentation/ArticlesErrorMessage/ArticlesErrorMessageViewModel.swift
+++ b/godtools/App/Features/Articles/Presentation/ArticlesErrorMessage/ArticlesErrorMessageViewModel.swift
@@ -15,7 +15,7 @@ class ArticlesErrorMessageViewModel {
     let message: String
     let downloadArticlesButtonTitle: String
     
-    init(appLanguage: AppLanguageDomainModel, localizationServices: LocalizationServices, message: String) {
+    init(appLanguage: AppLanguageDomainModel, localizationServices: LocalizationServicesInterface, message: String) {
         
         title = localizationServices.stringForLocaleElseEnglish(localeIdentifier: appLanguage, key: LocalizableStringKeys.downloadError.key)
         self.message = message

--- a/godtools/App/Features/Articles/Presentation/DownloadArticlesError/DownloadArticlesErrorViewModel.swift
+++ b/godtools/App/Features/Articles/Presentation/DownloadArticlesError/DownloadArticlesErrorViewModel.swift
@@ -13,7 +13,7 @@ class DownloadArticlesErrorViewModel {
     
     let message: String
     
-    init(appLanguage: AppLanguageDomainModel, localizationServices: LocalizationServices, error: ArticleAemDownloaderError) {
+    init(appLanguage: AppLanguageDomainModel, localizationServices: LocalizationServicesInterface, error: ArticleAemDownloaderError) {
             
         let notConnectedToNetworkMessage: String = localizationServices.stringForLocaleElseEnglish(localeIdentifier: appLanguage, key: LocalizableStringKeys.noInternet.key)
         let cancelledError: String = "The request was cancelled"

--- a/godtools/App/Features/Articles/Presentation/LoadingArticle/LoadingArticleViewModel.swift
+++ b/godtools/App/Features/Articles/Presentation/LoadingArticle/LoadingArticleViewModel.swift
@@ -22,7 +22,7 @@ class LoadingArticleViewModel: ObservableObject {
     
     let message: String
     
-    init(flowDelegate: FlowDelegate, aemUri: String, appLanguage: AppLanguageDomainModel, articleAemRepository: ArticleAemRepository, localizationServices: LocalizationServices) {
+    init(flowDelegate: FlowDelegate, aemUri: String, appLanguage: AppLanguageDomainModel, articleAemRepository: ArticleAemRepository, localizationServices: LocalizationServicesInterface) {
         
         self.flowDelegate = flowDelegate
         self.articleAemRepository = articleAemRepository

--- a/godtools/App/Features/Dashboard/Data-DomainInterface/GetDashboardInterfaceStringsRepository.swift
+++ b/godtools/App/Features/Dashboard/Data-DomainInterface/GetDashboardInterfaceStringsRepository.swift
@@ -12,9 +12,9 @@ import LocalizationServices
 
 class GetDashboardInterfaceStringsRepository: GetDashboardInterfaceStringsRepositoryInterface {
     
-    private let localizationServices: LocalizationServices
+    private let localizationServices: LocalizationServicesInterface
     
-    init(localizationServices: LocalizationServices) {
+    init(localizationServices: LocalizationServicesInterface) {
         
         self.localizationServices = localizationServices
     }

--- a/godtools/App/Features/Dashboard/Data-DomainInterface/GetToolsInterfaceStringsRepository.swift
+++ b/godtools/App/Features/Dashboard/Data-DomainInterface/GetToolsInterfaceStringsRepository.swift
@@ -12,9 +12,9 @@ import LocalizationServices
 
 class GetToolsInterfaceStringsRepository: GetToolsInterfaceStringsRepositoryInterface {
     
-    private let localizationServices: LocalizationServices
+    private let localizationServices: LocalizationServicesInterface
     
-    init(localizationServices: LocalizationServices) {
+    init(localizationServices: LocalizationServicesInterface) {
         
         self.localizationServices = localizationServices
     }

--- a/godtools/App/Features/Favorites/Data-DomainInterface/GetAllYourFavoritedToolsInterfaceStringsRepository.swift
+++ b/godtools/App/Features/Favorites/Data-DomainInterface/GetAllYourFavoritedToolsInterfaceStringsRepository.swift
@@ -12,9 +12,9 @@ import LocalizationServices
 
 class GetAllYourFavoritedToolsInterfaceStringsRepository: GetAllYourFavoritedToolsInterfaceStringsRepositoryInterface {
     
-    private let localizationServices: LocalizationServices
+    private let localizationServices: LocalizationServicesInterface
     
-    init(localizationServices: LocalizationServices) {
+    init(localizationServices: LocalizationServicesInterface) {
         
         self.localizationServices = localizationServices
     }

--- a/godtools/App/Features/Favorites/Data-DomainInterface/GetConfirmRemoveToolFromFavoritesInterfaceStringsRepository.swift
+++ b/godtools/App/Features/Favorites/Data-DomainInterface/GetConfirmRemoveToolFromFavoritesInterfaceStringsRepository.swift
@@ -12,10 +12,10 @@ import LocalizationServices
 
 class GetConfirmRemoveToolFromFavoritesInterfaceStringsRepository: GetConfirmRemoveToolFromFavoritesInterfaceStringsRepositoryInterface {
     
-    private let localizationServices: LocalizationServices
+    private let localizationServices: LocalizationServicesInterface
     private let getTranslatedToolName: GetTranslatedToolName
     
-    init(localizationServices: LocalizationServices, getTranslatedToolName: GetTranslatedToolName) {
+    init(localizationServices: LocalizationServicesInterface, getTranslatedToolName: GetTranslatedToolName) {
         
         self.localizationServices = localizationServices
         self.getTranslatedToolName = getTranslatedToolName

--- a/godtools/App/Features/Favorites/Data-DomainInterface/GetFavoritesInterfaceStringsRepository.swift
+++ b/godtools/App/Features/Favorites/Data-DomainInterface/GetFavoritesInterfaceStringsRepository.swift
@@ -12,9 +12,9 @@ import LocalizationServices
 
 class GetFavoritesInterfaceStringsRepository: GetFavoritesInterfaceStringsRepositoryInterface {
     
-    private let localizationServices: LocalizationServices
+    private let localizationServices: LocalizationServicesInterface
     
-    init(localizationServices: LocalizationServices) {
+    init(localizationServices: LocalizationServicesInterface) {
         
         self.localizationServices = localizationServices
     }

--- a/godtools/App/Features/GlobalActivity/Data-DomainInterface/GetGlobalActivityThisWeekRepository.swift
+++ b/godtools/App/Features/GlobalActivity/Data-DomainInterface/GetGlobalActivityThisWeekRepository.swift
@@ -13,10 +13,10 @@ import LocalizationServices
 class GetGlobalActivityThisWeekRepository: GetGlobalActivityThisWeekRepositoryInterface {
     
     private let globalAnalyticsRepository: GlobalAnalyticsRepository
-    private let localizationServices: LocalizationServices
+    private let localizationServices: LocalizationServicesInterface
     private let getTranslatedNumberCount: GetTranslatedNumberCount
     
-    init(globalAnalyticsRepository: GlobalAnalyticsRepository, localizationServices: LocalizationServices, getTranslatedNumberCount: GetTranslatedNumberCount) {
+    init(globalAnalyticsRepository: GlobalAnalyticsRepository, localizationServices: LocalizationServicesInterface, getTranslatedNumberCount: GetTranslatedNumberCount) {
         
         self.globalAnalyticsRepository = globalAnalyticsRepository
         self.localizationServices = localizationServices

--- a/godtools/App/Features/LearnToShareTool/Data-DomainInterface/GetLearnToShareToolInterfaceStringsRepository.swift
+++ b/godtools/App/Features/LearnToShareTool/Data-DomainInterface/GetLearnToShareToolInterfaceStringsRepository.swift
@@ -12,9 +12,9 @@ import LocalizationServices
 
 class GetLearnToShareToolInterfaceStringsRepository: GetLearnToShareToolInterfaceStringsRepositoryInterface {
     
-    private let localizationServices: LocalizationServices
+    private let localizationServices: LocalizationServicesInterface
     
-    init(localizationServices: LocalizationServices) {
+    init(localizationServices: LocalizationServicesInterface) {
         
         self.localizationServices = localizationServices
     }

--- a/godtools/App/Features/LearnToShareTool/Data-DomainInterface/GetLearnToShareToolTutorialItemsRepository.swift
+++ b/godtools/App/Features/LearnToShareTool/Data-DomainInterface/GetLearnToShareToolTutorialItemsRepository.swift
@@ -12,9 +12,9 @@ import LocalizationServices
 
 class GetLearnToShareToolTutorialItemsRepository: GetLearnToShareToolTutorialItemsRepositoryInterface {
     
-    private let localizationServices: LocalizationServices
+    private let localizationServices: LocalizationServicesInterface
     
-    init(localizationServices: LocalizationServices) {
+    init(localizationServices: LocalizationServicesInterface) {
         
         self.localizationServices = localizationServices
     }

--- a/godtools/App/Features/LessonEvaluation/Data-DomainInterface/GetLessonEvaluationInterfaceStringsRepository.swift
+++ b/godtools/App/Features/LessonEvaluation/Data-DomainInterface/GetLessonEvaluationInterfaceStringsRepository.swift
@@ -12,9 +12,9 @@ import LocalizationServices
 
 class GetLessonEvaluationInterfaceStringsRepository: GetLessonEvaluationInterfaceStringsRepositoryInterface {
     
-    private let localizationServices: LocalizationServices
+    private let localizationServices: LocalizationServicesInterface
     
-    init(localizationServices: LocalizationServices) {
+    init(localizationServices: LocalizationServicesInterface) {
         
         self.localizationServices = localizationServices
     }

--- a/godtools/App/Features/LessonSwipeTutorial/Data-DomainInterface/GetLessonSwipeTutorialInterfaceStringsRepository.swift
+++ b/godtools/App/Features/LessonSwipeTutorial/Data-DomainInterface/GetLessonSwipeTutorialInterfaceStringsRepository.swift
@@ -12,9 +12,9 @@ import LocalizationServices
 
 class GetLessonSwipeTutorialInterfaceStringsRepository: GetLessonSwipeTutorialInterfaceStringsRepositoryInterface {
     
-    private let localizationServices: LocalizationServices
+    private let localizationServices: LocalizationServicesInterface
     
-    init(localizationServices: LocalizationServices) {
+    init(localizationServices: LocalizationServicesInterface) {
         self.localizationServices = localizationServices
     }
     

--- a/godtools/App/Features/LessonSwipeTutorial/Data/LessonSwipeTutorialViewedRepository/Cache/LessonSwipeTutorialViewedUserDefaultsCache.swift
+++ b/godtools/App/Features/LessonSwipeTutorial/Data/LessonSwipeTutorialViewedRepository/Cache/LessonSwipeTutorialViewedUserDefaultsCache.swift
@@ -10,20 +10,20 @@ import Foundation
 
 class LessonSwipeTutorialViewedUserDefaultsCache {
     
-    private let sharedUserDefaultsCache: SharedUserDefaultsCache
+    private let userDefaultsCache: UserDefaultsCacheInterface
     private let lessonSwipeTutorialViewedKey: String = "lessonSwipeTutorialViewed"
     
-    init(sharedUserDefaultsCache: SharedUserDefaultsCache) {
-        self.sharedUserDefaultsCache = sharedUserDefaultsCache
+    init(userDefaultsCache: UserDefaultsCacheInterface) {
+        self.userDefaultsCache = userDefaultsCache
     }
     
     func getLessonSwipeTutorialViewed() -> Bool {
-        return sharedUserDefaultsCache.getValue(key: lessonSwipeTutorialViewedKey) as? Bool ?? false
+        return userDefaultsCache.getValue(key: lessonSwipeTutorialViewedKey) as? Bool ?? false
     }
     
     func storeLessonSwipeTutorialViewed(viewed: Bool) {
         
-        sharedUserDefaultsCache.cache(value: viewed, forKey: lessonSwipeTutorialViewedKey)
-        sharedUserDefaultsCache.commitChanges()
+        userDefaultsCache.cache(value: viewed, forKey: lessonSwipeTutorialViewedKey)
+        userDefaultsCache.commitChanges()
     }
 }

--- a/godtools/App/Features/LessonSwipeTutorial/DependencyContainer/LessonSwipeTutorialDataLayerDependencies.swift
+++ b/godtools/App/Features/LessonSwipeTutorial/DependencyContainer/LessonSwipeTutorialDataLayerDependencies.swift
@@ -21,7 +21,7 @@ class LessonSwipeTutorialDataLayerDependencies {
     func getLessonSwipeTutorialViewedRepository() -> LessonSwipeTutorialViewedRepository {
         return LessonSwipeTutorialViewedRepository(
             cache: LessonSwipeTutorialViewedUserDefaultsCache(
-                sharedUserDefaultsCache: coreDataLayer.getSharedUserDefaultsCache()
+                userDefaultsCache: coreDataLayer.getUserDefaultsCache()
             )
         )
     }

--- a/godtools/App/Features/Lessons/Data-DomainInterface/GetLessonsInterfaceStringsRepository.swift
+++ b/godtools/App/Features/Lessons/Data-DomainInterface/GetLessonsInterfaceStringsRepository.swift
@@ -12,9 +12,9 @@ import LocalizationServices
 
 class GetLessonsInterfaceStringsRepository: GetLessonsInterfaceStringsRepositoryInterface {
  
-    private let localizationServices: LocalizationServices
+    private let localizationServices: LocalizationServicesInterface
     
-    init(localizationServices: LocalizationServices) {
+    init(localizationServices: LocalizationServicesInterface) {
         
         self.localizationServices = localizationServices
     }

--- a/godtools/App/Features/Menu/Data-DomainInterface/GetMenuInterfaceStringsRepository.swift
+++ b/godtools/App/Features/Menu/Data-DomainInterface/GetMenuInterfaceStringsRepository.swift
@@ -12,10 +12,10 @@ import LocalizationServices
 
 class GetMenuInterfaceStringsRepository: GetMenuInterfaceStringsRepositoryInterface {
     
-    private let localizationServices: LocalizationServices
+    private let localizationServices: LocalizationServicesInterface
     private let infoPlist: InfoPlist
     
-    init(localizationServices: LocalizationServices, infoPlist: InfoPlist) {
+    init(localizationServices: LocalizationServicesInterface, infoPlist: InfoPlist) {
         
         self.localizationServices = localizationServices
         self.infoPlist = infoPlist

--- a/godtools/App/Features/Menu/Presentation/WebContent/Models/AskAQuestionWebContent.swift
+++ b/godtools/App/Features/Menu/Presentation/WebContent/Models/AskAQuestionWebContent.swift
@@ -16,7 +16,7 @@ struct AskAQuestionWebContent: WebContentType {
     let analyticsScreenName: String = "Ask A Question"
     let analyticsSiteSection: String = "menu"
     
-    init(localizationServices: LocalizationServices) {
+    init(localizationServices: LocalizationServicesInterface) {
         
         navTitle = localizationServices.stringForSystemElseEnglish(key: "menu.askAQuestion")
     }

--- a/godtools/App/Features/Menu/Presentation/WebContent/Models/CopyrightInfoWebContent.swift
+++ b/godtools/App/Features/Menu/Presentation/WebContent/Models/CopyrightInfoWebContent.swift
@@ -16,7 +16,7 @@ struct CopyrightInfoWebContent: WebContentType {
     let analyticsScreenName: String = "Copyright Info"
     let analyticsSiteSection: String = "menu"
     
-    init(localizationServices: LocalizationServices) {
+    init(localizationServices: LocalizationServicesInterface) {
         
         navTitle = localizationServices.stringForSystemElseEnglish(key: "copyright_info")
     }

--- a/godtools/App/Features/Menu/Presentation/WebContent/Models/PrivacyPolicyWebContent.swift
+++ b/godtools/App/Features/Menu/Presentation/WebContent/Models/PrivacyPolicyWebContent.swift
@@ -16,7 +16,7 @@ struct PrivacyPolicyWebContent: WebContentType {
     let analyticsScreenName: String = "Privacy Policy"
     let analyticsSiteSection: String = "menu"
     
-    init(localizationServices: LocalizationServices) {
+    init(localizationServices: LocalizationServicesInterface) {
         
         navTitle = localizationServices.stringForSystemElseEnglish(key: "privacy_policy")
     }

--- a/godtools/App/Features/Menu/Presentation/WebContent/Models/ReportABugWebContent.swift
+++ b/godtools/App/Features/Menu/Presentation/WebContent/Models/ReportABugWebContent.swift
@@ -16,7 +16,7 @@ struct ReportABugWebContent: WebContentType {
     let analyticsScreenName: String = "Report A Bug"
     let analyticsSiteSection: String = "menu"
     
-    init(localizationServices: LocalizationServices) {
+    init(localizationServices: LocalizationServicesInterface) {
         
         navTitle = localizationServices.stringForSystemElseEnglish(key: "menu.reportABug")
     }

--- a/godtools/App/Features/Menu/Presentation/WebContent/Models/SendFeedbackWebContent.swift
+++ b/godtools/App/Features/Menu/Presentation/WebContent/Models/SendFeedbackWebContent.swift
@@ -16,7 +16,7 @@ struct SendFeedbackWebContent: WebContentType {
     let analyticsScreenName: String = "Send Feedback"
     let analyticsSiteSection: String = "menu"
     
-    init(localizationServices: LocalizationServices) {
+    init(localizationServices: LocalizationServicesInterface) {
         
         navTitle = localizationServices.stringForSystemElseEnglish(key: "menu.sendFeedback")
     }

--- a/godtools/App/Features/Menu/Presentation/WebContent/Models/ShareAStoryWithUsWebContent.swift
+++ b/godtools/App/Features/Menu/Presentation/WebContent/Models/ShareAStoryWithUsWebContent.swift
@@ -16,7 +16,7 @@ struct ShareAStoryWithUsWebContent: WebContentType {
     let analyticsScreenName: String = "Share Story"
     let analyticsSiteSection: String = "menu"
     
-    init(localizationServices: LocalizationServices) {
+    init(localizationServices: LocalizationServicesInterface) {
         
         navTitle = localizationServices.stringForSystemElseEnglish(key: "share_a_story_with_us")
     }

--- a/godtools/App/Features/Menu/Presentation/WebContent/Models/TermsOfUseWebContent.swift
+++ b/godtools/App/Features/Menu/Presentation/WebContent/Models/TermsOfUseWebContent.swift
@@ -16,7 +16,7 @@ struct TermsOfUseWebContent: WebContentType {
     let analyticsScreenName: String = "Terms of Use"
     let analyticsSiteSection: String = "menu"
     
-    init(localizationServices: LocalizationServices) {
+    init(localizationServices: LocalizationServicesInterface) {
         
         navTitle = localizationServices.stringForSystemElseEnglish(key: "terms_of_use")
     }

--- a/godtools/App/Features/Onboarding/Data/OnboardingTutorialViewedRepository/Cache/OnboardingTutorialViewedUserDefaultsCache.swift
+++ b/godtools/App/Features/Onboarding/Data/OnboardingTutorialViewedRepository/Cache/OnboardingTutorialViewedUserDefaultsCache.swift
@@ -10,17 +10,17 @@ import Foundation
 
 class OnboardingTutorialViewedUserDefaultsCache {
         
-    private let sharedUserDefaultsCache: SharedUserDefaultsCache
+    private let userDefaultsCache: UserDefaultsCacheInterface
     private let onboardingTutorialViewedCacheKey: String = "keyOnboardingTutorialViewed"
     
-    init(sharedUserDefaultsCache: SharedUserDefaultsCache) {
+    init(userDefaultsCache: UserDefaultsCacheInterface) {
         
-        self.sharedUserDefaultsCache = sharedUserDefaultsCache
+        self.userDefaultsCache = userDefaultsCache
     }
     
     func getOnboardingTutorialViewed() -> Bool {
        
-        guard let viewed = sharedUserDefaultsCache.getValue(key: onboardingTutorialViewedCacheKey) as? Bool else {
+        guard let viewed = userDefaultsCache.getValue(key: onboardingTutorialViewedCacheKey) as? Bool else {
             return false
         }
         
@@ -29,7 +29,7 @@ class OnboardingTutorialViewedUserDefaultsCache {
     
     func storeOnboardingTutorialViewed(viewed: Bool) {
         
-        sharedUserDefaultsCache.cache(value: viewed, forKey: onboardingTutorialViewedCacheKey)
-        sharedUserDefaultsCache.commitChanges()
+        userDefaultsCache.cache(value: viewed, forKey: onboardingTutorialViewedCacheKey)
+        userDefaultsCache.commitChanges()
     }
 }

--- a/godtools/App/Features/Onboarding/DependencyContainer/OnboardingDataLayerDependencies.swift
+++ b/godtools/App/Features/Onboarding/DependencyContainer/OnboardingDataLayerDependencies.swift
@@ -21,7 +21,7 @@ class OnboardingDataLayerDependencies {
     
     private func getOnboardingTutorialViewedRepository() -> OnboardingTutorialViewedRepository {
         return OnboardingTutorialViewedRepository(
-            cache: OnboardingTutorialViewedUserDefaultsCache(sharedUserDefaultsCache: coreDataLayer.getSharedUserDefaultsCache())
+            cache: OnboardingTutorialViewedUserDefaultsCache(userDefaultsCache: coreDataLayer.getUserDefaultsCache())
         )
     }
     
@@ -35,7 +35,7 @@ class OnboardingDataLayerDependencies {
     
     func getOnboardingTutorialIsAvailable() -> GetOnboardingTutorialIsAvailableInterface {
         return GetOnboardingTutorialIsAvailable(
-            launchCountRepository: coreDataLayer.getSharedLaunchCountRepository(),
+            launchCountRepository: coreDataLayer.getLaunchCountRepository(),
             onboardingTutorialViewedRepository: getOnboardingTutorialViewedRepository()
         )
     }

--- a/godtools/App/Features/OptInNotification/Data-DomainInterface/GetOptInNotificationInterfaceStringsRepository.swift
+++ b/godtools/App/Features/OptInNotification/Data-DomainInterface/GetOptInNotificationInterfaceStringsRepository.swift
@@ -12,9 +12,9 @@ import LocalizationServices
 
 class GetOptInNotificationInterfaceStringsRepository: GetOptInNotificationInterfaceStringsRepositoryInterface {
     
-    private let localizationServices: LocalizationServices
+    private let localizationServices: LocalizationServicesInterface
 
-    init(localizationServices: LocalizationServices) {
+    init(localizationServices: LocalizationServicesInterface) {
 
         self.localizationServices = localizationServices
     }

--- a/godtools/App/Features/OptInNotification/Data/OptInNotificationRepository/Cache/OptInNotificationUserDefaultsCache.swift
+++ b/godtools/App/Features/OptInNotification/Data/OptInNotificationRepository/Cache/OptInNotificationUserDefaultsCache.swift
@@ -23,11 +23,11 @@ class OptInNotificationUserDefaultsCache {
         return formatter
     }()
     
-    private let sharedUserDefaultsCache: SharedUserDefaultsCache
+    private let userDefaultsCache: UserDefaultsCacheInterface
 
-    init(sharedUserDefaultsCache: SharedUserDefaultsCache) {
+    init(userDefaultsCache: UserDefaultsCacheInterface) {
 
-        self.sharedUserDefaultsCache = sharedUserDefaultsCache
+        self.userDefaultsCache = userDefaultsCache
     }
     
     func deleteAllData() {
@@ -36,17 +36,17 @@ class OptInNotificationUserDefaultsCache {
         
         for key in allKeys {
             
-            sharedUserDefaultsCache.deleteValue(
+            userDefaultsCache.deleteValue(
                 key: key.rawValue
             )
         }
         
-        sharedUserDefaultsCache.commitChanges()
+        userDefaultsCache.commitChanges()
     }
 
     func getLastPrompted() -> Date? {
        
-        guard let lastPrompted = sharedUserDefaultsCache.getValue(key: Key.lastPrompted.rawValue) as? String else {
+        guard let lastPrompted = userDefaultsCache.getValue(key: Key.lastPrompted.rawValue) as? String else {
             return nil
         }
 
@@ -60,7 +60,7 @@ class OptInNotificationUserDefaultsCache {
 
     func getPromptCount() -> Int {
         
-        guard let promptCount = sharedUserDefaultsCache.getValue(key: Key.promptedCount.rawValue) as? Int else {
+        guard let promptCount = userDefaultsCache.getValue(key: Key.promptedCount.rawValue) as? Int else {
             return 0
         }
 
@@ -75,16 +75,16 @@ class OptInNotificationUserDefaultsCache {
         let todaysDate: Date = Date()
         let stringDate: String = Self.dateFormatter.string(from: todaysDate)
         
-        sharedUserDefaultsCache.cache(
+        userDefaultsCache.cache(
             value: stringDate,
             forKey: Key.lastPrompted.rawValue
         )
 
-        sharedUserDefaultsCache.cache(
+        userDefaultsCache.cache(
             value: updatedPromptCount,
             forKey: Key.promptedCount.rawValue
         )
 
-        sharedUserDefaultsCache.commitChanges()
+        userDefaultsCache.commitChanges()
     }
 }

--- a/godtools/App/Features/OptInNotification/DependencyContainer/OptInNotificationDataLayerDependencies.swift
+++ b/godtools/App/Features/OptInNotification/DependencyContainer/OptInNotificationDataLayerDependencies.swift
@@ -23,12 +23,11 @@ class OptInNotificationDataLayerDependencies {
 
     func getOptInNotificationRepository() -> OptInNotificationRepository {
         return OptInNotificationRepository(
-            cache: OptInNotificationUserDefaultsCache(sharedUserDefaultsCache:coreDataLayer.getSharedUserDefaultsCache()), remoteConfigRepository: coreDataLayer.getRemoteConfigRepository()
+            cache: OptInNotificationUserDefaultsCache(
+                userDefaultsCache:coreDataLayer.getUserDefaultsCache()
+            ),
+            remoteConfigRepository: coreDataLayer.getRemoteConfigRepository()
         )
-    }
-    
-    func getLaunchCountRepository() -> LaunchCountRepository {
-        return coreDataLayer.getSharedLaunchCountRepository()
     }
 
     // MARK: - Domain Interface

--- a/godtools/App/Features/Shareables/Data-DomainInterface/GetReviewShareShareableInterfaceStringsRepository.swift
+++ b/godtools/App/Features/Shareables/Data-DomainInterface/GetReviewShareShareableInterfaceStringsRepository.swift
@@ -12,9 +12,9 @@ import LocalizationServices
 
 class GetReviewShareShareableInterfaceStringsRepository: GetReviewShareShareableInterfaceStringsRepositoryInterface {
     
-    private let localizationServices: LocalizationServices
+    private let localizationServices: LocalizationServicesInterface
     
-    init(localizationServices: LocalizationServices) {
+    init(localizationServices: LocalizationServicesInterface) {
         
         self.localizationServices = localizationServices
     }

--- a/godtools/App/Features/ToolDetails/Data-DomainInterface/GetToolDetailsInterfaceStringsRepository.swift
+++ b/godtools/App/Features/ToolDetails/Data-DomainInterface/GetToolDetailsInterfaceStringsRepository.swift
@@ -12,9 +12,9 @@ import LocalizationServices
 
 class GetToolDetailsInterfaceStringsRepository: GetToolDetailsInterfaceStringsRepositoryInterface {
     
-    private let localizationServices: LocalizationServices
+    private let localizationServices: LocalizationServicesInterface
     
-    init(localizationServices: LocalizationServices) {
+    init(localizationServices: LocalizationServicesInterface) {
         
         self.localizationServices = localizationServices
     }

--- a/godtools/App/Features/ToolDetails/Data-DomainInterface/GetToolDetailsRepository.swift
+++ b/godtools/App/Features/ToolDetails/Data-DomainInterface/GetToolDetailsRepository.swift
@@ -15,11 +15,11 @@ class GetToolDetailsRepository: GetToolDetailsRepositoryInterface {
     private let resourcesRepository: ResourcesRepository
     private let languagesRepository: LanguagesRepository
     private let translationsRepository: TranslationsRepository
-    private let localizationServices: LocalizationServices
+    private let localizationServices: LocalizationServicesInterface
     private let getTranslatedLanguageName: GetTranslatedLanguageName
     private let favoritedResourcesRepository: FavoritedResourcesRepository
     
-    init(resourcesRepository: ResourcesRepository, languagesRepository: LanguagesRepository, translationsRepository: TranslationsRepository, localizationServices: LocalizationServices, getTranslatedLanguageName: GetTranslatedLanguageName, favoritedResourcesRepository: FavoritedResourcesRepository) {
+    init(resourcesRepository: ResourcesRepository, languagesRepository: LanguagesRepository, translationsRepository: TranslationsRepository, localizationServices: LocalizationServicesInterface, getTranslatedLanguageName: GetTranslatedLanguageName, favoritedResourcesRepository: FavoritedResourcesRepository) {
         
         self.resourcesRepository = resourcesRepository
         self.languagesRepository = languagesRepository

--- a/godtools/App/Features/ToolScreenShare/Data-DomainInterface/GetCreatingToolScreenShareSessionInterfaceStringsRepository.swift
+++ b/godtools/App/Features/ToolScreenShare/Data-DomainInterface/GetCreatingToolScreenShareSessionInterfaceStringsRepository.swift
@@ -12,9 +12,9 @@ import LocalizationServices
 
 class GetCreatingToolScreenShareSessionInterfaceStringsRepository: GetCreatingToolScreenShareSessionInterfaceStringsRepositoryInterface {
     
-    private let localizationServices: LocalizationServices
+    private let localizationServices: LocalizationServicesInterface
     
-    init(localizationServices: LocalizationServices) {
+    init(localizationServices: LocalizationServicesInterface) {
         
         self.localizationServices = localizationServices
     }

--- a/godtools/App/Features/ToolScreenShare/Data-DomainInterface/GetCreatingToolScreenShareSessionTimedOutInterfaceStringsRepository.swift
+++ b/godtools/App/Features/ToolScreenShare/Data-DomainInterface/GetCreatingToolScreenShareSessionTimedOutInterfaceStringsRepository.swift
@@ -12,9 +12,9 @@ import LocalizationServices
 
 class GetCreatingToolScreenShareSessionTimedOutInterfaceStringsRepository: GetCreatingToolScreenShareSessionTimedOutInterfaceStringsRepositoryInterface {
     
-    private let localizationServices: LocalizationServices
+    private let localizationServices: LocalizationServicesInterface
     
-    init(localizationServices: LocalizationServices) {
+    init(localizationServices: LocalizationServicesInterface) {
         
         self.localizationServices = localizationServices
     }

--- a/godtools/App/Features/ToolScreenShare/Data-DomainInterface/GetShareToolScreenShareSessionInterfaceStringsRepository.swift
+++ b/godtools/App/Features/ToolScreenShare/Data-DomainInterface/GetShareToolScreenShareSessionInterfaceStringsRepository.swift
@@ -12,9 +12,9 @@ import LocalizationServices
 
 class GetShareToolScreenShareSessionInterfaceStringsRepository: GetShareToolScreenShareSessionInterfaceStringsRepositoryInterface {
     
-    private let localizationServices: LocalizationServices
+    private let localizationServices: LocalizationServicesInterface
     
-    init(localizationServices: LocalizationServices) {
+    init(localizationServices: LocalizationServicesInterface) {
         
         self.localizationServices = localizationServices
     }

--- a/godtools/App/Features/ToolScreenShare/Data-DomainInterface/GetToolScreenShareTutorialInterfaceStringsRepository.swift
+++ b/godtools/App/Features/ToolScreenShare/Data-DomainInterface/GetToolScreenShareTutorialInterfaceStringsRepository.swift
@@ -12,9 +12,9 @@ import LocalizationServices
 
 class GetToolScreenShareTutorialInterfaceStringsRepository: GetToolScreenShareTutorialInterfaceStringsRepositoryInterface {
     
-    private let localizationServices: LocalizationServices
+    private let localizationServices: LocalizationServicesInterface
         
-    init(localizationServices: LocalizationServices) {
+    init(localizationServices: LocalizationServicesInterface) {
         
         self.localizationServices = localizationServices
     }

--- a/godtools/App/Features/ToolScreenShare/Data-DomainInterface/GetToolScreenShareTutorialRepository.swift
+++ b/godtools/App/Features/ToolScreenShare/Data-DomainInterface/GetToolScreenShareTutorialRepository.swift
@@ -12,9 +12,9 @@ import LocalizationServices
 
 class GetToolScreenShareTutorialRepository: GetToolScreenShareTutorialRepositoryInterface {
     
-    private let localizationServices: LocalizationServices
+    private let localizationServices: LocalizationServicesInterface
     
-    init(localizationServices: LocalizationServices) {
+    init(localizationServices: LocalizationServicesInterface) {
         
         self.localizationServices = localizationServices
     }

--- a/godtools/App/Features/ToolSettings/Data-DomainInterface/GetShareToolInterfaceStringsRepository.swift
+++ b/godtools/App/Features/ToolSettings/Data-DomainInterface/GetShareToolInterfaceStringsRepository.swift
@@ -14,9 +14,9 @@ class GetShareToolInterfaceStringsRepository: GetShareToolInterfaceStringsReposi
     
     private let resourcesRepository: ResourcesRepository
     private let languagesRepository: LanguagesRepository
-    private let localizationServices: LocalizationServices
+    private let localizationServices: LocalizationServicesInterface
     
-    init(resourcesRepository: ResourcesRepository, languagesRepository: LanguagesRepository, localizationServices: LocalizationServices) {
+    init(resourcesRepository: ResourcesRepository, languagesRepository: LanguagesRepository, localizationServices: LocalizationServicesInterface) {
         
         self.resourcesRepository = resourcesRepository
         self.languagesRepository = languagesRepository

--- a/godtools/App/Features/ToolSettings/Data-DomainInterface/GetToolSettingsInterfaceStringsRepository.swift
+++ b/godtools/App/Features/ToolSettings/Data-DomainInterface/GetToolSettingsInterfaceStringsRepository.swift
@@ -12,9 +12,9 @@ import LocalizationServices
 
 class GetToolSettingsInterfaceStringsRepository: GetToolSettingsInterfaceStringsRepositoryInterface {
     
-    private let localizationServices: LocalizationServices
+    private let localizationServices: LocalizationServicesInterface
     
-    init(localizationServices: LocalizationServices) {
+    init(localizationServices: LocalizationServicesInterface) {
         
         self.localizationServices = localizationServices
     }

--- a/godtools/App/Features/ToolSettings/Data-DomainInterface/GetToolSettingsToolLanguagesListInterfaceStringsRepository.swift
+++ b/godtools/App/Features/ToolSettings/Data-DomainInterface/GetToolSettingsToolLanguagesListInterfaceStringsRepository.swift
@@ -12,9 +12,9 @@ import LocalizationServices
 
 class GetToolSettingsToolLanguagesListInterfaceStringsRepository: GetToolSettingsToolLanguagesListInterfaceStringsRepositoryInterface {
     
-    private let localizationServices: LocalizationServices
+    private let localizationServices: LocalizationServicesInterface
     
-    init(localizationServices: LocalizationServices) {
+    init(localizationServices: LocalizationServicesInterface) {
         
         self.localizationServices = localizationServices
     }

--- a/godtools/App/Features/ToolTraining/Presentation/ToolTrainingViewModel.swift
+++ b/godtools/App/Features/ToolTraining/Presentation/ToolTrainingViewModel.swift
@@ -20,7 +20,7 @@ class ToolTrainingViewModel: NSObject {
     private let setCompletedTrainingTipUseCase: SetCompletedTrainingTipUseCase
     private let getTrainingTipCompletedUseCase: GetTrainingTipCompletedUseCase
     private let trackScreenViewAnalyticsUseCase: TrackScreenViewAnalyticsUseCase
-    private let localizationServices: LocalizationServices
+    private let localizationServices: LocalizationServicesInterface
     private let closeTappedClosure: (() -> Void)
     
     private var page: Int = 0
@@ -33,7 +33,7 @@ class ToolTrainingViewModel: NSObject {
     let continueButtonTitle: ObservableValue<String> = ObservableValue(value: "")
     let numberOfTipPages: ObservableValue<Int> = ObservableValue(value: 0)
     
-    init(pageRenderer: MobileContentPageRenderer, renderedPageContext: MobileContentRenderedPageContext, trainingTipId: String, tipModel: Tip, setCompletedTrainingTipUseCase: SetCompletedTrainingTipUseCase, getTrainingTipCompletedUseCase: GetTrainingTipCompletedUseCase, trackScreenViewAnalyticsUseCase: TrackScreenViewAnalyticsUseCase, localizationServices: LocalizationServices, closeTappedClosure: @escaping (() -> Void)) {
+    init(pageRenderer: MobileContentPageRenderer, renderedPageContext: MobileContentRenderedPageContext, trainingTipId: String, tipModel: Tip, setCompletedTrainingTipUseCase: SetCompletedTrainingTipUseCase, getTrainingTipCompletedUseCase: GetTrainingTipCompletedUseCase, trackScreenViewAnalyticsUseCase: TrackScreenViewAnalyticsUseCase, localizationServices: LocalizationServicesInterface, closeTappedClosure: @escaping (() -> Void)) {
         
         self.renderedPageContext = renderedPageContext
         self.pageRenderer = pageRenderer

--- a/godtools/App/Features/ToolsFilter/Data-DomainInterface/GetToolFilterCategoriesInterfaceStringsRepository.swift
+++ b/godtools/App/Features/ToolsFilter/Data-DomainInterface/GetToolFilterCategoriesInterfaceStringsRepository.swift
@@ -12,9 +12,9 @@ import LocalizationServices
 
 class GetToolFilterCategoriesInterfaceStringsRepository: GetToolFilterCategoriesInterfaceStringsRepositoryInterface {
     
-    private let localizationServices: LocalizationServices
+    private let localizationServices: LocalizationServicesInterface
     
-    init(localizationServices: LocalizationServices) {
+    init(localizationServices: LocalizationServicesInterface) {
         self.localizationServices = localizationServices
     }
     

--- a/godtools/App/Features/ToolsFilter/Data-DomainInterface/GetToolFilterLanguagesInterfaceStringsRepository.swift
+++ b/godtools/App/Features/ToolsFilter/Data-DomainInterface/GetToolFilterLanguagesInterfaceStringsRepository.swift
@@ -12,9 +12,9 @@ import LocalizationServices
 
 class GetToolFilterLanguagesInterfaceStringsRepository: GetToolFilterLanguagesInterfaceStringsRepositoryInterface {
     
-    private let localizationServices: LocalizationServices
+    private let localizationServices: LocalizationServicesInterface
     
-    init(localizationServices: LocalizationServices) {
+    init(localizationServices: LocalizationServicesInterface) {
         self.localizationServices = localizationServices
     }
     

--- a/godtools/App/Features/Tutorial/Data-DomainInterface/GetTutorialInterfaceStringsRepository.swift
+++ b/godtools/App/Features/Tutorial/Data-DomainInterface/GetTutorialInterfaceStringsRepository.swift
@@ -12,9 +12,9 @@ import LocalizationServices
 
 class GetTutorialInterfaceStringsRepository: GetTutorialInterfaceStringsRepositoryInterface {
     
-    private let localizationServices: LocalizationServices
+    private let localizationServices: LocalizationServicesInterface
     
-    init(localizationServices: LocalizationServices) {
+    init(localizationServices: LocalizationServicesInterface) {
         
         self.localizationServices = localizationServices
     }

--- a/godtools/App/Features/Tutorial/Data-DomainInterface/GetTutorialRepository.swift
+++ b/godtools/App/Features/Tutorial/Data-DomainInterface/GetTutorialRepository.swift
@@ -12,9 +12,9 @@ import LocalizationServices
 
 class GetTutorialRepository: GetTutorialRepositoryInterface {
     
-    private let localizationServices: LocalizationServices
+    private let localizationServices: LocalizationServicesInterface
     
-    init(localizationServices: LocalizationServices) {
+    init(localizationServices: LocalizationServicesInterface) {
         
         self.localizationServices = localizationServices
     }

--- a/godtools/App/Features/UserLessonProgress/Data-DomainInterface/GetLessonListItemProgressRepository.swift
+++ b/godtools/App/Features/UserLessonProgress/Data-DomainInterface/GetLessonListItemProgressRepository.swift
@@ -15,10 +15,10 @@ class GetLessonListItemProgressRepository {
     
     private let lessonProgressRepository: UserLessonProgressRepository
     private let userCountersRepository: UserCountersRepository
-    private let localizationServices: LocalizationServices
+    private let localizationServices: LocalizationServicesInterface
     private let getTranslatedPercentage: GetTranslatedPercentage
     
-    init(lessonProgressRepository: UserLessonProgressRepository, userCountersRepository: UserCountersRepository, localizationServices: LocalizationServices, getTranslatedPercentage: GetTranslatedPercentage) {
+    init(lessonProgressRepository: UserLessonProgressRepository, userCountersRepository: UserCountersRepository, localizationServices: LocalizationServicesInterface, getTranslatedPercentage: GetTranslatedPercentage) {
         self.lessonProgressRepository = lessonProgressRepository
         self.userCountersRepository = userCountersRepository
         self.localizationServices = localizationServices

--- a/godtools/App/Features/UserLessonProgress/Data-DomainInterface/GetResumeLessonProgressModalInterfaceStringsRepository.swift
+++ b/godtools/App/Features/UserLessonProgress/Data-DomainInterface/GetResumeLessonProgressModalInterfaceStringsRepository.swift
@@ -12,9 +12,9 @@ import LocalizationServices
 
 class GetResumeLessonProgressModalInterfaceStringsRepository: GetResumeLessonProgressModalInterfaceStringsRepositoryInterface {
     
-    private let localizationServices: LocalizationServices
+    private let localizationServices: LocalizationServicesInterface
     
-    init(localizationServices: LocalizationServices) {
+    init(localizationServices: LocalizationServicesInterface) {
         self.localizationServices = localizationServices
     }
     

--- a/godtools/App/Flows/ArticleDeepLink/ArticleDeepLinkFlow.swift
+++ b/godtools/App/Flows/ArticleDeepLink/ArticleDeepLinkFlow.swift
@@ -67,7 +67,7 @@ class ArticleDeepLinkFlow: Flow {
             
         case .didFailToDownloadArticleFromLoadingArticle(let alertMessage):
             
-            let localizationServices: LocalizationServices = appDiContainer.dataLayer.getLocalizationServices()
+            let localizationServices: LocalizationServicesInterface = appDiContainer.dataLayer.getLocalizationServices()
             let appLanguage: AppLanguageDomainModel = self.appLanguage
             
             navigationController.dismiss(animated: true) { [weak self] in

--- a/godtools/App/Flows/Flow+PresentAlert/Flow+PresentAlert.swift
+++ b/godtools/App/Flows/Flow+PresentAlert/Flow+PresentAlert.swift
@@ -18,7 +18,7 @@ extension Flow {
     
     func presentAlert(appLanguage: AppLanguageDomainModel, title: String, message: String) {
         
-        let localizationServices: LocalizationServices = appDiContainer.dataLayer.getLocalizationServices()
+        let localizationServices: LocalizationServicesInterface = appDiContainer.dataLayer.getLocalizationServices()
                 
         let viewModel = AlertMessageViewModel(
             title: title,

--- a/godtools/App/Flows/Flow+PresentError/Flow+PresentError.swift
+++ b/godtools/App/Flows/Flow+PresentError/Flow+PresentError.swift
@@ -19,7 +19,7 @@ extension Flow {
             return
         }
 
-        let localizationServices: LocalizationServices = appDiContainer.dataLayer.getLocalizationServices()
+        let localizationServices: LocalizationServicesInterface = appDiContainer.dataLayer.getLocalizationServices()
         
         let title: String
         let message: String

--- a/godtools/App/Flows/Menu/MenuFlow.swift
+++ b/godtools/App/Flows/Menu/MenuFlow.swift
@@ -253,7 +253,7 @@ class MenuFlow: Flow {
 
         case .didFinishAccountDeletionWithSuccessFromDeleteAccountProgress:
             
-            let localizationServices: LocalizationServices = appDiContainer.dataLayer.getLocalizationServices()
+            let localizationServices: LocalizationServicesInterface = appDiContainer.dataLayer.getLocalizationServices()
             let appLanguage: AppLanguageDomainModel = self.appLanguage
             
             navigationController.dismissPresented(animated: true) {
@@ -491,7 +491,7 @@ extension MenuFlow {
     
     private func getAuthErrorAlertMessage(authError: AuthErrorDomainModel) -> AlertMessageType {
         
-        let localizationServices: LocalizationServices = appDiContainer.dataLayer.getLocalizationServices()
+        let localizationServices: LocalizationServicesInterface = appDiContainer.dataLayer.getLocalizationServices()
         let appLanguageLocaleId = appLanguage.localeId
         
         let message: String
@@ -603,7 +603,7 @@ extension MenuFlow {
     
     private func getConfirmDeleteAccountView() -> UIViewController {
         
-        let localizationServices: LocalizationServices = appDiContainer.dataLayer.getLocalizationServices()
+        let localizationServices: LocalizationServicesInterface = appDiContainer.dataLayer.getLocalizationServices()
         
         let viewController = UIAlertController(
             title: localizationServices.stringForLocaleElseEnglish(localeIdentifier: appLanguage, key: LocalizableStringKeys.confirmDeleteAccountTitle.key),

--- a/godtools/App/Flows/Tract/TractFlow.swift
+++ b/godtools/App/Flows/Tract/TractFlow.swift
@@ -72,7 +72,7 @@ class TractFlow: ToolNavigationFlow, ToolSettingsNavigationFlow {
             
             if isScreenSharing {
                 
-                let localizationServices: LocalizationServices = appDiContainer.dataLayer.getLocalizationServices()
+                let localizationServices: LocalizationServicesInterface = appDiContainer.dataLayer.getLocalizationServices()
                                 
                 let viewModel = AlertMessageViewModel(
                     title: nil,

--- a/godtools/App/Services/CardJumpService/CardJumpUserDefaultsCache.swift
+++ b/godtools/App/Services/CardJumpService/CardJumpUserDefaultsCache.swift
@@ -10,11 +10,11 @@ import Foundation
 
 class CardJumpUserDefaultsCache {
     
-    private let sharedUserDefaultsCache: SharedUserDefaultsCache
+    private let userDefaultsCache: UserDefaultsCacheInterface
     
-    init(sharedUserDefaultsCache: SharedUserDefaultsCache) {
+    init(userDefaultsCache: UserDefaultsCacheInterface) {
         
-        self.sharedUserDefaultsCache = sharedUserDefaultsCache
+        self.userDefaultsCache = userDefaultsCache
     }
     
     private var didShowCardJumpKey: String {
@@ -22,14 +22,14 @@ class CardJumpUserDefaultsCache {
     }
     
     var didShowCardJump: Bool {
-        if let value = sharedUserDefaultsCache.getValue(key: didShowCardJumpKey) as? Bool {
+        if let value = userDefaultsCache.getValue(key: didShowCardJumpKey) as? Bool {
             return value
         }
         return false
     }
     
     func cacheDidShowCardJump() {
-        sharedUserDefaultsCache.cache(value: true, forKey: didShowCardJumpKey)
-        sharedUserDefaultsCache.commitChanges()
+        userDefaultsCache.cache(value: true, forKey: didShowCardJumpKey)
+        userDefaultsCache.commitChanges()
     }
 }

--- a/godtools/App/Services/Renderer/Renderer/MobileContentRendererPageViewFactories.swift
+++ b/godtools/App/Services/Renderer/Renderer/MobileContentRendererPageViewFactories.swift
@@ -20,7 +20,7 @@ class MobileContentRendererPageViewFactories: MobileContentPageViewFactoryType {
         
         let trackScreenViewAnalyticsUseCase: TrackScreenViewAnalyticsUseCase = appDiContainer.domainLayer.getTrackScreenViewAnalyticsUseCase()
         let mobileContentAnalytics: MobileContentRendererAnalytics = appDiContainer.getMobileContentRendererAnalytics()
-        let localizationServices: LocalizationServices = appDiContainer.dataLayer.getLocalizationServices()
+        let localizationServices: LocalizationServicesInterface = appDiContainer.dataLayer.getLocalizationServices()
         let followUpsService: FollowUpsService = appDiContainer.dataLayer.getFollowUpsService()
         let cardJumpService: CardJumpService = appDiContainer.getCardJumpService()
         

--- a/godtools/App/Services/Renderer/Views/MobileContent/Views/Error/MobileContentErrorViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/MobileContent/Views/Error/MobileContentErrorViewModel.swift
@@ -15,7 +15,7 @@ class MobileContentErrorViewModel {
     let message: String
     let acceptTitle: String
     
-    init(appLanguage: AppLanguageDomainModel, title: String, message: String, localizationServices: LocalizationServices) {
+    init(appLanguage: AppLanguageDomainModel, title: String, message: String, localizationServices: LocalizationServicesInterface) {
         
         self.title = title
         self.message = message

--- a/godtools/App/Services/Renderer/Views/Tract/ViewFactory/TractPageViewFactory.swift
+++ b/godtools/App/Services/Renderer/Views/Tract/ViewFactory/TractPageViewFactory.swift
@@ -14,11 +14,11 @@ class TractPageViewFactory: MobileContentPageViewFactoryType {
         
     private let trackScreenViewAnalyticsUseCase: TrackScreenViewAnalyticsUseCase
     private let mobileContentAnalytics: MobileContentRendererAnalytics
-    private let localizationServices: LocalizationServices
+    private let localizationServices: LocalizationServicesInterface
     private let cardJumpService: CardJumpService
     private let followUpService: FollowUpsService
         
-    init(trackScreenViewAnalyticsUseCase: TrackScreenViewAnalyticsUseCase, mobileContentAnalytics: MobileContentRendererAnalytics, localizationServices: LocalizationServices, cardJumpService: CardJumpService, followUpService: FollowUpsService) {
+    init(trackScreenViewAnalyticsUseCase: TrackScreenViewAnalyticsUseCase, mobileContentAnalytics: MobileContentRendererAnalytics, localizationServices: LocalizationServicesInterface, cardJumpService: CardJumpService, followUpService: FollowUpsService) {
         
         self.trackScreenViewAnalyticsUseCase = trackScreenViewAnalyticsUseCase
         self.mobileContentAnalytics = mobileContentAnalytics

--- a/godtools/App/Services/Renderer/Views/Tract/Views/Card/TractPageCardViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/Tract/Views/Card/TractPageCardViewModel.swift
@@ -14,7 +14,7 @@ class TractPageCardViewModel: MobileContentViewModel {
     
     private let cardModel: TractPage.Card
     private let trackScreenViewAnalyticsUseCase: TrackScreenViewAnalyticsUseCase
-    private let localizationServices: LocalizationServices
+    private let localizationServices: LocalizationServicesInterface
     private let trainingTipsEnabled: Bool
     private let visibleAnalyticsEventsObjects: [MobileContentRendererAnalyticsEvent]
     private let numberOfVisbleCards: Int
@@ -25,7 +25,7 @@ class TractPageCardViewModel: MobileContentViewModel {
     let hidesNextButton: Bool
     let isHiddenCard: Bool
     
-    init(cardModel: TractPage.Card, renderedPageContext: MobileContentRenderedPageContext, trackScreenViewAnalyticsUseCase: TrackScreenViewAnalyticsUseCase, mobileContentAnalytics: MobileContentRendererAnalytics, localizationServices: LocalizationServices, numberOfVisbleCards: Int, trainingTipsEnabled: Bool) {
+    init(cardModel: TractPage.Card, renderedPageContext: MobileContentRenderedPageContext, trackScreenViewAnalyticsUseCase: TrackScreenViewAnalyticsUseCase, mobileContentAnalytics: MobileContentRendererAnalytics, localizationServices: LocalizationServicesInterface, numberOfVisbleCards: Int, trainingTipsEnabled: Bool) {
                         
         self.cardModel = cardModel
         self.trackScreenViewAnalyticsUseCase = trackScreenViewAnalyticsUseCase
@@ -89,10 +89,10 @@ class TractPageCardViewModel: MobileContentViewModel {
     
     private func getTranslatedStringFromToolLanguageElseAppLanguage(localizedKey: String) -> String {
         
-        if let languageTranslation = localizationServices.stringsRepository.stringForLocale(localeIdentifier: renderedPageContext.language.localeId, key: localizedKey) {
+        if let languageTranslation = localizationServices.stringForLocale(localeIdentifier: renderedPageContext.language.localeId, key: localizedKey) {
             return languageTranslation
         }
-        else if let appLanguageTranslation = localizationServices.stringsRepository.stringForLocale(localeIdentifier: renderedPageContext.appLanguage, key: localizedKey) {
+        else if let appLanguageTranslation = localizationServices.stringForLocale(localeIdentifier: renderedPageContext.appLanguage, key: localizedKey) {
             return appLanguageTranslation
         }
         

--- a/godtools/App/Services/Renderer/Views/Tract/Views/Form/TractPageFormViewModel.swift
+++ b/godtools/App/Services/Renderer/Views/Tract/Views/Form/TractPageFormViewModel.swift
@@ -16,12 +16,12 @@ class TractPageFormViewModel: MobileContentFormViewModel {
     private static var backgroundCancellables: Set<AnyCancellable> = Set()
     
     private let followUpService: FollowUpsService
-    private let localizationServices: LocalizationServices
+    private let localizationServices: LocalizationServicesInterface
     
     let didSendFollowUpSignal: SignalValue<[EventId]> = SignalValue()
     let error: ObservableValue<MobileContentErrorViewModel?> = ObservableValue(value: nil)
     
-    init(formModel: Form, renderedPageContext: MobileContentRenderedPageContext, mobileContentAnalytics: MobileContentRendererAnalytics, followUpService: FollowUpsService, localizationServices: LocalizationServices) {
+    init(formModel: Form, renderedPageContext: MobileContentRenderedPageContext, mobileContentAnalytics: MobileContentRendererAnalytics, followUpService: FollowUpsService, localizationServices: LocalizationServicesInterface) {
         
         self.followUpService = followUpService
         self.localizationServices = localizationServices

--- a/godtools/App/Share/Common/SharedUserDefaultsCache/SharedUserDefaultsCache.swift
+++ b/godtools/App/Share/Common/SharedUserDefaultsCache/SharedUserDefaultsCache.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-class SharedUserDefaultsCache {
+class SharedUserDefaultsCache: UserDefaultsCacheInterface {
     
     private let userDefaults: UserDefaults = UserDefaults.standard
     

--- a/godtools/App/Share/Common/SharedUserDefaultsCache/UserDefaultsCacheInterface.swift
+++ b/godtools/App/Share/Common/SharedUserDefaultsCache/UserDefaultsCacheInterface.swift
@@ -1,0 +1,17 @@
+//
+//  UserDefaultsCacheInterface.swift
+//  godtools
+//
+//  Created by Levi Eggert on 8/20/25.
+//  Copyright © 2025 Cru. All rights reserved.
+//
+
+import Foundation
+
+protocol UserDefaultsCacheInterface {
+    
+    func deleteValue(key: String)
+    func getValue(key: String) -> Any?
+    func cache(value: Any?, forKey: String)
+    func commitChanges()
+}

--- a/godtools/App/Share/Common/SyncInvalidator/SyncInvalidator.swift
+++ b/godtools/App/Share/Common/SyncInvalidator/SyncInvalidator.swift
@@ -12,9 +12,9 @@ class SyncInvalidator {
     
     private let id: String
     private let timeInterval: SyncInvalidatorTimeInterval
-    private let userDefaultsCache: SharedUserDefaultsCache
+    private let userDefaultsCache: UserDefaultsCacheInterface
     
-    init(id: String, timeInterval: SyncInvalidatorTimeInterval, userDefaultsCache: SharedUserDefaultsCache) {
+    init(id: String, timeInterval: SyncInvalidatorTimeInterval, userDefaultsCache: UserDefaultsCacheInterface) {
         
         self.id = id
         self.timeInterval = timeInterval

--- a/godtools/App/Share/Data/ArticlesRepository/Categories/ArticleManifestAemRepository.swift
+++ b/godtools/App/Share/Data/ArticlesRepository/Categories/ArticleManifestAemRepository.swift
@@ -14,12 +14,12 @@ import RequestOperation
 class ArticleManifestAemRepository: ArticleAemRepository {
     
     private let categoryArticlesCache: RealmCategoryArticlesCache
-    private let sharedUserDefaultsCache: SharedUserDefaultsCache
+    private let userDefaultsCache: UserDefaultsCacheInterface
         
-    init(downloader: ArticleAemDownloader, cache: ArticleAemCache, categoryArticlesCache: RealmCategoryArticlesCache, sharedUserDefaultsCache: SharedUserDefaultsCache) {
+    init(downloader: ArticleAemDownloader, cache: ArticleAemCache, categoryArticlesCache: RealmCategoryArticlesCache, userDefaultsCache: UserDefaultsCacheInterface) {
         
         self.categoryArticlesCache = categoryArticlesCache
-        self.sharedUserDefaultsCache = sharedUserDefaultsCache
+        self.userDefaultsCache = userDefaultsCache
         
         super.init(downloader: downloader, cache: cache)
     }
@@ -45,7 +45,7 @@ class ArticleManifestAemRepository: ArticleAemRepository {
         let syncInvalidator = SyncInvalidator(
             id: getSyncInvalidatorId(translationId: translationId),
             timeInterval: .days(day: 5),
-            userDefaultsCache: sharedUserDefaultsCache
+            userDefaultsCache: userDefaultsCache
         )
                 
         guard syncInvalidator.shouldSync || forceFetchFromRemote else {

--- a/godtools/App/Share/Data/ResourcesRepository/ResourcesRepository.swift
+++ b/godtools/App/Share/Data/ResourcesRepository/ResourcesRepository.swift
@@ -18,15 +18,15 @@ class ResourcesRepository {
     private let cache: RealmResourcesCache
     private let attachmentsRepository: AttachmentsRepository
     private let languagesRepository: LanguagesRepository
-    private let sharedUserDefaultsCache: SharedUserDefaultsCache
+    private let userDefaultsCache: UserDefaultsCacheInterface
     
-    init(api: MobileContentResourcesApi, cache: RealmResourcesCache, attachmentsRepository: AttachmentsRepository, languagesRepository: LanguagesRepository, sharedUserDefaultsCache: SharedUserDefaultsCache) {
+    init(api: MobileContentResourcesApi, cache: RealmResourcesCache, attachmentsRepository: AttachmentsRepository, languagesRepository: LanguagesRepository, userDefaultsCache: UserDefaultsCacheInterface) {
         
         self.api = api
         self.cache = cache
         self.attachmentsRepository = attachmentsRepository
         self.languagesRepository = languagesRepository
-        self.sharedUserDefaultsCache = sharedUserDefaultsCache
+        self.userDefaultsCache = userDefaultsCache
     }
     
     var numberOfResources: Int {
@@ -182,7 +182,7 @@ class ResourcesRepository {
         let syncInvalidator = SyncInvalidator(
             id: Self.syncInvalidatorIdForResourcesPlustLatestTranslationsAndAttachments,
             timeInterval: .hours(hour: 8),
-            userDefaultsCache: sharedUserDefaultsCache
+            userDefaultsCache: userDefaultsCache
         )
         
         let shouldFetchFromRemote: Bool = forceFetchFromRemote || syncInvalidator.shouldSync

--- a/godtoolsTests/UnitTests/App/Features/OptInNotification/Data/Cache/OptInNotificationsUserDefaultsCacheTests.swift
+++ b/godtoolsTests/UnitTests/App/Features/OptInNotification/Data/Cache/OptInNotificationsUserDefaultsCacheTests.swift
@@ -12,7 +12,7 @@ import XCTest
 
 class OptInNotificationUserDefaultsCacheTests: XCTestCase {
     
-    private let cache: OptInNotificationUserDefaultsCache = OptInNotificationUserDefaultsCache(sharedUserDefaultsCache: SharedUserDefaultsCache())
+    private let cache: OptInNotificationUserDefaultsCache = OptInNotificationUserDefaultsCache(userDefaultsCache: SharedUserDefaultsCache())
     
     override func setUp() {
         // Put setup code here. This method is called before the invocation of each test method in the class.


### PR DESCRIPTION
This PR begins some of the ground work for mocking the data layer.  The goal is to mock the data layer when UI tests are run. 

PR Changes:
- Creates interface for the app's core data layer dependencies.
- Adds interfaces LocalizationServicesInterface, UserDefaultsCacheInterface, LaunchCountRepositoryInterface.
- Pointing to interfaces LocalizationServicesInterface, UserDefaultsCacheInterface, LaunchCountRepositoryInterface.