### PR TITLE
GT-2727 Add method to get the current launch count

### DIFF
--- a/godtools/App/Flows/App/AppFlow.swift
+++ b/godtools/App/Flows/App/AppFlow.swift
@@ -16,6 +16,7 @@ class AppFlow: NSObject, Flow {
     private let deepLinkingService: DeepLinkingService
     private let appMessaging: AppMessagingInterface
     private let appLaunchObserver: AppLaunchObserver = AppLaunchObserver()
+    private let launchCountRepository: LaunchCountRepositoryInterface
     private let dashboardFlow: DashboardFlow
     private let rootController: AppRootController = AppRootController(nibName: nil, bundle: nil)
     
@@ -49,6 +50,7 @@ class AppFlow: NSObject, Flow {
         self.rootView = AppRootView(appRootController: rootController)
         self.deepLinkingService = appDeepLinkingService
         self.appMessaging = appDiContainer.dataLayer.getAppMessaging()
+        self.launchCountRepository = appDiContainer.dataLayer.getLaunchCountRepository()
         self.dashboardFlow = DashboardFlow(appDiContainer: appDiContainer, sharedNavigationController: navigationController, rootController: rootController)
         
         super.init()
@@ -134,6 +136,8 @@ class AppFlow: NSObject, Flow {
                     }
                     
                     appFlow.cancellableForAppLaunchedFromTerminatedStateOptions = nil
+                    
+                    let launchCount: Int = appFlow.launchCountRepository.getLaunchCount()
                     
                     if let deepLink = appFlow.appLaunchedFromDeepLink {
                         

--- a/godtools/App/Share/Data/LaunchCountRepository/LaunchCountRepository.swift
+++ b/godtools/App/Share/Data/LaunchCountRepository/LaunchCountRepository.swift
@@ -42,6 +42,13 @@ class LaunchCountRepository: LaunchCountRepositoryInterface {
         cache.storeLaunchCount(launchCount: newLaunchCount)
     }
     
+    func getLaunchCount() -> Int {
+        
+        incrementLaunchCountForAppLaunchIfNeeded()
+        
+        return cache.getLaunchCountValue()
+    }
+    
     func getLaunchCountPublisher() -> AnyPublisher<Int, Never> {
         
         incrementLaunchCountForAppLaunchIfNeeded()

--- a/godtools/App/Share/Data/LaunchCountRepository/LaunchCountRepositoryInterface.swift
+++ b/godtools/App/Share/Data/LaunchCountRepository/LaunchCountRepositoryInterface.swift
@@ -11,5 +11,6 @@ import Combine
 
 protocol LaunchCountRepositoryInterface {
     
+    func getLaunchCount() -> Int
     func getLaunchCountPublisher() -> AnyPublisher<Int, Never>
 }

--- a/godtools/Mock/App/Share/Data/LaunchCountRepository/MockLaunchCountRepository.swift
+++ b/godtools/Mock/App/Share/Data/LaunchCountRepository/MockLaunchCountRepository.swift
@@ -18,6 +18,10 @@ class MockLaunchCountRepository: LaunchCountRepositoryInterface {
         self.launchCount = launchCount
     }
     
+    func getLaunchCount() -> Int {
+        return launchCount
+    }
+    
     func getLaunchCountPublisher() -> AnyPublisher<Int, Never> {
         
         return Just(launchCount)


### PR DESCRIPTION
Adding method to get the current launch count.  Will be needed for the dynalink deferred deep linking.