### PR TITLE
GT Remove dependabot swift and use workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,11 +8,3 @@ updates:
   - levieggertcru
   assignees:
   - levieggertcru
-- package-ecosystem: swift
-  directory: "/"
-  schedule:
-    interval: daily
-  reviewers:
-  - levieggertcru
-  assignees:
-  - levieggertcru

--- a/.github/workflows/update-swift-package-dependencies.yml
+++ b/.github/workflows/update-swift-package-dependencies.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   update_xcode_project_swift_package_dependencies:
-    runs-on: macos-26
+    runs-on: macos-latest
 
     steps:
       - name: Checkout code
@@ -23,7 +23,7 @@ jobs:
         id: resolution
         uses: GetSidetrack/action-xcodeproj-spm-update@main
         with:
-          workspace: 'godtools.xcworkspace'
+          workspace: 'godtools.xcodeproj'
           scheme: 'GodTools-Production'
           forceResolution: true
           failWhenOutdated: false


### PR DESCRIPTION
Removing dependabot swift since that's for repositories with a Package.swift file.  Will use workflow for updating xcode project swift package dependencies. 