### PR TITLE
GT-2926 Show Personalization Unavailable

### DIFF
--- a/godtools/App/Features/PersonalizedTools/Domain/UseCases/GetPersonalizedLessonsUseCase.swift
+++ b/godtools/App/Features/PersonalizedTools/Domain/UseCases/GetPersonalizedLessonsUseCase.swift
@@ -54,12 +54,11 @@ final class GetPersonalizedLessonsUseCase: Sendable {
             countryIsoRegionCode: countryIsoRegionCode,
             languageCode: languageCode,
             appLanguage: appLanguage,
-            filterLessonsByLanguage: filterLessonsByLanguage,
-            hasCountry: countryIsoRegionCode != nil
+            filterLessonsByLanguage: filterLessonsByLanguage
         )
     }
 
-    @MainActor private func getPersonalizedLessonsPublisher(countryIsoRegionCode: String?, languageCode: String, appLanguage: AppLanguageDomainModel, filterLessonsByLanguage: LessonFilterLanguageDomainModel?, hasCountry: Bool) -> AnyPublisher<PersonalizedLessonsDomainModel, Error> {
+    @MainActor private func getPersonalizedLessonsPublisher(countryIsoRegionCode: String?, languageCode: String, appLanguage: AppLanguageDomainModel, filterLessonsByLanguage: LessonFilterLanguageDomainModel?) -> AnyPublisher<PersonalizedLessonsDomainModel, Error> {
 
         return Publishers.CombineLatest3(
             personalizedToolsRepository
@@ -93,7 +92,7 @@ final class GetPersonalizedLessonsUseCase: Sendable {
                 filterLessonsByLanguage: filterLessonsByLanguage
             )
 
-            let showsPersonalizationUnavailable: Bool = !hasCountry && lessons.isEmpty
+            let showsPersonalizationUnavailable: Bool = lessons.isEmpty
             let unavailableStrings: PersonalizedLessonsUnavailableDomainModel? = showsPersonalizationUnavailable ? self.getLessonsUnavailable(appLanguage: appLanguage) : nil
 
             return PersonalizedLessonsDomainModel(

--- a/godtools/App/Features/PersonalizedTools/Domain/UseCases/GetPersonalizedToolsUseCase.swift
+++ b/godtools/App/Features/PersonalizedTools/Domain/UseCases/GetPersonalizedToolsUseCase.swift
@@ -51,8 +51,6 @@ final class GetPersonalizedToolsUseCase: Sendable {
             return nil
         }()
         
-        let hasCountry: Bool = countryIsoRegionCode != nil
-        
         return Publishers.CombineLatest(
             personalizedToolsRepository
                 .getPersonalizedToolsChanged(
@@ -84,7 +82,7 @@ final class GetPersonalizedToolsUseCase: Sendable {
                     languageIdForAvailabilityText: filterToolsByLanguage.filterId
                 )
 
-            let showsPersonalizationUnavailable: Bool = !hasCountry && tools.isEmpty
+            let showsPersonalizationUnavailable: Bool = tools.isEmpty
             let unavailableStrings: PersonalizedToolsUnavailableDomainModel? = showsPersonalizationUnavailable ? self.getToolsUnavailable(appLanguage: appLanguage) : nil
 
             return PersonalizedToolsDomainModel(

--- a/godtoolsTests/BehaviorTests/App/Features/PersonalizedTools/Domain/UseCases/GetPersonalizedLessonsUseCaseTests.swift
+++ b/godtoolsTests/BehaviorTests/App/Features/PersonalizedTools/Domain/UseCases/GetPersonalizedLessonsUseCaseTests.swift
@@ -141,7 +141,7 @@ struct GetPersonalizedLessonsUseCaseTests {
     @available(iOS 17.4, *)
     @Test(
         """
-        Given: User has not selected a country and there are no personalized lessons.
+        Given: There are no personalized lessons.
         When: Personalized lessons are requested.
         Then: I expect to see the personalization unavailable strings translated in my app language.
         """,
@@ -158,7 +158,7 @@ struct GetPersonalizedLessonsUseCaseTests {
             )
         ]
     )
-    @MainActor func personalizationUnavailableIsShownWhenNoCountryIsSelectedAndThereAreNoLessons(argument: UnavailableArgument) async throws {
+    @MainActor func personalizationUnavailableIsShownWhenThereAreNoLessons(argument: UnavailableArgument) async throws {
 
         let personalizedLessons: PersonalizedLessonsDomainModel = try await getPersonalizedLessons(
             appLanguage: argument.appLanguage,
@@ -178,10 +178,10 @@ struct GetPersonalizedLessonsUseCaseTests {
         """
         Given: User has selected a country and there are no personalized lessons.
         When: Personalized lessons are requested.
-        Then: I expect to see no lessons and no personalization unavailable strings.
+        Then: I expect to see no lessons and the personalization unavailable strings.
         """
     )
-    @MainActor func personalizationUnavailableIsNotShownWhenACountryIsSelectedAndThereAreNoLessons() async throws {
+    @MainActor func personalizationUnavailableIsShownWhenACountryIsSelectedAndThereAreNoLessons() async throws {
 
         let personalizedLessons: PersonalizedLessonsDomainModel = try await getPersonalizedLessons(
             appLanguage: LanguageCodeDomainModel.english.value,
@@ -190,7 +190,7 @@ struct GetPersonalizedLessonsUseCaseTests {
         )
 
         #expect(personalizedLessons.lessons.isEmpty)
-        #expect(personalizedLessons.unavailableStrings == nil)
+        #expect(personalizedLessons.unavailableStrings != nil)
     }
 
     @available(iOS 17.4, *)

--- a/godtoolsTests/BehaviorTests/App/Features/PersonalizedTools/Domain/UseCases/GetPersonalizedToolsUseCaseTests.swift
+++ b/godtoolsTests/BehaviorTests/App/Features/PersonalizedTools/Domain/UseCases/GetPersonalizedToolsUseCaseTests.swift
@@ -140,7 +140,7 @@ struct GetPersonalizedToolsUseCaseTests {
     @available(iOS 17.4, *)
     @Test(
         """
-        Given: User has not selected a country and there are no personalized tools.
+        Given: There are no personalized tools.
         When: Personalized tools are requested.
         Then: I expect to see the personalization unavailable strings translated in my app language.
         """,
@@ -157,7 +157,7 @@ struct GetPersonalizedToolsUseCaseTests {
             )
         ]
     )
-    @MainActor func personalizationUnavailableIsShownWhenNoCountryIsSelectedAndThereAreNoTools(argument: UnavailableArgument) async throws {
+    @MainActor func personalizationUnavailableIsShownWhenThereAreNoTools(argument: UnavailableArgument) async throws {
 
         let personalizedTools: PersonalizedToolsDomainModel = try await getPersonalizedTools(
             appLanguage: argument.appLanguage,
@@ -177,10 +177,10 @@ struct GetPersonalizedToolsUseCaseTests {
         """
         Given: User has selected a country and there are no personalized tools.
         When: Personalized tools are requested.
-        Then: I expect to see no tools and no personalization unavailable strings.
+        Then: I expect to see no tools and the personalization unavailable strings.
         """
     )
-    @MainActor func personalizationUnavailableIsNotShownWhenACountryIsSelectedAndThereAreNoTools() async throws {
+    @MainActor func personalizationUnavailableIsShownWhenACountryIsSelectedAndThereAreNoTools() async throws {
 
         let personalizedTools: PersonalizedToolsDomainModel = try await getPersonalizedTools(
             appLanguage: LanguageCodeDomainModel.english.value,
@@ -189,7 +189,7 @@ struct GetPersonalizedToolsUseCaseTests {
         )
 
         #expect(personalizedTools.tools.isEmpty)
-        #expect(personalizedTools.unavailableStrings == nil)
+        #expect(personalizedTools.unavailableStrings != nil)
     }
 
     @available(iOS 17.4, *)


### PR DESCRIPTION
I think the business logic here changed from what we expected.  Jill's comment on the ticket:

Currently if you have a country and language selected but there is no data for that combination it shows the "Displaying localized Lesson list" (blue background). We would like it to instead show the "Personalization unavailable" (grey background - "Fallback 2 - option b" in the figma design). Anytime there is no data available for any combination the Personalization unavailable option should be displayed.