### PR TITLE
Fix JSON:API filter parameter names

### DIFF
--- a/godtools/App/Features/PersonalizedTools/Data/PersonalizedToolsRepository/Api/PersonalizedToolsApi.swift
+++ b/godtools/App/Features/PersonalizedTools/Data/PersonalizedToolsRepository/Api/PersonalizedToolsApi.swift
@@ -12,8 +12,8 @@ import RequestOperation
 final class PersonalizedToolsApi: PersonalizedToolsApiInterface {
     
     enum QueryName: String {
-        case country = "country"
-        case language = "lang"
+        case country = "filter[country]"
+        case language = "filter[lang]"
         case resourceType = "resource_type"
     }
         
@@ -38,7 +38,7 @@ final class PersonalizedToolsApi: PersonalizedToolsApiInterface {
             ]
         )
 
-        let resourceTypeQueryItems: [URLQueryItem] = buildResourceTypeQueryItems(resourceTypes: resourceTypes)
+        let QueryItems: [URLQueryItem] = buildQueryItems(s: s)
         queryItems?.append(contentsOf: resourceTypeQueryItems)
 
         return try requestBuilder


### PR DESCRIPTION
I don't believe you are using the `resource_type` parameter, but if you are that should be updated to `filter[resource-type]` after https://github.com/CruGlobal/mobile-content-api/pull/2036 lands. I also implemented multi-value support for the resource type, it takes it as a comma separated list, `filter[resource-type]=tract,cyoa`

This PR is currently safe to merge before the API PR lands. The bare parameters are not supported by the JSON:API spec, and the API already supports the correct `filter[*]` parameters that are part of the JSON:API spec. The `filter[resource-type]=a,b` parameter is not supported until after the API PR merges