### PR TITLE
GT 6.3.12 remove liquid glass effect on nav bar button items

### DIFF
--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -15300,7 +15300,7 @@
 					"@executable_path/Frameworks",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
-				MARKETING_VERSION = 6.3.11;
+				MARKETING_VERSION = 6.3.12;
 				OTHER_SWIFT_FLAGS = "$(inherited) -D COCOAPODS -DDEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = org.cru.godtools;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -15502,7 +15502,7 @@
 					"@executable_path/Frameworks",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
-				MARKETING_VERSION = 6.3.11;
+				MARKETING_VERSION = 6.3.12;
 				OTHER_SWIFT_FLAGS = "$(inherited) -D COCOAPODS -DDEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = org.cru.godtools.beta;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -15703,7 +15703,7 @@
 					"@executable_path/Frameworks",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
-				MARKETING_VERSION = 6.3.11;
+				MARKETING_VERSION = 6.3.12;
 				OTHER_SWIFT_FLAGS = "$(inherited) -D COCOAPODS -DDEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = org.cru.godtools.beta;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -15904,7 +15904,7 @@
 					"@executable_path/Frameworks",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
-				MARKETING_VERSION = 6.3.11;
+				MARKETING_VERSION = 6.3.12;
 				OTHER_SWIFT_FLAGS = "$(inherited) -D COCOAPODS -DDEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = org.cru.godtools;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -16141,7 +16141,7 @@
 					"@executable_path/Frameworks",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
-				MARKETING_VERSION = 6.3.11;
+				MARKETING_VERSION = 6.3.12;
 				OTHER_SWIFT_FLAGS = "$(inherited) -D COCOAPODS -DRELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = org.cru.godtools;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/godtools/App/Share/Views/Navigation/NavigationBar/NavBarItems/NavBarItemData/NavBarItemData.swift
+++ b/godtools/App/Share/Views/Navigation/NavigationBar/NavBarItems/NavBarItemData/NavBarItemData.swift
@@ -56,6 +56,11 @@ class NavBarItemData {
             buttonItem.accessibilityIdentifier = accessibilityIdentifier
         }
         
+        if #available(iOS 26, *) {
+            // This disables the liquid glass effect on UINavigation Button Items. ~Levi
+            buttonItem.hidesSharedBackground = true
+        }
+        
         return buttonItem
     }
 }


### PR DESCRIPTION
Disables the liquid glass effect on the navigation bar button items.

https://developer.apple.com/documentation/uikit/uibarbuttonitem/hidessharedbackground

