### PR TITLE
GT-2675 gt modal view present and dismiss timing

### DIFF
--- a/godtools/App/Flows/ToolScreenShare/ToolScreenShareFlow.swift
+++ b/godtools/App/Flows/ToolScreenShare/ToolScreenShareFlow.swift
@@ -457,12 +457,14 @@ extension ToolScreenShareFlow {
         
         let hostingView = AppHostingController<ToolScreenShareQRCodeView>(
             rootView: view,
-            navigationBar: nil
+            navigationBar: nil,
+            animateInAnimatedTransitioning: NoAnimationTransition(transition: .transitionIn),
+            animateOutAnimatedTransitioning: NoAnimationTransition(transition: .transitionOut)
         )
-        
-        hostingView.view.backgroundColor = .clear
-        hostingView.modalPresentationStyle = .overFullScreen
 
+        hostingView.view.backgroundColor = .clear
+        hostingView.modalPresentationStyle = .overCurrentContext
+        
         return hostingView
     }
 }

--- a/godtools/App/Share/SwiftUI Views/GTModalView/GTModalView.swift
+++ b/godtools/App/Share/SwiftUI Views/GTModalView/GTModalView.swift
@@ -18,10 +18,12 @@ struct GTModalView<Content: View>: View {
     private let strokeColor: Color
     private let strokeLineWidth: CGFloat
     private let contentAnimationDuration: TimeInterval = 0.3
+    // NOTE: I noticed the content height would frequently change between what appeared to be the correct calculated height and then a smaller height. This flag will only ever set the contentHeight to the maximum calculated height ignoring the smaller calculated height. ~Levi
+    private let shouldLockContentHeightToMaxCalculatedHeight: Bool = true
     
     @State private var overlayOpacity: CGFloat = 0
     @State private var contentBottomOffsetY: CGFloat = 1000
-    @State private var contentHeight: CGFloat = 100
+    @State private var contentHeight: CGFloat = 0
     
     @Binding private var isHidden: Bool
     
@@ -67,7 +69,10 @@ struct GTModalView<Content: View>: View {
                                         
                                         let clampedContentHeight: CGFloat
                                         
-                                        if newContentHeight < minimumHeight {
+                                        if shouldLockContentHeightToMaxCalculatedHeight && newContentHeight < currentContentHeight {
+                                            clampedContentHeight = currentContentHeight
+                                        }
+                                        else if newContentHeight < minimumHeight {
                                             clampedContentHeight = minimumHeight
                                         }
                                         else if newContentHeight > maximumHeight {
@@ -77,10 +82,12 @@ struct GTModalView<Content: View>: View {
                                             clampedContentHeight = newContentHeight
                                         }
                                         
-                                        if currentContentHeight != clampedContentHeight {
+                                        let contentHeightDidChange: Bool = currentContentHeight != clampedContentHeight
+                                        
+                                        if contentHeightDidChange {
                                             
                                             contentHeight = clampedContentHeight
-                                            
+                                                                                        
                                             if isHidden {
                                                 contentBottomOffsetY = contentHeight
                                             }


### PR DESCRIPTION
The GTModalView will calculate it's content height which is used to set the offset of the modal view when animating on and off screen.

I noticed the content height calculation would fluctuate between the actual height and a smaller value.  This change adds a flag to lock the content height calculation to the maximum height calculated to prevent the fluctuation. Kind of hacky, but the quickest solution I can think of for now unless I can find a better way to animate the modal view off and on screen without the height calculation. 